### PR TITLE
Fix displaying of non-ascii chars in Hex Viewer

### DIFF
--- a/src/NotepadNext/EditorHexViewerTableModel.cpp
+++ b/src/NotepadNext/EditorHexViewerTableModel.cpp
@@ -89,7 +89,7 @@ QVariant EditorHexViewerTableModel::data(const QModelIndex &index, int role) con
         int docPos = (index.row() * 16) + index.column();
         if (docPos >= editor->length()) return QVariant();
 
-        int ch = editor->charAt(docPos);
+        unsigned char ch = static_cast<unsigned char>(editor->charAt(docPos));
         return QString("%1").arg(ch, 2, 16, QChar('0')).toUpper();
     }
     else if (role == Qt::TextAlignmentRole) {


### PR DESCRIPTION
In the Hex Viewer the char values bigger than 0x7f is interpreted as negative integer and is padded with leading 'FF' when displaying.

This commit cast the char value returned by scintilla to 'unsigned char' before formatting it to QString for displaying.
![hexviewer](https://user-images.githubusercontent.com/3928298/196121507-cdd16504-1b93-4983-94ee-ff8ff2e070e5.PNG)
