### PR TITLE
fix developer name missing in metainfo

### DIFF
--- a/deploy/linux/com.github.dail8859.NotepadNext.metainfo.xml
+++ b/deploy/linux/com.github.dail8859.NotepadNext.metainfo.xml
@@ -3,7 +3,7 @@
 <!-- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
 <component type="desktop-application">
     <id>com.github.dail8859.NotepadNext</id>
-    <developer_name>dail8859</developer_name>
+    <developer_name>Justin Dailey</developer_name>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
     <content_rating type="oars-1.1" />

--- a/deploy/linux/com.github.dail8859.NotepadNext.metainfo.xml
+++ b/deploy/linux/com.github.dail8859.NotepadNext.metainfo.xml
@@ -3,6 +3,7 @@
 <!-- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
 <component type="desktop-application">
     <id>com.github.dail8859.NotepadNext</id>
+    <developer_name>dail8859</developer_name>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
     <content_rating type="oars-1.1" />


### PR DESCRIPTION
fixes developer name missing on the Flathub page:
![grafik](https://user-images.githubusercontent.com/36563538/164549892-a5f34ab5-1dde-4114-a03f-5219d2b7df17.png)
