### PR TITLE
Wrap string literals with tr() for translation

### DIFF
--- a/i18n/NotepadNext.zh_CN.ts
+++ b/i18n/NotepadNext.zh_CN.ts
@@ -168,10 +168,228 @@
     </message>
 </context>
 <context>
+    <name>EditorInfoStatusBar</name>
+    <message>
+        <location filename="../src/NotepadNext/widgets/EditorInfoStatusBar.cpp" line="98"/>
+        <source>Length: %1    Lines: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/widgets/EditorInfoStatusBar.cpp" line="109"/>
+        <source>Sel: N/A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/widgets/EditorInfoStatusBar.cpp" line="119"/>
+        <source>Sel: %1 | %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/widgets/EditorInfoStatusBar.cpp" line="125"/>
+        <source>Ln: %1    Col: %2    </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/widgets/EditorInfoStatusBar.cpp" line="143"/>
+        <source>Macintosh (CR)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/widgets/EditorInfoStatusBar.cpp" line="146"/>
+        <source>Windows (CR LF)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/widgets/EditorInfoStatusBar.cpp" line="149"/>
+        <source>Unix (LF)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/widgets/EditorInfoStatusBar.cpp" line="158"/>
+        <source>ANSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/widgets/EditorInfoStatusBar.cpp" line="161"/>
+        <source>UTF-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>EditorInspectorDock</name>
     <message>
         <location filename="../src/NotepadNext/docks/EditorInspectorDock.ui" line="14"/>
         <source>Editor Inspector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="39"/>
+        <source>Current Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="40"/>
+        <source>Current Position (x, y)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="41"/>
+        <source>Column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="43"/>
+        <source>Current Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="44"/>
+        <source>Current Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="45"/>
+        <source>Line Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="46"/>
+        <source>Line End Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="47"/>
+        <source>Line Indentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="48"/>
+        <source>Line Indent Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="52"/>
+        <source>Selection Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="69"/>
+        <source>Is Rectangle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="70"/>
+        <source>Selection Empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="71"/>
+        <source>Main Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="72"/>
+        <source># of Selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="75"/>
+        <source>Multiple Selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="80"/>
+        <source>Document Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="83"/>
+        <source>Length </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="84"/>
+        <source>Line Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="88"/>
+        <source>View Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="91"/>
+        <source>Lines on Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="92"/>
+        <source>First Visible Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="93"/>
+        <source>X Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="97"/>
+        <source>Fold Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="100"/>
+        <source>Visible From Doc Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="101"/>
+        <source>Doc Line From Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="102"/>
+        <source>Fold Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="103"/>
+        <source>Is Fold Header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="104"/>
+        <source>Fold Parent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="105"/>
+        <source>Last Child</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="106"/>
+        <source>Contracted Fold Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="175"/>
+        <source>Caret</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="179"/>
+        <source>Anchor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="183"/>
+        <source>Caret Virtual Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/EditorInspectorDock.cpp" line="187"/>
+        <source>Anchor Virtual Space</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -180,6 +398,7 @@
     <message>
         <location filename="../src/NotepadNext/dialogs/FindReplaceDialog.ui" line="441"/>
         <location filename="../src/NotepadNext/dialogs/FindReplaceDialog.ui" line="674"/>
+        <location filename="../src/NotepadNext/dialogs/FindReplaceDialog.cpp" line="57"/>
         <source>Find</source>
         <translation type="unfinished"></translation>
     </message>
@@ -288,6 +507,36 @@
         <source>Wra&amp;p Around</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/FindReplaceDialog.cpp" line="58"/>
+        <source>Replace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/FindReplaceDialog.cpp" line="204"/>
+        <source>No matches found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/FindReplaceDialog.cpp" line="234"/>
+        <source>1 occurrence was replaced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/FindReplaceDialog.cpp" line="243"/>
+        <source>No more occurrences were found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/FindReplaceDialog.cpp" line="272"/>
+        <source>Replaced %1 matches</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/FindReplaceDialog.cpp" line="296"/>
+        <source>Found %1 matches</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FolderAsWorkspaceDock</name>
@@ -332,6 +581,11 @@
     <message>
         <location filename="../src/NotepadNext/docks/LanguageInspectorDock.ui" line="121"/>
         <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/docks/LanguageInspectorDock.cpp" line="137"/>
+        <source>Postion %1 Style %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1054,6 +1308,93 @@
     <message>
         <location filename="../src/NotepadNext/dialogs/MainWindow.ui" line="936"/>
         <source>Open Folder as Workspace...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="274"/>
+        <source>Go to line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="274"/>
+        <source>Line Number (1 - %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="632"/>
+        <source>New %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="666"/>
+        <source>Create File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="666"/>
+        <source>&lt;b&gt;%1&lt;/b&gt; does not exist. Do you want to create it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="715"/>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="811"/>
+        <source>Save file &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="716"/>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="812"/>
+        <source>Save File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="769"/>
+        <source>Open Folder as Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="785"/>
+        <source>Reload File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="785"/>
+        <source>Are you sure you want to reload &lt;b&gt;%1&lt;/b&gt;? Any unsaved changes will be lost.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="974"/>
+        <source>Save a Copy As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="998"/>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="1024"/>
+        <source>Delete File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="1024"/>
+        <source>Are you sure you want to move &lt;b&gt;%1&lt;/b&gt; to the trash?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="1034"/>
+        <source>Error Deleting File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="1034"/>
+        <source>Something went wrong deleting &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/NotepadNext/dialogs/MainWindow.cpp" line="1443"/>
+        <source>No updates are availale at this time.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/NotepadNext/dialogs/FindReplaceDialog.cpp
+++ b/src/NotepadNext/dialogs/FindReplaceDialog.cpp
@@ -54,8 +54,8 @@ FindReplaceDialog::FindReplaceDialog(QWidget *parent) :
     ui->setupUi(this);
 
     tabBar = new QTabBar();
-    tabBar->addTab("Find");
-    tabBar->addTab("Replace");
+    tabBar->addTab(tr("Find"));
+    tabBar->addTab(tr("Replace"));
     tabBar->setExpanding(false);
     qobject_cast<QVBoxLayout *>(layout())->insertWidget(0, tabBar);
     connect(tabBar, &QTabBar::currentChanged, this, &FindReplaceDialog::changeTab);
@@ -201,7 +201,7 @@ void FindReplaceDialog::find()
         goToMatch(range);
     }
     else {
-        showMessage("No matches found.", "red");
+        showMessage(tr("No matches found."), "red");
     }
 }
 
@@ -231,7 +231,7 @@ void FindReplaceDialog::replace()
     Sci_CharacterRange range = finder->replaceSelectionIfMatch(replaceText);
 
     if (isRangeValid(range)) {
-        showMessage("1 occurrence was replaced", "blue");
+        showMessage(tr("1 occurrence was replaced"), "blue");
     }
 
     Sci_CharacterRange next_match = finder->findNext();
@@ -240,7 +240,7 @@ void FindReplaceDialog::replace()
         goToMatch(next_match);
     }
     else {
-        showMessage("No more occurrences were found", "red");
+        showMessage(tr("No more occurrences were found"), "red");
         ui->comboFind->setFocus();
         ui->comboFind->lineEdit()->selectAll();
     }
@@ -269,7 +269,7 @@ void FindReplaceDialog::replaceAll()
     finder->setSearchText(findText);
 
     int count = finder->replaceAll(replaceText);
-    showMessage(QString("Replaced %1 matches").arg(count), "green");
+    showMessage(tr("Replaced %1 matches").arg(count), "green");
 }
 
 void FindReplaceDialog::count()
@@ -293,7 +293,7 @@ void FindReplaceDialog::count()
     finder->setSearchText(text);
 
     int total = finder->count();
-    showMessage(QString("Found %1 matches").arg(total), "green");
+    showMessage(tr("Found %1 matches").arg(total), "green");
 }
 
 void FindReplaceDialog::setEditor(ScintillaNext *edit)

--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -271,7 +271,7 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
 
         QInputDialog d = QInputDialog(this);
         Qt::WindowFlags flags = d.windowFlags() & ~Qt::WindowContextHelpButtonHint;
-        int lineToGoTo = d.getInt(this, "Go to line", QString("Line Number (1 - %1)").arg(maxLine), currentLine, 1, maxLine, 1, &ok, flags);
+        int lineToGoTo = d.getInt(this, tr("Go to line"), tr("Line Number (1 - %1)").arg(maxLine), currentLine, 1, maxLine, 1, &ok, flags);
 
         if (ok) {
             editor->ensureVisible(lineToGoTo - 1);
@@ -507,8 +507,8 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
 
     ui->actionAboutNotepadNext->setShortcut(QKeySequence::HelpContents);
     connect(ui->actionAboutNotepadNext, &QAction::triggered, [=]() {
-        QMessageBox::about(this, "About Notepad Next",
-                            QString("<h3>Notepad Next v%1</h3>"
+        QMessageBox::about(this, tr("About Notepad Next"),
+                            tr("<h3>Notepad Next v%1</h3>"
                                     "<p>%2</p>"
                                     "<p>This program does stuff.</p>"
                                     R"(<p>This program is free software: you can redistribute it and/or modify
@@ -629,7 +629,7 @@ void MainWindow::newFile()
 
     static int count = 1;
 
-    app->getEditorManager()->createEmptyEditor(QString("New %1").arg(count++));
+    app->getEditorManager()->createEmptyEditor(tr("New %1").arg(count++));
 }
 
 // One unedited, new blank document
@@ -663,7 +663,7 @@ void MainWindow::openFileList(const QStringList &fileNames)
             QFileInfo fileInfo(filePath);
 
             if (!fileInfo.isFile()) {
-                auto reply = QMessageBox::question(this, "Create File", QString("<b>%1</b> does not exist. Do you want to create it?").arg(filePath));
+                auto reply = QMessageBox::question(this, tr("Create File"), QString(tr("<b>%1</b> does not exist. Do you want to create it?")).arg(filePath));
 
                 if (reply == QMessageBox::Yes) {
                     editor = app->getEditorManager()->createEditorFromFile(filePath);
@@ -712,8 +712,8 @@ bool MainWindow::checkEditorsBeforeClose(const QVector<ScintillaNext *> &editors
             dockedEditor->switchToEditor(editor);
 
             // Ask the user what to do
-            QString message = QString("Save file <b>%1</b>?").arg(editor->getName());
-            auto reply = QMessageBox::question(this, "Save File", message, QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Save);
+            QString message = tr("Save file <b>%1</b>?").arg(editor->getName());
+            auto reply = QMessageBox::question(this, tr("Save File"), message, QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Save);
 
             if (reply == QMessageBox::Cancel) {
                 // Stop checking and let the caller know
@@ -766,7 +766,7 @@ void MainWindow::openFolderAsWorkspaceDialog()
         dialogDir = editor->getPath();
     }
 
-    QString dir = QFileDialog::getExistingDirectory(this, "Open Folder as Workspace", dialogDir, QFileDialog::ShowDirsOnly);
+    QString dir = QFileDialog::getExistingDirectory(this, tr("Open Folder as Workspace"), dialogDir, QFileDialog::ShowDirsOnly);
 
     FolderAsWorkspaceDock *fawDock = findChild<FolderAsWorkspaceDock *>();
     fawDock->setRootPath(dir);
@@ -782,7 +782,7 @@ void MainWindow::reloadFile()
     }
 
     const QString filePath = editor->getFilePath();
-    auto reply = QMessageBox::question(this, "Reload File", QString("Are you sure you want to reload <b>%1</b>? Any unsaved changes will be lost.").arg(filePath));
+    auto reply = QMessageBox::question(this, tr("Reload File"), tr("Are you sure you want to reload <b>%1</b>? Any unsaved changes will be lost.").arg(filePath));
 
     if (reply == QMessageBox::Yes) {
         editor->reload();
@@ -808,8 +808,8 @@ void MainWindow::closeFile(ScintillaNext *editor)
         // The user needs be asked what to do about this file, so switch to it
         dockedEditor->switchToEditor(editor);
 
-        QString message = QString("Save file <b>%1</b>?").arg(editor->getName());
-        auto reply = QMessageBox::question(this, "Save File", message, QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Save);
+        QString message = tr("Save file <b>%1</b>?").arg(editor->getName());
+        auto reply = QMessageBox::question(this, tr("Save File"), message, QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Save);
 
         if (reply == QMessageBox::Cancel) {
             return;
@@ -971,7 +971,7 @@ void MainWindow::saveCopyAsDialog()
         dialogDir = editor->getFilePath();
     }
 
-    QString fileName = QFileDialog::getSaveFileName(this, "Save a Copy As", dialogDir, filter, Q_NULLPTR);
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Save a Copy As"), dialogDir, filter, Q_NULLPTR);
 
     saveCopyAs(fileName);
 }
@@ -995,7 +995,7 @@ void MainWindow::renameFile()
 
     Q_ASSERT(editor->isFile());
 
-    QString fileName = QFileDialog::getSaveFileName(this, "Rename", editor->getFilePath());
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Rename"), editor->getFilePath());
 
     if (fileName.size() == 0) {
         return;
@@ -1021,7 +1021,7 @@ void MainWindow::moveFileToTrash(ScintillaNext *editor)
     Q_ASSERT(editor->isFile());
 
     const QString filePath = editor->getFilePath();
-    auto reply = QMessageBox::question(this, "Delete File", QString("Are you sure you want to move <b>%1</b> to the trash?").arg(filePath));;
+    auto reply = QMessageBox::question(this, tr("Delete File"), tr("Are you sure you want to move <b>%1</b> to the trash?").arg(filePath));;
 
     if (reply == QMessageBox::Yes) {
         if (editor->moveToTrash()) {
@@ -1031,7 +1031,7 @@ void MainWindow::moveFileToTrash(ScintillaNext *editor)
             app->getRecentFilesListManager()->removeFile(editor->getFilePath());
         }
         else {
-            QMessageBox::warning(this, "Error Deleting File",  QString("Something went wrong deleting <b>%1</b>?").arg(filePath));
+            QMessageBox::warning(this, tr("Error Deleting File"),  tr("Something went wrong deleting <b>%1</b>?").arg(filePath));
         }
     }
 }
@@ -1252,7 +1252,7 @@ void MainWindow::activateEditor(ScintillaNext *editor)
 void MainWindow::setLanguage(ScintillaNext *editor, const QString &languageName)
 {
     qInfo(Q_FUNC_INFO);
-    qInfo("%s", qUtf8Printable("Language Name: " + languageName));
+    qInfo("%s", qUtf8Printable(tr("Language Name: ") + languageName));
 
     app->setEditorLanguage(editor, languageName);
 }
@@ -1440,7 +1440,7 @@ void MainWindow::checkForUpdatesFinished(QString url)
 {
 #ifdef Q_OS_WIN
     if (!QSimpleUpdater::getInstance()->getUpdateAvailable(url)) {
-        QMessageBox::information(this, "Notepad Next", "No updates are availale at this time.");
+        QMessageBox::information(this, "Notepad Next", tr("No updates are availale at this time."));
     }
 #endif
 }

--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -663,7 +663,7 @@ void MainWindow::openFileList(const QStringList &fileNames)
             QFileInfo fileInfo(filePath);
 
             if (!fileInfo.isFile()) {
-                auto reply = QMessageBox::question(this, tr("Create File"), QString(tr("<b>%1</b> does not exist. Do you want to create it?")).arg(filePath));
+                auto reply = QMessageBox::question(this, tr("Create File"), tr("<b>%1</b> does not exist. Do you want to create it?").arg(filePath));
 
                 if (reply == QMessageBox::Yes) {
                     editor = app->getEditorManager()->createEditorFromFile(filePath);
@@ -1252,7 +1252,7 @@ void MainWindow::activateEditor(ScintillaNext *editor)
 void MainWindow::setLanguage(ScintillaNext *editor, const QString &languageName)
 {
     qInfo(Q_FUNC_INFO);
-    qInfo("%s", qUtf8Printable(tr("Language Name: ") + languageName));
+    qInfo("%s", qUtf8Printable("Language Name: " + languageName));
 
     app->setEditorLanguage(editor, languageName);
 }

--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -507,9 +507,9 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
 
     ui->actionAboutNotepadNext->setShortcut(QKeySequence::HelpContents);
     connect(ui->actionAboutNotepadNext, &QAction::triggered, [=]() {
-        QMessageBox::about(this, tr("About Notepad Next"),
-                            tr("<h3>Notepad Next v%1</h3>"
-                                    "<p>%2</p>"
+        QMessageBox::about(this, QString(),
+                            QStringLiteral("<h3>%1 v%2</h3>"
+                                    "<p>%3</p>"
                                     "<p>This program does stuff.</p>"
                                     R"(<p>This program is free software: you can redistribute it and/or modify
                                     it under the terms of the GNU General Public License as published by
@@ -521,7 +521,7 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
                                     GNU General Public License for more details.</p>
                                     <p>You should have received a copy of the GNU General Public License
                                     along with this program. If not, see &lt;https://www.gnu.org/licenses/&gt;.</p>)")
-                                .arg(APP_VERSION, QStringLiteral(APP_COPYRIGHT).toHtmlEscaped()));
+                                .arg(QApplication::applicationDisplayName(), APP_VERSION, QStringLiteral(APP_COPYRIGHT).toHtmlEscaped()));
     });
 
     QAction *separator = ui->menuHelp->insertSeparator(ui->actionCheckForUpdates);
@@ -1252,7 +1252,7 @@ void MainWindow::activateEditor(ScintillaNext *editor)
 void MainWindow::setLanguage(ScintillaNext *editor, const QString &languageName)
 {
     qInfo(Q_FUNC_INFO);
-    qInfo("%s", qUtf8Printable("Language Name: " + languageName));
+    qInfo("Language Name: %s", qUtf8Printable(languageName));
 
     app->setEditorLanguage(editor, languageName);
 }
@@ -1440,7 +1440,7 @@ void MainWindow::checkForUpdatesFinished(QString url)
 {
 #ifdef Q_OS_WIN
     if (!QSimpleUpdater::getInstance()->getUpdateAvailable(url)) {
-        QMessageBox::information(this, "Notepad Next", tr("No updates are availale at this time."));
+        QMessageBox::information(this, QString(), tr("No updates are availale at this time."));
     }
 #endif
 }

--- a/src/NotepadNext/docks/EditorInspectorDock.cpp
+++ b/src/NotepadNext/docks/EditorInspectorDock.cpp
@@ -36,20 +36,20 @@ EditorInspectorDock::EditorInspectorDock(MainWindow *parent) :
     positionInfo->setText(0, "Position Information");
     positionInfo->setExpanded(true);
 
-    newItem(positionInfo, "Current Position", [](ScintillaNext *editor) { return QString::number(editor->currentPos()); });
-    newItem(positionInfo, "Current Position (x, y)", [](ScintillaNext *editor) { return QString("(%1, %2)").arg(editor->pointXFromPosition(editor->currentPos())).arg(editor->pointYFromPosition(editor->currentPos())); });
-    newItem(positionInfo, "Column", [](ScintillaNext *editor) { return QString::number(editor->column(editor->currentPos())); });
+    newItem(positionInfo, tr("Current Position"), [](ScintillaNext *editor) { return QString::number(editor->currentPos()); });
+    newItem(positionInfo, tr("Current Position (x, y)"), [](ScintillaNext *editor) { return QString("(%1, %2)").arg(editor->pointXFromPosition(editor->currentPos())).arg(editor->pointYFromPosition(editor->currentPos())); });
+    newItem(positionInfo, tr("Column"), [](ScintillaNext *editor) { return QString::number(editor->column(editor->currentPos())); });
     // SCI_GETCHARAT(position pos) → int
-    newItem(positionInfo, "Current Style", [](ScintillaNext *editor) { return QString::number(editor->styleAt(editor->currentPos())); });
-    newItem(positionInfo, "Current Line", [](ScintillaNext *editor) { return QString::number(editor->lineFromPosition(editor->currentPos()) + 1); });
-    newItem(positionInfo, "Line Length", [](ScintillaNext *editor) { return QString::number(editor->lineLength(editor->lineFromPosition(editor->currentPos()))); });
-    newItem(positionInfo, "Line End Position", [](ScintillaNext *editor) { return QString::number(editor->lineEndPosition(editor->lineFromPosition(editor->currentPos()))); });
-    newItem(positionInfo, "Line Indentation", [](ScintillaNext *editor) { return QString::number(editor->lineIndentation(editor->lineFromPosition(editor->currentPos()))); });
-    newItem(positionInfo, "Line Indent Position", [](ScintillaNext *editor) { return QString::number(editor->lineIndentPosition(editor->lineFromPosition(editor->currentPos()))); });
+    newItem(positionInfo, tr("Current Style"), [](ScintillaNext *editor) { return QString::number(editor->styleAt(editor->currentPos())); });
+    newItem(positionInfo, tr("Current Line"), [](ScintillaNext *editor) { return QString::number(editor->lineFromPosition(editor->currentPos()) + 1); });
+    newItem(positionInfo, tr("Line Length"), [](ScintillaNext *editor) { return QString::number(editor->lineLength(editor->lineFromPosition(editor->currentPos()))); });
+    newItem(positionInfo, tr("Line End Position"), [](ScintillaNext *editor) { return QString::number(editor->lineEndPosition(editor->lineFromPosition(editor->currentPos()))); });
+    newItem(positionInfo, tr("Line Indentation"), [](ScintillaNext *editor) { return QString::number(editor->lineIndentation(editor->lineFromPosition(editor->currentPos()))); });
+    newItem(positionInfo, tr("Line Indent Position"), [](ScintillaNext *editor) { return QString::number(editor->lineIndentPosition(editor->lineFromPosition(editor->currentPos()))); });
 
 
     QTreeWidgetItem *selInfo = new QTreeWidgetItem(ui->treeWidget);
-    selInfo->setText(0, "Selection Information");
+    selInfo->setText(0, tr("Selection Information"));
     selInfo->setExpanded(true);
 
     newItem(selInfo, "Mode", [](ScintillaNext *editor) {
@@ -66,44 +66,44 @@ EditorInspectorDock::EditorInspectorDock(MainWindow *parent) :
                 return QStringLiteral("");
         }
     });
-    newItem(selInfo, "Is Rectangle", [](ScintillaNext *editor) { return toBool(editor->selectionIsRectangle()); });
-    newItem(selInfo, "Selection Empty", [](ScintillaNext *editor) { return toBool(editor->selectionEmpty()); });
-    newItem(selInfo, "Main Selection", [](ScintillaNext *editor) { return QString::number(editor->mainSelection()); });
-    newItem(selInfo, "# of Selections", [](ScintillaNext *editor) { return QString::number(editor->selections()); });
+    newItem(selInfo, tr("Is Rectangle"), [](ScintillaNext *editor) { return toBool(editor->selectionIsRectangle()); });
+    newItem(selInfo, tr("Selection Empty"), [](ScintillaNext *editor) { return toBool(editor->selectionEmpty()); });
+    newItem(selInfo, tr("Main Selection"), [](ScintillaNext *editor) { return QString::number(editor->mainSelection()); });
+    newItem(selInfo, tr("# of Selections"), [](ScintillaNext *editor) { return QString::number(editor->selections()); });
 
     selectionsInfo = new QTreeWidgetItem(selInfo);
-    selectionsInfo->setText(0, "Multiple Selections");
+    selectionsInfo->setText(0, tr("Multiple Selections"));
     selectionsInfo->setExpanded(true);
 
 
     QTreeWidgetItem *documentInfo = new QTreeWidgetItem(ui->treeWidget);
-    documentInfo->setText(0, "Document Information");
+    documentInfo->setText(0, tr("Document Information"));
     documentInfo->setExpanded(true);
 
-    newItem(documentInfo, "Length ", [](ScintillaNext *editor) { return QString::number(editor->length()); });
-    newItem(documentInfo, "Line Count", [](ScintillaNext *editor) { return QString::number(editor->lineCount()); });
+    newItem(documentInfo, tr("Length "), [](ScintillaNext *editor) { return QString::number(editor->length()); });
+    newItem(documentInfo, tr("Line Count"), [](ScintillaNext *editor) { return QString::number(editor->lineCount()); });
 
 
     QTreeWidgetItem *viewInfo = new QTreeWidgetItem(ui->treeWidget);
-    viewInfo->setText(0, "View Information");
+    viewInfo->setText(0, tr("View Information"));
     viewInfo->setExpanded(true);
 
-    newItem(viewInfo, "Lines on Screen", [](ScintillaNext *editor) { return QString::number(editor->linesOnScreen()); });
-    newItem(viewInfo, "First Visible Line", [](ScintillaNext *editor) { return QString::number(editor->firstVisibleLine() + 1); });
-    newItem(viewInfo, "X Offset", [](ScintillaNext *editor) { return QString::number(editor->xOffset()); });
+    newItem(viewInfo, tr("Lines on Screen"), [](ScintillaNext *editor) { return QString::number(editor->linesOnScreen()); });
+    newItem(viewInfo, tr("First Visible Line"), [](ScintillaNext *editor) { return QString::number(editor->firstVisibleLine() + 1); });
+    newItem(viewInfo, tr("X Offset"), [](ScintillaNext *editor) { return QString::number(editor->xOffset()); });
 
 
     QTreeWidgetItem *foldInfo = new QTreeWidgetItem(ui->treeWidget);
-    foldInfo->setText(0, "Fold Information");
+    foldInfo->setText(0, tr("Fold Information"));
     foldInfo->setExpanded(true);
 
-    newItem(foldInfo, "Visible From Doc Line", [](ScintillaNext *editor) { return QString::number(editor->visibleFromDocLine(editor->lineFromPosition(editor->currentPos())) + 1); });
-    newItem(foldInfo, "Doc Line From Visible", [](ScintillaNext *editor) { return QString::number(editor->docLineFromVisible(editor->lineFromPosition(editor->currentPos())) + 1); });
-    newItem(foldInfo, "Fold Level", [](ScintillaNext *editor) { return QString::number((editor->foldLevel(editor->lineFromPosition(editor->currentPos())) & SC_FOLDLEVELNUMBERMASK) - SC_FOLDLEVELBASE); });
-    newItem(foldInfo, "Is Fold Header", [](ScintillaNext *editor) { return toBool((editor->foldLevel(editor->lineFromPosition(editor->currentPos())) & SC_FOLDLEVELHEADERFLAG) == SC_FOLDLEVELHEADERFLAG); });
-    newItem(foldInfo, "Fold Parent", [](ScintillaNext *editor) { return QString::number(editor->foldParent(editor->lineFromPosition(editor->currentPos())) + 1); });
-    newItem(foldInfo, "Last Child", [](ScintillaNext *editor) { return QString::number(editor->lastChild(editor->lineFromPosition(editor->currentPos()), -1) + 1); });
-    newItem(foldInfo, "Contracted Fold Next", [](ScintillaNext *editor) { return QString::number(editor->contractedFoldNext(editor->lineFromPosition(editor->currentPos())) + 1); });
+    newItem(foldInfo, tr("Visible From Doc Line"), [](ScintillaNext *editor) { return QString::number(editor->visibleFromDocLine(editor->lineFromPosition(editor->currentPos())) + 1); });
+    newItem(foldInfo, tr("Doc Line From Visible"), [](ScintillaNext *editor) { return QString::number(editor->docLineFromVisible(editor->lineFromPosition(editor->currentPos())) + 1); });
+    newItem(foldInfo, tr("Fold Level"), [](ScintillaNext *editor) { return QString::number((editor->foldLevel(editor->lineFromPosition(editor->currentPos())) & SC_FOLDLEVELNUMBERMASK) - SC_FOLDLEVELBASE); });
+    newItem(foldInfo, tr("Is Fold Header"), [](ScintillaNext *editor) { return toBool((editor->foldLevel(editor->lineFromPosition(editor->currentPos())) & SC_FOLDLEVELHEADERFLAG) == SC_FOLDLEVELHEADERFLAG); });
+    newItem(foldInfo, tr("Fold Parent"), [](ScintillaNext *editor) { return QString::number(editor->foldParent(editor->lineFromPosition(editor->currentPos())) + 1); });
+    newItem(foldInfo, tr("Last Child"), [](ScintillaNext *editor) { return QString::number(editor->lastChild(editor->lineFromPosition(editor->currentPos()), -1) + 1); });
+    newItem(foldInfo, tr("Contracted Fold Next"), [](ScintillaNext *editor) { return QString::number(editor->contractedFoldNext(editor->lineFromPosition(editor->currentPos())) + 1); });
 
     connect(this, &QDockWidget::visibilityChanged, this, [=](bool visible) {
         if (visible) {
@@ -172,19 +172,19 @@ void EditorInspectorDock::updateEditorInfo(ScintillaNext *editor)
         selection->setExpanded(true);
 
         QTreeWidgetItem *caret = new QTreeWidgetItem(selection);
-        caret->setText(0, QStringLiteral("Caret"));
+        caret->setText(0, tr("Caret"));
         caret->setText(1, QString::number(editor->selectionNCaret(i)));
 
         QTreeWidgetItem *anchor = new QTreeWidgetItem(selection);
-        anchor->setText(0, QStringLiteral("Anchor"));
+        anchor->setText(0, tr("Anchor"));
         anchor->setText(1, QString::number(editor->selectionNAnchor(i)));
 
         QTreeWidgetItem *caretVirtual = new QTreeWidgetItem(selection);
-        caretVirtual->setText(0, QStringLiteral("Caret Virtual Space"));
+        caretVirtual->setText(0, tr("Caret Virtual Space"));
         caretVirtual->setText(1, QString::number(editor->selectionNCaretVirtualSpace(i)));
 
         QTreeWidgetItem *anchorVirtual = new QTreeWidgetItem(selection);
-        anchorVirtual->setText(0, QStringLiteral("Anchor Virtual Space"));
+        anchorVirtual->setText(0, tr("Anchor Virtual Space"));
         anchorVirtual->setText(1, QString::number(editor->selectionNAnchorVirtualSpace(i)));
     }
 

--- a/src/NotepadNext/docks/LanguageInspectorDock.cpp
+++ b/src/NotepadNext/docks/LanguageInspectorDock.cpp
@@ -134,7 +134,7 @@ void LanguageInspectorDock::updatePositionInfo(Scintilla::Update updated)
 
     if (FlagSet(updated, Scintilla::Update::Content) || FlagSet(updated, Scintilla::Update::Selection)) {
         ScintillaNext *editor = qobject_cast<ScintillaNext*>(sender());
-        ui->lblInfo->setText(QString("Postion %1 Style %2").arg(editor->currentPos()).arg(editor->styleAt(editor->currentPos())));
+        ui->lblInfo->setText(tr("Postion %1 Style %2").arg(editor->currentPos()).arg(editor->styleAt(editor->currentPos())));
     }
 }
 

--- a/src/NotepadNext/widgets/EditorInfoStatusBar.cpp
+++ b/src/NotepadNext/widgets/EditorInfoStatusBar.cpp
@@ -95,7 +95,7 @@ void EditorInfoStatusBar::editorUpdated(Scintilla::Update updated)
 
 void EditorInfoStatusBar::updateDocumentSize(ScintillaNext *editor)
 {
-    QString sizeText = QStringLiteral("Length: %1    Lines: %2").arg(
+    QString sizeText = tr("Length: %1    Lines: %2").arg(
             QLocale::system().toString(editor->length()),
             QLocale::system().toString(editor->lineCount()));
     docSize->setText(sizeText);
@@ -106,7 +106,7 @@ void EditorInfoStatusBar::updateSelectionInfo(ScintillaNext *editor)
     QString selectionText;
 
     if (editor->selections() > 1) {
-        selectionText = QStringLiteral("Sel: N/A");
+        selectionText = tr("Sel: N/A");
     }
     else {
         int start = editor->selectionStart();
@@ -116,13 +116,13 @@ void EditorInfoStatusBar::updateSelectionInfo(ScintillaNext *editor)
         if (end > start)
             lines++;
 
-        selectionText = QStringLiteral("Sel: %1 | %2").arg(
+        selectionText = tr("Sel: %1 | %2").arg(
                 QLocale::system().toString(editor->countCharacters(start, end)),
                 QLocale::system().toString(lines));
     }
 
     const int pos = editor->currentPos();
-    QString positionText = QStringLiteral("Ln: %1    Col: %2    ").arg(
+    QString positionText = tr("Ln: %1    Col: %2    ").arg(
             QLocale::system().toString(editor->lineFromPosition(pos) + 1),
             QLocale::system().toString(editor->column(pos) + 1));
     docPos->setText(positionText + selectionText);
@@ -140,13 +140,13 @@ void EditorInfoStatusBar::updateEol(ScintillaNext *editor)
 
     switch(editor->eOLMode()) {
     case SC_EOL_CR:
-        eolFormat->setText(QStringLiteral("Macintosh (CR)"));
+        eolFormat->setText(tr("Macintosh (CR)"));
         break;
     case SC_EOL_CRLF:
-        eolFormat->setText(QStringLiteral("Windows (CR LF)"));
+        eolFormat->setText(tr("Windows (CR LF)"));
         break;
     case SC_EOL_LF:
-        eolFormat->setText(QStringLiteral("Unix (LF)"));
+        eolFormat->setText(tr("Unix (LF)"));
         break;
     }
 }
@@ -155,10 +155,10 @@ void EditorInfoStatusBar::updateEncoding(ScintillaNext *editor)
 {
     switch(editor->codePage()) {
     case 0:
-        unicodeType->setText(QStringLiteral("ANSI"));
+        unicodeType->setText(tr("ANSI"));
         break;
     case SC_CP_UTF8:
-        unicodeType->setText(QStringLiteral("UTF-8"));
+        unicodeType->setText(tr("UTF-8"));
         break;
     default:
         unicodeType->setText(QString::number(editor->codePage()));


### PR DESCRIPTION
I open this PR for the issue #56

For translation, the hardcoded string literals need to be wrapped with tr(). This does not affect the current state of the program, if no translation files are present, the default English phrases are displayed.
Note that in some cases I replaced QStringLiteral with tr, but it shouldn't be a problem at all. (in the function *void EditorInspectorDock::updateEditorInfo(ScintillaNext *editor)* and in several places in *EditorInfoStatusBar.cpp* file)