### PR TITLE
Enable some NSIS Components by default

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -152,7 +152,7 @@ SectionEnd
 
 # -----------------------------------------------
 
-${MementoUnselectedSection} "Start Menu Shortcut" SEC_START_MENU_SHORTCUT
+${MementoSection} "Start Menu Shortcut" SEC_START_MENU_SHORTCUT
 	CreateShortCut "$SMPROGRAMS\Notepad Next.lnk" "$INSTDIR\NotepadNext.exe"
 ${MementoSectionEnd}
 
@@ -162,7 +162,7 @@ SectionEnd
 
 # -----------------------------------------------
 
-${MementoUnselectedSection} "Context Menu" SEC_CONTEXT_MENU
+${MementoSection} "Context Menu" SEC_CONTEXT_MENU
 	SetRegView 64
 
 	WriteRegStr SHCTX "Software\Classes\*\shell\NotepadNext" "" "Edit with Notepad Next"
@@ -178,7 +178,7 @@ SectionEnd
 
 # -----------------------------------------------
 
-${MementoUnselectedSection} "Auto Updater" SEC_AUTO_UPDATER
+${MementoSection} "Auto Updater" SEC_AUTO_UPDATER
 	SetRegView 64
 	SetOutPath $INSTDIR
 


### PR DESCRIPTION
I think a start menu shortcut, context menu, and an auto-updater are what users would want by default in an installation. This is especially important for Winget users, as it runs silently by default, and they would expect it to appear in the Start Menu right after installation.