### PR TITLE
[i18n] load translations for Qt

### DIFF
--- a/src/NotepadNext.pro
+++ b/src/NotepadNext.pro
@@ -34,10 +34,22 @@ win32 {
         xcopy $$shell_path($${OUT_PWD}/NotepadNext/LICENSE) $$shell_path($${OUT_PWD}/package/) /Y && \
         xcopy $$shell_path($${OUT_PWD}/NotepadNext/i18n/*.qm) $$shell_path($${OUT_PWD}/package/i18n/) /Y &&
 
+    # Get all translation language names
+    #   get full path:      `../i18n/NotepadNext.en.ts`
+    TRANSLATION_LANGS = $$files($$PWD/../i18n/*.ts)
+    #   keep filename:      `NotepadNext.en.ts`
+    TRANSLATION_LANGS = $$basename(TRANSLATION_LANGS)
+    #   remove App name:    `en.ts`
+    TRANSLATION_LANGS = $$replace(TRANSLATION_LANGS, NotepadNext.,)
+    #   remove `.ts` ext:   `en`
+    TRANSLATION_LANGS = $$replace(TRANSLATION_LANGS, .ts,)
+    #   join all lang:      `en,zh_CN,...`
+    TRANSLATION_LANGS = $$join(TRANSLATION_LANGS, ',', '', '')
+
     equals(QT_MAJOR_VERSION, 6) {
-        package.commands += windeployqt --release --no-translations --no-system-d3d-compiler --no-compiler-runtime --no-opengl-sw $$shell_path($${OUT_PWD}/package/NotepadNext.exe)
+        package.commands += windeployqt --release --translations $$TRANSLATION_LANGS --no-system-d3d-compiler --no-compiler-runtime --no-opengl-sw $$shell_path($${OUT_PWD}/package/NotepadNext.exe)
     } else {
-        package.commands += windeployqt --release --no-translations --no-system-d3d-compiler --no-compiler-runtime --no-angle --no-opengl-sw $$shell_path($${OUT_PWD}/package/NotepadNext.exe)
+        package.commands += windeployqt --release --translations $$TRANSLATION_LANGS --no-system-d3d-compiler --no-compiler-runtime --no-angle --no-opengl-sw $$shell_path($${OUT_PWD}/package/NotepadNext.exe)
     }
 
     # Zip it up

--- a/src/NotepadNext.pro
+++ b/src/NotepadNext.pro
@@ -34,22 +34,10 @@ win32 {
         xcopy $$shell_path($${OUT_PWD}/NotepadNext/LICENSE) $$shell_path($${OUT_PWD}/package/) /Y && \
         xcopy $$shell_path($${OUT_PWD}/NotepadNext/i18n/*.qm) $$shell_path($${OUT_PWD}/package/i18n/) /Y &&
 
-    # Get all translation language names
-    #   get full path:      `../i18n/NotepadNext.en.ts`
-    TRANSLATION_LANGS = $$files($$PWD/../i18n/*.ts)
-    #   keep filename:      `NotepadNext.en.ts`
-    TRANSLATION_LANGS = $$basename(TRANSLATION_LANGS)
-    #   remove App name:    `en.ts`
-    TRANSLATION_LANGS = $$replace(TRANSLATION_LANGS, NotepadNext.,)
-    #   remove `.ts` ext:   `en`
-    TRANSLATION_LANGS = $$replace(TRANSLATION_LANGS, .ts,)
-    #   join all lang:      `en,zh_CN,...`
-    TRANSLATION_LANGS = $$join(TRANSLATION_LANGS, ',', '', '')
-
     equals(QT_MAJOR_VERSION, 6) {
-        package.commands += windeployqt --release --translations $$TRANSLATION_LANGS --no-system-d3d-compiler --no-compiler-runtime --no-opengl-sw $$shell_path($${OUT_PWD}/package/NotepadNext.exe)
+        package.commands += windeployqt --release --no-translations --no-system-d3d-compiler --no-compiler-runtime --no-opengl-sw $$shell_path($${OUT_PWD}/package/NotepadNext.exe)
     } else {
-        package.commands += windeployqt --release --translations $$TRANSLATION_LANGS --no-system-d3d-compiler --no-compiler-runtime --no-angle --no-opengl-sw $$shell_path($${OUT_PWD}/package/NotepadNext.exe)
+        package.commands += windeployqt --release --no-translations --no-system-d3d-compiler --no-compiler-runtime --no-angle --no-opengl-sw $$shell_path($${OUT_PWD}/package/NotepadNext.exe)
     }
 
     # Zip it up

--- a/src/NotepadNext/NotepadNextApplication.cpp
+++ b/src/NotepadNext/NotepadNextApplication.cpp
@@ -289,7 +289,7 @@ void NotepadNextApplication::loadSystemDefaultTranslation()
 
     // Load translation for Qt components
     //  e.g. `translations/qt_en.qm`
-    if (translatorQt.load(locale, QString("qt"), QString("_"), QString("translations"))) {
+    if (translatorQt.load(locale, QString("qt"), QString("_"), QString("i18n"))) {
         installTranslator(&translatorQt);
         qInfo("Loaded %s translation for QT components", qUtf8Printable(locale.name()));
     } else {

--- a/src/NotepadNext/NotepadNextApplication.cpp
+++ b/src/NotepadNext/NotepadNextApplication.cpp
@@ -278,12 +278,22 @@ void NotepadNextApplication::loadSystemDefaultTranslation()
 {
     QLocale locale =  QLocale::system();
 
-    // look up e.g. i18n/NotepadNext.en.qm
-    if (translator.load(locale, QApplication::applicationName(), QString("."), QString("i18n"))) {
-        installTranslator(&translator);
-        qInfo("Loaded translation for %s", qUtf8Printable(locale.name()));
+    // Load translation for NotepadNext
+    //  e.g. `i18n/NotepadNext.en.qm`
+    if (translatorNpn.load(locale, QApplication::applicationName(), QString("."), QString("i18n"))) {
+        installTranslator(&translatorNpn);
+        qInfo("Loaded %s translation for NotepadNext", qUtf8Printable(locale.name()));
     } else {
-        qInfo("Translation not found for %s", qUtf8Printable(locale.name()));
+        qInfo("%s translation not found for NotepadNext", qUtf8Printable(locale.name()));
+    }
+
+    // Load translation for Qt components
+    //  e.g. `translations/qt_en.qm`
+    if (translatorQt.load(locale, QString("qt"), QString("_"), QString("translations"))) {
+        installTranslator(&translatorQt);
+        qInfo("Loaded %s translation for QT components", qUtf8Printable(locale.name()));
+    } else {
+        qInfo("%s translation not found for QT components", qUtf8Printable(locale.name()));
     }
 }
 

--- a/src/NotepadNext/NotepadNextApplication.h
+++ b/src/NotepadNext/NotepadNextApplication.h
@@ -68,7 +68,8 @@ private:
 
     void applyArguments(const QStringList &args);
     MainWindow *createNewWindow();
-    QTranslator translator;
+    QTranslator translatorNpn;
+    QTranslator translatorQt;
 };
 
 #endif // NOTEPADNEXTAPPLICATION_H

--- a/src/i18n.pri
+++ b/src/i18n.pri
@@ -18,8 +18,11 @@
 
 CONFIG += lrelease
 
-# All `*.ts` files:
-TRANSLATIONS = $$files($$PWD/../i18n/*.ts)
+TRANSLATIONS = \
+    ../../i18n/NotepadNext.zh_CN.ts
+
+EXTRA_TRANSLATIONS = \
+    $$[QT_INSTALL_TRANSLATIONS]/qt_zh_CN.qm
 
 # Output folder for `.qm` files
 LRELEASE_DIR = $$OUT_PWD/i18n


### PR DESCRIPTION
The translation of `Qt_base` for Simplified Chinese is not complete, so this patch does not actually copy any files.

You can test the `windeployqt` process by adding a new ts file to the i18n folder.
eg.: 
```sh
cd i18n/
cp NotepadNext.zh_CN.ts  NotepadNext.zh_TW.ts
cp NotepadNext.zh_CN.ts  NotepadNext.en.ts
```

After `jom package`, you may get `build\package\translations\qt_*.qm`
