### PR TITLE
Update Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -24,7 +24,7 @@ jobs:
     name: Publish to WinGet
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: dail8859.NotepadNext
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Winget Releaser is now switching to version tags instead of the `latest` tag.

As mentioned in https://github.com/dail8859/NotepadNext/issues/208#issuecomment-1258827654, please install the [Pull](https://github.com/apps/pull) app on the winget-pkgs fork to ensure that it is always updated.