### PR TITLE
Reminder that metainfo file also needs to include new releases

### DIFF
--- a/deploy/linux/com.github.dail8859.NotepadNext.metainfo.xml
+++ b/deploy/linux/com.github.dail8859.NotepadNext.metainfo.xml
@@ -25,6 +25,7 @@
 
     <launchable type="desktop-id">com.github.dail8859.NotepadNext.desktop</launchable>
     <releases>
+        <release version="v0.5" date="2022-04-17" />
         <release version="v0.4.9" date="2022-03-18" />
     </releases>
 </component>

--- a/doc/Create Release.md
+++ b/doc/Create Release.md
@@ -1,6 +1,7 @@
 ## Prepare Release
 
 - Update version in `src/Version.pri`
+- Add new `<release>` tag to metainfo file in `deploy/linux`
 - Commit
 - Tag commit with new version number
 - Push to commit and tag to GitHub


### PR DESCRIPTION
because otherwise it will report the wrong application version in Flathub and Flatpak:
![grafik](https://user-images.githubusercontent.com/36563538/163713901-2d827dce-cbb7-4eff-83e6-336722e734b5.png)

despite having v0.5 installed