### PR TITLE
Fix "Copy Full Path" & "Copy File Directory"

### DIFF
--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -182,7 +182,7 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     connect(ui->actionCopyFullPath, &QAction::triggered, [=]() {
         auto editor = dockedEditor->getCurrentEditor();
         if (editor->isFile()) {
-            QApplication::clipboard()->setText(editor->getPath());
+            QApplication::clipboard()->setText(editor->getFilePath());
         }
     });
     connect(ui->actionCopyFileName, &QAction::triggered, [=]() {
@@ -191,7 +191,7 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     connect(ui->actionCopyFileDirectory, &QAction::triggered, [=]() {
         auto editor = dockedEditor->getCurrentEditor();
         if (editor->isFile()) {
-            QApplication::clipboard()->setText(editor->getFilePath());
+            QApplication::clipboard()->setText(editor->getPath());
         }
     });
     connect(ui->actionIncrease_Indent, &QAction::triggered, [=]() { dockedEditor->getCurrentEditor()->tab();});


### PR DESCRIPTION
Without this Patch:

```
Copy Full Path: 	E:\github\NotepadNext\src
Copy File Name: 	Version.pri
Copy File Directory: 	E:\github\NotepadNext\src\Version.pri
```

This PR:
```
Copy Full Path: 	E:\github\NotepadNext\src\Version.pri
Copy File Name: 	Version.pri
Copy File Directory:	E:\github\NotepadNext\src
```

Note:

- `editor->getFilePath()` ==> `fileInfo.canonicalFilePath()`
    > Returns the canonical path _including the file name_

- `editor->getPath()` ==> `fileInfo.canonicalPath()`
    > Returns the file's path canonical path (_excluding the file name_)
