### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -19,3 +19,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+  winget:
+    name: Publish to WinGet
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: dail8859.NotepadNext
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ There are numerous bugs and half working implementations. Pull requests are grea
 
 Packages are available for Windows, Linux, and MacOS.
 
-Windows packages are available as an installer or a stand-alone zip file on the [release](https://github.com/dail8859/NotepadNext/releases) page. The installer provides additional components such as an auto-updater and Windows context menu integration.
+Windows packages are available as an installer or a stand-alone zip file on the [release](https://github.com/dail8859/NotepadNext/releases) page. The installer provides additional components such as an auto-updater and Windows context menu integration. You can easily install it with Winget:
+
+```powershell
+winget install dail8859.NotepadNext
+```
 
 Linux packages can be obtained by downloading the stand-alone AppImage on the [release](https://github.com/dail8859/NotepadNext/releases) page or by installing the [flatpak](https://flathub.org/apps/details/com.github.dail8859.NotepadNext) by executing:
 


### PR DESCRIPTION
This action automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

[Notepad Next](https://github.com/microsoft/winget-pkgs/tree/master/manifests/d/dail8859/NotepadNext) is already in Winget, and this workflow will be used to update it.

Before merging this:
1. Add a PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN` (or rename the secret name in the workflow).

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)



2. Fork https://github.com/microsoft/winget-pkgs under @dail8859. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Sign the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs) for winget-pkgs as you (the PAT owner) will be a first-time contributor.

If you would like to read about this action further, the documentation is [here](https://bittu.eu.org/docs/wr-intro), and the source code is [here](https://github.com/vedantmgoyal2009/winget-releaser).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using 🛫 WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).