### PR TITLE
Update Building.md

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -52,3 +52,8 @@ cd build
 qmake ../src/NotepadNext.pro
 make -j$(nproc)
 ```
+
+If encountered `/usr/lib/qt5/bin/lrelease not found` error. Please install `qttools5-dev-tools`.
+```
+sudo apt-get install qttools5-dev-tools
+```


### PR DESCRIPTION
Encountered en error on PopOS 21.04

```
$ make -j$(nproc)
cd NotepadNext/ && ( test -e Makefile || /usr/lib/qt5/bin/qmake -o Makefile /home/user/Repos/NotepadNext/src/NotepadNext/NotepadNext.pro ) && make -f Makefile 
make[1]: Entering directory '/home/user/Repos/NotepadNext/build/NotepadNext'
/usr/lib/qt5/bin/lrelease ../../i18n/NotepadNext.zh_CN.ts -qm i18n/NotepadNext.zh_CN.qm
make[1]: /usr/lib/qt5/bin/lrelease: No such file or directory
make[1]: *** [Makefile:1621: i18n/NotepadNext.zh_CN.qm] Error 127
make[1]: Leaving directory '/home/user/Repos/NotepadNext/build/NotepadNext'
make: *** [Makefile:47: sub-NotepadNext-make_first] Error 2
```

However. installing `qttools5-dev-tools` solved the problem.