### PR TITLE
Use Qt 6.2.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
           qt_version: "5.15.2"
           modules: ""
         - 
-          qt_version: "6.2.3"
+          qt_version: "6.2.4"
           modules: "qt5compat"
 
     runs-on: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
           qt_version: "5.15.2"
           modules: ""
         - 
-          qt_version: "6.2.3"
+          qt_version: "6.2.4"
           modules: "qt5compat"
 
     runs-on: windows-latest


### PR DESCRIPTION
When switching between Qt5 and Qt6 it could lead to crashes or loss of settings due to this bug that was finally fixed.

> QTBUG-96916 Qt 6 breaks compatibility of QVariant streaming into QDataStream