### PR TITLE
add text/plain mime type to .desktop

### DIFF
--- a/deploy/linux/NotepadNext.desktop
+++ b/deploy/linux/NotepadNext.desktop
@@ -7,3 +7,4 @@ Name=Notepad Next
 StartupNotify=true
 Terminal=false
 Categories=Qt;TextEditor;Utility;
+MimeType=text/plain;


### PR DESCRIPTION
This will fix the issue of NotepadNext not being listed in the "open with" dialogue when opening text files. 
Currently it is not listed at all unless it is manually selected.