### PR TITLE
Use all cpu cores for compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           mkdir build-linux 
           cd build-linux
           qmake ../src/NotepadNext.pro
-          make
+          make -j$(nproc)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Using all cpu cores decreases compilation time almost half of time. Sweet! I dunno why i didn't use it in first place.