### PR TITLE
Restore opened files between application restarts

### DIFF
--- a/src/NotepadNext/DockedEditor.cpp
+++ b/src/NotepadNext/DockedEditor.cpp
@@ -182,9 +182,10 @@ void DockedEditor::addEditor(ScintillaNext *editor)
         dockWidget->tabWidget()->setIcon(QIcon(":/icons/readonly.png"));
     }
     else {
-        dockWidget->tabWidget()->setIcon(QIcon(":/icons/saved.png"));
+        dockWidget->tabWidget()->setIcon(QIcon( editor->canSaveToDisk() ? ":/icons/unsaved.png" : ":/icons/saved.png"));
         connect(editor, &ScintillaNext::savePointChanged, dockWidget, [=](bool dirty) {
-            const QString iconPath = dirty ? ":/icons/unsaved.png" : ":/icons/saved.png";
+            const bool actuallyDirty = editor->canSaveToDisk();
+            const QString iconPath = actuallyDirty ? ":/icons/unsaved.png" : ":/icons/saved.png";
             dockWidget->tabWidget()->setIcon(QIcon(iconPath));
         });
     }

--- a/src/NotepadNext/DockedEditor.cpp
+++ b/src/NotepadNext/DockedEditor.cpp
@@ -182,7 +182,7 @@ void DockedEditor::addEditor(ScintillaNext *editor)
         dockWidget->tabWidget()->setIcon(QIcon(":/icons/readonly.png"));
     }
     else {
-        dockWidget->tabWidget()->setIcon(QIcon( editor->canSaveToDisk() ? ":/icons/unsaved.png" : ":/icons/saved.png"));
+        dockWidget->tabWidget()->setIcon(QIcon(editor->canSaveToDisk() ? ":/icons/unsaved.png" : ":/icons/saved.png"));
         connect(editor, &ScintillaNext::savePointChanged, dockWidget, [=](bool dirty) {
             const bool actuallyDirty = editor->canSaveToDisk();
             const QString iconPath = actuallyDirty ? ":/icons/unsaved.png" : ":/icons/saved.png";

--- a/src/NotepadNext/EditorManager.cpp
+++ b/src/NotepadNext/EditorManager.cpp
@@ -76,21 +76,6 @@ ScintillaNext *EditorManager::createEditorFromFile(const QString &filePath, bool
     return editor;
 }
 
-/*
-ScintillaNext *EditorManager::cloneEditor(ScintillaNext *editor)
-{
-    ScintillaNext *clonedEditor = new ScintillaNext("Clone");
-
-    manageEditor(editor);
-
-    setupEditor(clonedEditor);
-
-    emit editorCreated(clonedEditor);
-
-    return clonedEditor;
-}
-*/
-
 ScintillaNext *EditorManager::getEditorByFilePath(const QString &filePath)
 {
     QFileInfo newInfo(filePath);

--- a/src/NotepadNext/EditorManager.cpp
+++ b/src/NotepadNext/EditorManager.cpp
@@ -58,15 +58,11 @@ EditorManager::EditorManager(QObject *parent) : QObject(parent)
     });
 }
 
-ScintillaNext *EditorManager::createEmptyEditor(const QString &name)
+ScintillaNext *EditorManager::createEditor(const QString &name)
 {
     ScintillaNext *editor = new ScintillaNext(name);
 
     manageEditor(editor);
-
-    setupEditor(editor);
-
-    emit editorCreated(editor);
 
     return editor;
 }
@@ -77,13 +73,10 @@ ScintillaNext *EditorManager::createEditorFromFile(const QString &filePath, bool
 
     manageEditor(editor);
 
-    setupEditor(editor);
-
-    emit editorCreated(editor);
-
     return editor;
 }
 
+/*
 ScintillaNext *EditorManager::cloneEditor(ScintillaNext *editor)
 {
     ScintillaNext *clonedEditor = new ScintillaNext("Clone");
@@ -96,6 +89,7 @@ ScintillaNext *EditorManager::cloneEditor(ScintillaNext *editor)
 
     return clonedEditor;
 }
+*/
 
 ScintillaNext *EditorManager::getEditorByFilePath(const QString &filePath)
 {
@@ -116,6 +110,10 @@ ScintillaNext *EditorManager::getEditorByFilePath(const QString &filePath)
 void EditorManager::manageEditor(ScintillaNext *editor)
 {
     editors.append(QPointer<ScintillaNext>(editor));
+
+    setupEditor(editor);
+
+    emit editorCreated(editor);
 }
 
 void EditorManager::setupEditor(ScintillaNext *editor)

--- a/src/NotepadNext/EditorManager.h
+++ b/src/NotepadNext/EditorManager.h
@@ -35,7 +35,6 @@ public:
 
     ScintillaNext *createEditor(const QString &name);
     ScintillaNext *createEditorFromFile(const QString &filePath, bool tryToCreate=false);
-    //ScintillaNext *cloneEditor(ScintillaNext *editor);
 
     ScintillaNext *getEditorByFilePath(const QString &filePath);
 

--- a/src/NotepadNext/EditorManager.h
+++ b/src/NotepadNext/EditorManager.h
@@ -33,18 +33,19 @@ class EditorManager : public QObject
 public:
     explicit EditorManager(QObject *parent = nullptr);
 
-    ScintillaNext *createEmptyEditor(const QString &name);
+    ScintillaNext *createEditor(const QString &name);
     ScintillaNext *createEditorFromFile(const QString &filePath, bool tryToCreate=false);
-    ScintillaNext *cloneEditor(ScintillaNext *editor);
+    //ScintillaNext *cloneEditor(ScintillaNext *editor);
 
     ScintillaNext *getEditorByFilePath(const QString &filePath);
+
+    void manageEditor(ScintillaNext *editor);
 
 signals:
     void editorCreated(ScintillaNext *editor);
     void editorClosed(ScintillaNext *editor);
 
 private:
-    void manageEditor(ScintillaNext *editor);
     void setupEditor(ScintillaNext *editor);
     void purgeOldEditorPointers();
 

--- a/src/NotepadNext/NotepadNext.pro
+++ b/src/NotepadNext/NotepadNext.pro
@@ -93,6 +93,7 @@ SOURCES += \
     ScintillaCommenter.cpp \
     ScintillaNext.cpp \
     SelectionTracker.cpp \
+    SessionManager.cpp \
     Settings.cpp \
     SpinBoxDelegate.cpp \
     UndoAction.cpp \
@@ -167,6 +168,7 @@ HEADERS += \
     ScintillaEnums.h \
     ScintillaNext.h \
     SelectionTracker.h \
+    SessionManager.h \
     Settings.h \
     SpinBoxDelegate.h \
     UndoAction.h \

--- a/src/NotepadNext/NotepadNextApplication.cpp
+++ b/src/NotepadNext/NotepadNextApplication.cpp
@@ -218,7 +218,7 @@ bool NotepadNextApplication::init()
 
     if (settings->restorePreviousSession()) {
         qInfo("Restoring previous session");
-        SessionManager::LoadSession(editorManager);
+        SessionManager::LoadSession(windows.first(), editorManager);
     }
 
     openFiles(parser.positionalArguments());
@@ -441,7 +441,7 @@ MainWindow *NotepadNextApplication::createNewWindow()
         }
 
         if (settings->restorePreviousSession()) {
-            SessionManager::SaveSession(w->editors());
+            SessionManager::SaveSession(w);
         }
         else {
             // Make sure any previous session info is erased

--- a/src/NotepadNext/NotepadNextApplication.cpp
+++ b/src/NotepadNext/NotepadNextApplication.cpp
@@ -23,6 +23,7 @@
 #include "EditorManager.h"
 #include "LuaExtension.h"
 #include "DebugManager.h"
+#include "SessionManager.h"
 
 #include "LuaState.h"
 #include "lua.hpp"
@@ -211,6 +212,8 @@ bool NotepadNextApplication::init()
             }
         }
     });
+
+    SessionManager::LoadSession(editorManager);
 
     openFiles(parser.positionalArguments());
 
@@ -430,6 +433,8 @@ MainWindow *NotepadNextApplication::createNewWindow()
                 recentFilesListManager->addFile(editor->getFilePath());
             }
         }
+
+        SessionManager::SaveSession(w->editors());
     });
 
     return w;

--- a/src/NotepadNext/NotepadNextApplication.cpp
+++ b/src/NotepadNext/NotepadNextApplication.cpp
@@ -127,6 +127,7 @@ bool NotepadNextApplication::init()
     QSettings qsettings;
 
     settings->setRestorePreviousSession(qsettings.value("App/RestorePreviousSession", false).toBool());
+    settings->setRestoreUnsavedFiles(qsettings.value("App/RestoreUnsavedFiles", false).toBool());
     settings->setRestoreTempFiles(qsettings.value("App/RestoreTempFiles", false).toBool());
     recentFilesListManager->setFileList(qsettings.value("App/RecentFilesList").toStringList());
 
@@ -134,6 +135,7 @@ bool NotepadNextApplication::init()
         QSettings qsettings;
 
         qsettings.setValue("App/RestorePreviousSession", settings->restorePreviousSession());
+        qsettings.setValue("App/RestoreUnsavedFiles", settings->restoreUnsavedFiles());
         qsettings.setValue("App/RestoreTempFiles", settings->restoreTempFiles());
         qsettings.setValue("App/RecentFilesList", recentFilesListManager->fileList());
     });
@@ -251,7 +253,7 @@ SessionManager *NotepadNextApplication::getSessionManager() const
         fileTypes |= SessionManager::SavedFile;
     }
 
-    if (false /*settings->restorePreviousSession()*/) {
+    if (settings->restoreUnsavedFiles()) {
         fileTypes |= SessionManager::UnsavedFile;
     }
 

--- a/src/NotepadNext/NotepadNextApplication.h
+++ b/src/NotepadNext/NotepadNextApplication.h
@@ -34,6 +34,7 @@ class LuaState;
 class EditorManager;
 class RecentFilesListManager;
 class ScintillaNext;
+class SessionManager;
 
 class NotepadNextApplication : public SingleApplication
 {
@@ -46,6 +47,7 @@ public:
 
     RecentFilesListManager *getRecentFilesListManager() const { return recentFilesListManager; }
     EditorManager *getEditorManager() const { return editorManager; }
+    SessionManager *getSessionManager() const;
 
     LuaState *getLuaState() const { return luaState; }
     QString getFileDialogFilter() const;
@@ -70,6 +72,7 @@ private:
     EditorManager *editorManager;
     RecentFilesListManager *recentFilesListManager;
     Settings *settings;
+    SessionManager *sessionManager;
 
     LuaState *luaState = Q_NULLPTR;
 

--- a/src/NotepadNext/ScintillaNext.cpp
+++ b/src/NotepadNext/ScintillaNext.cpp
@@ -83,7 +83,6 @@ ScintillaNext *ScintillaNext::fromFile(const QString &filePath, bool tryToCreate
     }
 
     editor->setFileInfo(filePath);
-    editor->updateTimestamp();
 
     return editor;
 }
@@ -104,12 +103,24 @@ void ScintillaNext::goToRange(const Sci_CharacterRange &range)
 
 bool ScintillaNext::isSavedToDisk() const
 {
-    return bufferType != ScintillaNext::FileMissing && !modify();
+    return !canSaveToDisk();
+}
+
+bool ScintillaNext::canSaveToDisk() const
+{
+    // The buffer can be saved if:
+    // - It is marked as a temporary since as soon as it gets saved it is no longer a temporary buffer
+    // - A modified file
+    // - A missing file since as soon as it is saved it is no longer missing.
+    return temporary ||
+           (bufferType == ScintillaNext::New && modify()) ||
+           (bufferType == ScintillaNext::File && modify()) ||
+           (bufferType == ScintillaNext::FileMissing);
 }
 
 bool ScintillaNext::isFile() const
 {
-    return bufferType == ScintillaNext::File || bufferType == ScintillaNext::FileMissing;;
+    return bufferType == ScintillaNext::File || bufferType == ScintillaNext::FileMissing;
 }
 
 QFileInfo ScintillaNext::getFileInfo() const
@@ -176,6 +187,9 @@ bool ScintillaNext::save()
         updateTimestamp();
         setSavePoint();
 
+        // If this was a temporary file, make sure it is not any more
+        setTemporary(false);
+
         emit saved();
     }
 
@@ -215,7 +229,7 @@ void ScintillaNext::reload()
 
 bool ScintillaNext::saveAs(const QString &newFilePath)
 {
-    bool isRenamed = bufferType == ScintillaNext::Temporary || fileInfo.canonicalFilePath() != newFilePath;
+    bool isRenamed = bufferType == ScintillaNext::New || fileInfo.canonicalFilePath() != newFilePath;
 
     emit aboutToSave();
 
@@ -223,8 +237,10 @@ bool ScintillaNext::saveAs(const QString &newFilePath)
 
     if (saveSuccessful) {
         setFileInfo(newFilePath);
-        updateTimestamp();
         setSavePoint();
+
+        // If this was a temporary file, make sure it is not any more
+        setTemporary(false);
 
         emit saved();
 
@@ -253,8 +269,10 @@ bool ScintillaNext::rename(const QString &newFilePath)
 
         // Everything worked fine, so update the buffer's info
         setFileInfo(newFilePath);
-        updateTimestamp();
         setSavePoint();
+
+        // If this was a temporary file, make sure it is not any more
+        setTemporary(false);
 
         emit saved();
 
@@ -268,7 +286,7 @@ bool ScintillaNext::rename(const QString &newFilePath)
 
 ScintillaNext::FileStateChange ScintillaNext::checkFileForStateChange()
 {
-    if (bufferType == BufferType::Temporary) {
+    if (bufferType == BufferType::New) {
         return FileStateChange::NoChange;
     }
     else if (bufferType == BufferType::File) {
@@ -470,7 +488,7 @@ bool ScintillaNext::readFromDisk(QFile &file)
 
 QDateTime ScintillaNext::fileTimestamp()
 {
-    Q_ASSERT(bufferType != ScintillaNext::Temporary);
+    Q_ASSERT(bufferType != ScintillaNext::New);
 
     fileInfo.refresh();
     qInfo("%s last modified %s", qUtf8Printable(fileInfo.fileName()), qUtf8Printable(fileInfo.lastModified().toString()));
@@ -491,4 +509,20 @@ void ScintillaNext::setFileInfo(const QString &filePath)
 
     name = fileInfo.fileName();
     bufferType = ScintillaNext::File;
+
+    updateTimestamp();
+}
+
+void ScintillaNext::detachFileInfo(const QString &newName)
+{
+    this->name = newName;
+    bufferType = ScintillaNext::New;
+}
+
+void ScintillaNext::setTemporary(bool temp)
+{
+    temporary = temp;
+
+    // Fake this signal
+    emit savePointChanged(temporary);
 }

--- a/src/NotepadNext/ScintillaNext.h
+++ b/src/NotepadNext/ScintillaNext.h
@@ -59,12 +59,19 @@ public:
     void goToRange(const Sci_CharacterRange &range);
 
     bool isFile() const;
-    bool isSavedToDisk() const;
     QFileInfo getFileInfo() const;
+
+    bool isSavedToDisk() const;
+    bool canSaveToDisk() const;
 
     QString getName() const { return name; }
     QString getPath() const;
     QString getFilePath() const;
+
+    // NOTE: this is dangerous and should only be used in very rare situations
+    void setFileInfo(const QString &filePath);
+
+    void detachFileInfo(const QString &newName);
 
     enum FileStateChange {
         NoChange,
@@ -74,10 +81,13 @@ public:
     };
 
     enum BufferType {
-        Temporary = 0, // A temporary buffer, e.g. "New 1"
-        File = 1, // Buffer tied to a file on the file system
-        FileMissing = 2, // Buffer with a missing file on the file system
+        New, // A temporary buffer, e.g. "New 1"
+        File, // Buffer tied to a file on the file system
+        FileMissing, // Buffer with a missing file on the file system
     };
+
+    bool isTemporary() const { return temporary; }
+    void setTemporary(bool temp);
 
     void setFoldMarkers(const QString &type);
 
@@ -85,6 +95,7 @@ public:
     QByteArray languageSingleLineComment;
 
     #include "ScintillaEnums.h"
+
 
 public slots:
     void close();
@@ -114,14 +125,16 @@ protected:
 
 private:
     QString name;
-    BufferType bufferType = BufferType::Temporary;
+    BufferType bufferType = BufferType::New;
     QFileInfo fileInfo;
     QDateTime modifiedTime;
+
+    bool temporary = false; // Temporary file loaded from a session. It can either be a 'New' file or actual 'File'
 
     bool readFromDisk(QFile &file);
     QDateTime fileTimestamp();
     void updateTimestamp();
-    void setFileInfo(const QString &filePath);
+
 };
 
 template<typename Func>

--- a/src/NotepadNext/SessionManager.cpp
+++ b/src/NotepadNext/SessionManager.cpp
@@ -54,7 +54,7 @@ void SessionManager::SaveSession(QVector<ScintillaNext *> editors)
             settings.setArrayIndex(i);
             settings.setValue("FilePath", editor->getFilePath());
             settings.setValue("FirstVisibleLine", static_cast<int>(editor->firstVisibleLine() + 1)); // Keep it 1-based in the settings just for human-readability
-            //settings.setValue("XOffset", editor->xOffset());
+            settings.setValue("CurrentPosition", static_cast<int>(editor->currentPos()));
             ++i;
         }
     }
@@ -75,7 +75,7 @@ void SessionManager::LoadSession(EditorManager *editorManager)
         settings.setArrayIndex(i);
         QString filePath = settings.value("FilePath").toString();
         int firstVisibleLine = settings.value("FirstVisibleLine").toInt() - 1;
-        //int xOffset = settings.value("XOffset").toInt();
+        int currentPosition = settings.value("CurrentPosition").toInt();
 
         // See if it is already opened, if so just ignore it
         ScintillaNext *editor = editorManager->getEditorByFilePath(filePath);
@@ -87,7 +87,7 @@ void SessionManager::LoadSession(EditorManager *editorManager)
                 editor = editorManager->createEditorFromFile(filePath);
 
                 editor->setFirstVisibleLine(firstVisibleLine);
-                //editor->setXOffset(xOffset);
+                editor->setEmptySelection(currentPosition);
             }
         }
     }

--- a/src/NotepadNext/SessionManager.cpp
+++ b/src/NotepadNext/SessionManager.cpp
@@ -28,7 +28,7 @@ SessionManager::SessionManager()
 
 }
 
-void SessionManager::SaveSession(QVector<ScintillaNext *> editors)
+void SessionManager::ClearSession()
 {
     // Save session
     QSettings settings;
@@ -36,6 +36,15 @@ void SessionManager::SaveSession(QVector<ScintillaNext *> editors)
 
     // Clear everything out. There can be left over entries that are no longer needed
     settings.remove("");
+}
+
+void SessionManager::SaveSession(QVector<ScintillaNext *> editors)
+{
+    SessionManager::ClearSession();
+
+    // Save session
+    QSettings settings;
+    settings.beginGroup("CurrentSession");
 
     settings.beginWriteArray("OpenedFiles");
 
@@ -49,6 +58,7 @@ void SessionManager::SaveSession(QVector<ScintillaNext *> editors)
             ++i;
         }
     }
+
     settings.endArray();
     settings.endGroup();
 }

--- a/src/NotepadNext/SessionManager.cpp
+++ b/src/NotepadNext/SessionManager.cpp
@@ -53,7 +53,7 @@ void SessionManager::SaveSession(QVector<ScintillaNext *> editors)
         if (editor->isFile()) {
             settings.setArrayIndex(i);
             settings.setValue("FilePath", editor->getFilePath());
-            settings.setValue("FirstVisibleLine", editor->firstVisibleLine() + 1); // Keep it 1-based in the settings just for human-readability
+            settings.setValue("FirstVisibleLine", static_cast<int>(editor->firstVisibleLine() + 1)); // Keep it 1-based in the settings just for human-readability
             //settings.setValue("XOffset", editor->xOffset());
             ++i;
         }

--- a/src/NotepadNext/SessionManager.cpp
+++ b/src/NotepadNext/SessionManager.cpp
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2022 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "ScintillaNext.h"
+#include "SessionManager.h"
+#include "EditorManager.h"
+
+#include <QSettings>
+
+SessionManager::SessionManager()
+{
+
+}
+
+void SessionManager::SaveSession(QVector<ScintillaNext *> editors)
+{
+    // Save session
+    QSettings settings;
+    settings.beginGroup("CurrentSession");
+
+    // Clear everything out. There can be left over entries that are no longer needed
+    settings.remove("");
+
+    settings.beginWriteArray("OpenedFiles");
+
+    int i = 0;
+    for (const auto &editor : editors) {
+        if (editor->isFile()) {
+            settings.setArrayIndex(i);
+            settings.setValue("FilePath", editor->getFilePath());
+            settings.setValue("FirstVisibleLine", editor->firstVisibleLine() + 1); // Keep it 1-based in the settings just for human-readability
+            //settings.setValue("XOffset", editor->xOffset());
+            ++i;
+        }
+    }
+    settings.endArray();
+    settings.endGroup();
+}
+
+void SessionManager::LoadSession(EditorManager *editorManager)
+{
+    QSettings settings;
+
+    settings.beginGroup("CurrentSession");
+
+    int size = settings.beginReadArray("OpenedFiles");
+
+    for (int i = 0; i < size; ++i) {
+        settings.setArrayIndex(i);
+        QString filePath = settings.value("FilePath").toString();
+        int firstVisibleLine = settings.value("FirstVisibleLine").toInt() - 1;
+        //int xOffset = settings.value("XOffset").toInt();
+
+        // See if it is already opened, if so just ignore it
+        ScintillaNext *editor = editorManager->getEditorByFilePath(filePath);
+
+        if (editor == Q_NULLPTR) {
+            QFileInfo fileInfo(filePath);
+
+            if (fileInfo.isFile()) {
+                editor = editorManager->createEditorFromFile(filePath);
+
+                editor->setFirstVisibleLine(firstVisibleLine);
+                //editor->setXOffset(xOffset);
+            }
+        }
+    }
+
+    settings.endArray();
+    settings.endGroup();
+}

--- a/src/NotepadNext/SessionManager.h
+++ b/src/NotepadNext/SessionManager.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2022 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef SESSIONMANAGER_H
+#define SESSIONMANAGER_H
+
+#include <QVector>
+
+
+class ScintillaNext;
+class EditorManager;
+
+class SessionManager
+{
+public:
+    SessionManager();
+
+    static void SaveSession(QVector<ScintillaNext *> editors);
+    static void LoadSession(EditorManager *editorManager);
+};
+
+#endif // SESSIONMANAGER_H

--- a/src/NotepadNext/SessionManager.h
+++ b/src/NotepadNext/SessionManager.h
@@ -55,6 +55,8 @@ public:
 private:
     QDir sessionDirectory() const;
 
+    void saveIntoSessionDirectory(ScintillaNext *editor, const QString &sessionFileName) const;
+
     SessionFileType determineType(ScintillaNext *editor) const;
 
     void clearSettings() const;

--- a/src/NotepadNext/SessionManager.h
+++ b/src/NotepadNext/SessionManager.h
@@ -20,7 +20,9 @@
 #ifndef SESSIONMANAGER_H
 #define SESSIONMANAGER_H
 
-#include <QVector>
+
+#include <QDir>
+#include <QSettings>
 
 
 class ScintillaNext;
@@ -30,12 +32,49 @@ class MainWindow;
 class SessionManager
 {
 public:
-    SessionManager();
+    enum SessionFileType {
+        None = 0,
+        SavedFile = 1,
+        UnsavedFile = 2,
+        TempFile = 3,
+    };
+    Q_DECLARE_FLAGS(SessionFileTypes, SessionFileType)
 
-    static void ClearSession();
 
-    static void SaveSession(MainWindow *window);
-    static void LoadSession(MainWindow *window, EditorManager *editorManager);
+    SessionManager(SessionFileTypes types = SessionFileTypes());
+
+    void setSessionFileTypes(SessionFileTypes types);
+
+    void clear() const;
+
+    void saveSession(MainWindow *window);
+    void loadSession(MainWindow *window, EditorManager *editorManager);
+
+    bool willFileGetStoredInSession(ScintillaNext *editor) const;
+
+private:
+    QDir sessionDirectory() const;
+
+    SessionFileType determineType(ScintillaNext *editor) const;
+
+    void clearSettings() const;
+    void clearDirectory() const;
+
+    void storeFileDetails(ScintillaNext *editor, QSettings &settings);
+    ScintillaNext *loadFileDetails(QSettings &settings, EditorManager *editorManager);
+
+    void storeUnsavedFileDetails(ScintillaNext *editor, QSettings &settings);
+    ScintillaNext *loadUnsavedFileDetails(QSettings &settings, EditorManager *editorManager);
+
+    void storeUnsavedTempFile(ScintillaNext *editor, QSettings &settings);
+    ScintillaNext *loadUnsavedTempFile(QSettings &settings, EditorManager *editorManager);
+
+    void storeEditorViewDetails(ScintillaNext *editor, QSettings &settings);
+    void loadEditorViewDetails(ScintillaNext *editor, QSettings &settings);
+
+    SessionFileTypes fileTypes;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(SessionManager::SessionFileTypes)
 
 #endif // SESSIONMANAGER_H

--- a/src/NotepadNext/SessionManager.h
+++ b/src/NotepadNext/SessionManager.h
@@ -31,6 +31,8 @@ class SessionManager
 public:
     SessionManager();
 
+    static void ClearSession();
+
     static void SaveSession(QVector<ScintillaNext *> editors);
     static void LoadSession(EditorManager *editorManager);
 };

--- a/src/NotepadNext/SessionManager.h
+++ b/src/NotepadNext/SessionManager.h
@@ -25,6 +25,7 @@
 
 class ScintillaNext;
 class EditorManager;
+class MainWindow;
 
 class SessionManager
 {
@@ -33,8 +34,8 @@ public:
 
     static void ClearSession();
 
-    static void SaveSession(QVector<ScintillaNext *> editors);
-    static void LoadSession(EditorManager *editorManager);
+    static void SaveSession(MainWindow *window);
+    static void LoadSession(MainWindow *window, EditorManager *editorManager);
 };
 
 #endif // SESSIONMANAGER_H

--- a/src/NotepadNext/SessionManager.h
+++ b/src/NotepadNext/SessionManager.h
@@ -36,7 +36,7 @@ public:
         None = 0,
         SavedFile = 1,
         UnsavedFile = 2,
-        TempFile = 3,
+        TempFile = 4,
     };
     Q_DECLARE_FLAGS(SessionFileTypes, SessionFileType)
 
@@ -66,8 +66,8 @@ private:
     void storeUnsavedFileDetails(ScintillaNext *editor, QSettings &settings);
     ScintillaNext *loadUnsavedFileDetails(QSettings &settings, EditorManager *editorManager);
 
-    void storeUnsavedTempFile(ScintillaNext *editor, QSettings &settings);
-    ScintillaNext *loadUnsavedTempFile(QSettings &settings, EditorManager *editorManager);
+    void storeTempFile(ScintillaNext *editor, QSettings &settings);
+    ScintillaNext *loadTempFile(QSettings &settings, EditorManager *editorManager);
 
     void storeEditorViewDetails(ScintillaNext *editor, QSettings &settings);
     void loadEditorViewDetails(ScintillaNext *editor, QSettings &settings);

--- a/src/NotepadNext/Settings.cpp
+++ b/src/NotepadNext/Settings.cpp
@@ -32,6 +32,7 @@ bool Settings::showStatusBar() const { return m_showStatusBar; }
 bool Settings::tabsClosable() const { return m_tabsClosable; }
 
 bool Settings::restorePreviousSession() const { return m_restorePreviousSession; }
+bool Settings::restoreTempFiles() const { return m_restoreTempFiles; }
 
 
 void Settings::setShowMenuBar(bool showMenuBar)
@@ -86,4 +87,13 @@ void Settings::setRestorePreviousSession(bool restorePreviousSession)
 
     m_restorePreviousSession = restorePreviousSession;
     emit tabsClosableChanged(m_restorePreviousSession);
+}
+
+void Settings::setRestoreTempFiles(bool restoreTempFiles)
+{
+    if (m_restoreTempFiles == restoreTempFiles)
+        return;
+
+    m_restoreTempFiles = restoreTempFiles;
+    emit tabsClosableChanged(m_restoreTempFiles);
 }

--- a/src/NotepadNext/Settings.cpp
+++ b/src/NotepadNext/Settings.cpp
@@ -31,6 +31,8 @@ bool Settings::showStatusBar() const { return m_showStatusBar; }
 
 bool Settings::tabsClosable() const { return m_tabsClosable; }
 
+bool Settings::restorePreviousSession() const { return m_restorePreviousSession; }
+
 
 void Settings::setShowMenuBar(bool showMenuBar)
 {
@@ -75,4 +77,13 @@ void Settings::setTabsClosable(bool tabsClosable)
 
     m_tabsClosable = tabsClosable;
     emit tabsClosableChanged(m_tabsClosable);
+}
+
+void Settings::setRestorePreviousSession(bool restorePreviousSession)
+{
+    if (m_restorePreviousSession == restorePreviousSession)
+        return;
+
+    m_restorePreviousSession = restorePreviousSession;
+    emit tabsClosableChanged(m_restorePreviousSession);
 }

--- a/src/NotepadNext/Settings.cpp
+++ b/src/NotepadNext/Settings.cpp
@@ -32,6 +32,7 @@ bool Settings::showStatusBar() const { return m_showStatusBar; }
 bool Settings::tabsClosable() const { return m_tabsClosable; }
 
 bool Settings::restorePreviousSession() const { return m_restorePreviousSession; }
+bool Settings::restoreUnsavedFiles() const { return m_restoreUnsavedFiles; }
 bool Settings::restoreTempFiles() const { return m_restoreTempFiles; }
 
 
@@ -86,7 +87,16 @@ void Settings::setRestorePreviousSession(bool restorePreviousSession)
         return;
 
     m_restorePreviousSession = restorePreviousSession;
-    emit tabsClosableChanged(m_restorePreviousSession);
+    emit restorePreviousSessionChanged(m_restorePreviousSession);
+}
+
+void Settings::setRestoreUnsavedFiles(bool restoreUnsavedFiles)
+{
+    if (m_restoreUnsavedFiles == restoreUnsavedFiles)
+        return;
+
+    m_restoreUnsavedFiles = restoreUnsavedFiles;
+    emit restoreUnsavedFilesChanged(m_restoreUnsavedFiles);
 }
 
 void Settings::setRestoreTempFiles(bool restoreTempFiles)
@@ -95,5 +105,5 @@ void Settings::setRestoreTempFiles(bool restoreTempFiles)
         return;
 
     m_restoreTempFiles = restoreTempFiles;
-    emit tabsClosableChanged(m_restoreTempFiles);
+    emit restoreTempFilesChanged(m_restoreTempFiles);
 }

--- a/src/NotepadNext/Settings.h
+++ b/src/NotepadNext/Settings.h
@@ -34,6 +34,7 @@ class Settings : public QObject
 
     Q_PROPERTY(bool tabsClosable READ tabsClosable WRITE setTabsClosable NOTIFY tabsClosableChanged)
 
+    Q_PROPERTY(bool restorePreviousSession READ restorePreviousSession WRITE setRestorePreviousSession NOTIFY restorePreviousSessionChanged)
 
     bool m_showMenuBar = true;
     bool m_showToolBar = true;
@@ -41,6 +42,8 @@ class Settings : public QObject
     bool m_showStatusBar = true;
 
     bool m_tabsClosable = true;
+
+    bool m_restorePreviousSession = false;
 
 public:
     explicit Settings(QObject *parent = nullptr);
@@ -52,6 +55,8 @@ public:
 
     bool tabsClosable() const;
 
+    bool restorePreviousSession() const;
+
 signals:
     void showMenuBarChanged(bool showMenuBar);
     void showToolBarChanged(bool showToolBar);
@@ -60,6 +65,8 @@ signals:
 
     void tabsClosableChanged(bool tabsClosable);
 
+    void restorePreviousSessionChanged(bool restorePreviousSession);
+
 public slots:
     void setShowMenuBar(bool showMenuBar);
     void setShowToolBar(bool showToolBar);
@@ -67,6 +74,8 @@ public slots:
     void setShowStatusBar(bool showStatusBar);
 
     void setTabsClosable(bool tabsClosable);
+
+    void setRestorePreviousSession(bool restorePreviousSession);
 };
 
 #endif // SETTINGS_H

--- a/src/NotepadNext/Settings.h
+++ b/src/NotepadNext/Settings.h
@@ -35,6 +35,7 @@ class Settings : public QObject
     Q_PROPERTY(bool tabsClosable READ tabsClosable WRITE setTabsClosable NOTIFY tabsClosableChanged)
 
     Q_PROPERTY(bool restorePreviousSession READ restorePreviousSession WRITE setRestorePreviousSession NOTIFY restorePreviousSessionChanged)
+    Q_PROPERTY(bool restoreUnsavedFiles READ restoreUnsavedFiles WRITE setRestoreUnsavedFiles NOTIFY restoreUnsavedFilesChanged)
     Q_PROPERTY(bool restoreTempFiles READ restoreTempFiles WRITE setRestoreTempFiles NOTIFY restoreTempFilesChanged)
 
     bool m_showMenuBar = true;
@@ -45,6 +46,7 @@ class Settings : public QObject
     bool m_tabsClosable = true;
 
     bool m_restorePreviousSession = false;
+    bool m_restoreUnsavedFiles = false;
     bool m_restoreTempFiles = false;
 
 public:
@@ -58,6 +60,7 @@ public:
     bool tabsClosable() const;
 
     bool restorePreviousSession() const;
+    bool restoreUnsavedFiles() const;
     bool restoreTempFiles() const;
 
 signals:
@@ -69,6 +72,7 @@ signals:
     void tabsClosableChanged(bool tabsClosable);
 
     void restorePreviousSessionChanged(bool restorePreviousSession);
+    void restoreUnsavedFilesChanged(bool restureUnsavedFiles);
     void restoreTempFilesChanged(bool restoreTempFiles);
 
 public slots:
@@ -80,6 +84,7 @@ public slots:
     void setTabsClosable(bool tabsClosable);
 
     void setRestorePreviousSession(bool restorePreviousSession);
+    void setRestoreUnsavedFiles(bool restoreUnsavedFiles);
     void setRestoreTempFiles(bool restoreTempFiles);
 };
 

--- a/src/NotepadNext/Settings.h
+++ b/src/NotepadNext/Settings.h
@@ -35,6 +35,7 @@ class Settings : public QObject
     Q_PROPERTY(bool tabsClosable READ tabsClosable WRITE setTabsClosable NOTIFY tabsClosableChanged)
 
     Q_PROPERTY(bool restorePreviousSession READ restorePreviousSession WRITE setRestorePreviousSession NOTIFY restorePreviousSessionChanged)
+    Q_PROPERTY(bool restoreTempFiles READ restoreTempFiles WRITE setRestoreTempFiles NOTIFY restoreTempFilesChanged)
 
     bool m_showMenuBar = true;
     bool m_showToolBar = true;
@@ -44,6 +45,7 @@ class Settings : public QObject
     bool m_tabsClosable = true;
 
     bool m_restorePreviousSession = false;
+    bool m_restoreTempFiles = false;
 
 public:
     explicit Settings(QObject *parent = nullptr);
@@ -56,6 +58,7 @@ public:
     bool tabsClosable() const;
 
     bool restorePreviousSession() const;
+    bool restoreTempFiles() const;
 
 signals:
     void showMenuBarChanged(bool showMenuBar);
@@ -66,6 +69,7 @@ signals:
     void tabsClosableChanged(bool tabsClosable);
 
     void restorePreviousSessionChanged(bool restorePreviousSession);
+    void restoreTempFilesChanged(bool restoreTempFiles);
 
 public slots:
     void setShowMenuBar(bool showMenuBar);
@@ -76,6 +80,7 @@ public slots:
     void setTabsClosable(bool tabsClosable);
 
     void setRestorePreviousSession(bool restorePreviousSession);
+    void setRestoreTempFiles(bool restoreTempFiles);
 };
 
 #endif // SETTINGS_H

--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -680,7 +680,26 @@ void MainWindow::newFile()
 
     static int count = 1;
 
-    app->getEditorManager()->createEditor(tr("New %1").arg(count++));
+    // NOTE: in theory need to check all editors in the editorManager to future proof this.
+    // If there is another window it would need to check those too to see if New X exists. The editor
+    // manager would encompass all editors
+
+    forever {
+        QString newFileName = tr("New %1").arg(count++);
+        bool canUseName = true;
+
+        for (const ScintillaNext *editor : editors()) {
+            if (!editor->isFile() && editor->getName() == newFileName) {
+                canUseName = false;
+                break;
+            }
+        }
+
+        if (canUseName) {
+            app->getEditorManager()->createEditor(newFileName);
+            break;
+        }
+    }
 }
 
 // One unedited, new blank document

--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -1512,6 +1512,11 @@ void MainWindow::restoreWindowState()
     srDock->hide();
 }
 
+void MainWindow::switchToEditor(const ScintillaNext *editor)
+{
+    dockedEditor->switchToEditor(editor);
+}
+
 void MainWindow::focusIn()
 {
     qInfo(Q_FUNC_INFO);

--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -1493,7 +1493,6 @@ void MainWindow::restoreSettings()
     zoomLevel = settings.value("Editor/ZoomLevel", 0).toInt();
 }
 
-
 void MainWindow::restoreWindowState()
 {
     QSettings settings;

--- a/src/NotepadNext/dialogs/MainWindow.h
+++ b/src/NotepadNext/dialogs/MainWindow.h
@@ -110,7 +110,6 @@ public slots:
     void updateGui(ScintillaNext *editor);
 
     void detectLanguage(ScintillaNext *editor);
-    void activateEditor(ScintillaNext *editor);
 
     void setLanguage(ScintillaNext *editor, const QString &languageName);
 
@@ -136,6 +135,7 @@ private slots:
     void tabBarRightClicked(ScintillaNext *editor);
     void languageMenuTriggered();
     void checkForUpdatesFinished(QString url);
+    void activateEditor(ScintillaNext *editor);
 
 private:
     Ui::MainWindow *ui = Q_NULLPTR;

--- a/src/NotepadNext/dialogs/MainWindow.h
+++ b/src/NotepadNext/dialogs/MainWindow.h
@@ -69,7 +69,7 @@ public slots:
 
     void closeCurrentFile();
     void closeFile(ScintillaNext *editor);
-    void closeAllFiles(bool forceClose);
+    void closeAllFiles();
     void closeAllExceptActive();
     void closeAllToLeft();
     void closeAllToRight();

--- a/src/NotepadNext/dialogs/MainWindow.h
+++ b/src/NotepadNext/dialogs/MainWindow.h
@@ -122,6 +122,8 @@ public slots:
 
     void restoreWindowState();
 
+    void switchToEditor(const ScintillaNext *editor);
+
 signals:
     void editorActivated(ScintillaNext *editor);
     void aboutToClose();

--- a/src/NotepadNext/dialogs/PreferencesDialog.cpp
+++ b/src/NotepadNext/dialogs/PreferencesDialog.cpp
@@ -40,6 +40,10 @@ PreferencesDialog::PreferencesDialog(Settings *settings, QWidget *parent) :
     ui->checkBoxStatusBar->setChecked(settings->showStatusBar());
     connect(settings, &Settings::showStatusBarChanged, ui->checkBoxStatusBar, &QCheckBox::setChecked);
     connect(ui->checkBoxStatusBar, &QCheckBox::clicked, settings, &Settings::setShowStatusBar);
+
+    ui->checkBoxRememberSession->setChecked(settings->restorePreviousSession());
+    connect(settings, &Settings::restorePreviousSessionChanged, ui->checkBoxRememberSession, &QCheckBox::setChecked);
+    connect(ui->checkBoxRememberSession, &QCheckBox::clicked, settings, &Settings::setRestorePreviousSession);
 }
 
 PreferencesDialog::~PreferencesDialog()

--- a/src/NotepadNext/dialogs/PreferencesDialog.cpp
+++ b/src/NotepadNext/dialogs/PreferencesDialog.cpp
@@ -31,29 +31,37 @@ PreferencesDialog::PreferencesDialog(Settings *settings, QWidget *parent) :
 
     ui->checkBoxMenuBar->setChecked(settings->showMenuBar());
     connect(settings, &Settings::showMenuBarChanged, ui->checkBoxMenuBar, &QCheckBox::setChecked);
-    connect(ui->checkBoxMenuBar, &QCheckBox::clicked, settings, &Settings::setShowMenuBar);
+    connect(ui->checkBoxMenuBar, &QCheckBox::toggled, settings, &Settings::setShowMenuBar);
 
     ui->checkBoxToolBar->setChecked(settings->showToolBar());
     connect(settings, &Settings::showToolBarChanged, ui->checkBoxToolBar, &QCheckBox::setChecked);
-    connect(ui->checkBoxToolBar, &QCheckBox::clicked, settings, &Settings::setShowToolBar);
+    connect(ui->checkBoxToolBar, &QCheckBox::toggled, settings, &Settings::setShowToolBar);
 
     ui->checkBoxStatusBar->setChecked(settings->showStatusBar());
     connect(settings, &Settings::showStatusBarChanged, ui->checkBoxStatusBar, &QCheckBox::setChecked);
-    connect(ui->checkBoxStatusBar, &QCheckBox::clicked, settings, &Settings::setShowStatusBar);
+    connect(ui->checkBoxStatusBar, &QCheckBox::toggled, settings, &Settings::setShowStatusBar);
 
-    ui->checkBoxRememberSession->setChecked(settings->restorePreviousSession());
-    connect(settings, &Settings::restorePreviousSessionChanged, ui->checkBoxRememberSession, &QCheckBox::setChecked);
-    connect(ui->checkBoxRememberSession, &QCheckBox::clicked, settings, &Settings::setRestorePreviousSession);
+    ui->gbxRestorePreviousSession->setChecked(settings->restorePreviousSession());
+    connect(settings, &Settings::restorePreviousSessionChanged, ui->gbxRestorePreviousSession, &QGroupBox::setChecked);
+    connect(ui->gbxRestorePreviousSession, &QGroupBox::toggled, settings, &Settings::setRestorePreviousSession);
 
+    ui->checkBoxUnsavedFiles->setChecked(settings->restoreUnsavedFiles());
     ui->checkBoxRestoreTempFiles->setChecked(settings->restoreTempFiles());
-    connect(ui->checkBoxRememberSession, &QCheckBox::clicked, ui->checkBoxRestoreTempFiles, &QCheckBox::setEnabled);
-    connect(ui->checkBoxRememberSession, &QCheckBox::clicked, this, [=](bool checked) {
+
+    connect(ui->gbxRestorePreviousSession, &QGroupBox::toggled, ui->checkBoxRestoreTempFiles, &QCheckBox::setEnabled);
+
+    connect(ui->gbxRestorePreviousSession, &QGroupBox::toggled, this, [=](bool checked) {
         if (!checked) {
+            ui->checkBoxUnsavedFiles->setChecked(false);
             ui->checkBoxRestoreTempFiles->setChecked(false);
         }
     });
+
+    connect(settings, &Settings::restoreUnsavedFilesChanged, ui->checkBoxUnsavedFiles, &QCheckBox::setChecked);
+    connect(ui->checkBoxUnsavedFiles, &QCheckBox::toggled, settings, &Settings::setRestoreUnsavedFiles);
+
     connect(settings, &Settings::restoreTempFilesChanged, ui->checkBoxRestoreTempFiles, &QCheckBox::setChecked);
-    connect(ui->checkBoxRestoreTempFiles, &QCheckBox::clicked, settings, &Settings::setRestoreTempFiles);
+    connect(ui->checkBoxRestoreTempFiles, &QCheckBox::toggled, settings, &Settings::setRestoreTempFiles);
 }
 
 PreferencesDialog::~PreferencesDialog()

--- a/src/NotepadNext/dialogs/PreferencesDialog.cpp
+++ b/src/NotepadNext/dialogs/PreferencesDialog.cpp
@@ -44,6 +44,16 @@ PreferencesDialog::PreferencesDialog(Settings *settings, QWidget *parent) :
     ui->checkBoxRememberSession->setChecked(settings->restorePreviousSession());
     connect(settings, &Settings::restorePreviousSessionChanged, ui->checkBoxRememberSession, &QCheckBox::setChecked);
     connect(ui->checkBoxRememberSession, &QCheckBox::clicked, settings, &Settings::setRestorePreviousSession);
+
+    ui->checkBoxRestoreTempFiles->setChecked(settings->restoreTempFiles());
+    connect(ui->checkBoxRememberSession, &QCheckBox::clicked, ui->checkBoxRestoreTempFiles, &QCheckBox::setEnabled);
+    connect(ui->checkBoxRememberSession, &QCheckBox::clicked, this, [=](bool checked) {
+        if (!checked) {
+            ui->checkBoxRestoreTempFiles->setChecked(false);
+        }
+    });
+    connect(settings, &Settings::restoreTempFilesChanged, ui->checkBoxRestoreTempFiles, &QCheckBox::setChecked);
+    connect(ui->checkBoxRestoreTempFiles, &QCheckBox::clicked, settings, &Settings::setRestoreTempFiles);
 }
 
 PreferencesDialog::~PreferencesDialog()

--- a/src/NotepadNext/dialogs/PreferencesDialog.ui
+++ b/src/NotepadNext/dialogs/PreferencesDialog.ui
@@ -37,6 +37,13 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="checkBoxRememberSession">
+       <property name="text">
+        <string>Restore Previous Session</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/src/NotepadNext/dialogs/PreferencesDialog.ui
+++ b/src/NotepadNext/dialogs/PreferencesDialog.ui
@@ -38,17 +38,32 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="checkBoxRememberSession">
-       <property name="text">
+      <widget class="QGroupBox" name="gbxRestorePreviousSession">
+       <property name="title">
         <string>Restore Previous Session</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkBoxRestoreTempFiles">
-       <property name="text">
-        <string>Restore Temp Files</string>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="checkBoxUnsavedFiles">
+          <property name="text">
+           <string>Unsaved changes</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkBoxRestoreTempFiles">
+          <property name="text">
+           <string>Temp Files</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>

--- a/src/NotepadNext/dialogs/PreferencesDialog.ui
+++ b/src/NotepadNext/dialogs/PreferencesDialog.ui
@@ -44,6 +44,13 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="checkBoxRestoreTempFiles">
+       <property name="text">
+        <string>Restore Temp Files</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/src/NotepadNext/docks/FileListDock.cpp
+++ b/src/NotepadNext/docks/FileListDock.cpp
@@ -85,7 +85,7 @@ void FileListDock::addEditor(ScintillaNext *editor)
     item->setToolTip(editor->getName());
     item->setIcon(QIcon(":/icons/saved.png"));
     item->setData(Qt::UserRole, QVariant::fromValue(editor));
-    item->setIcon(QIcon(editor->modify() ? ":/icons/unsaved.png" : ":/icons/saved.png"));
+    item->setIcon(QIcon(editor->canSaveToDisk() ? ":/icons/unsaved.png" : ":/icons/saved.png"));
 
     // Need some notifications from the editor itself
     // NOTE: Cannot use a lambda here because item is not a QObject, and thus cannot be used as a context for Qt to know
@@ -138,7 +138,7 @@ void FileListDock::editorSavePointChanged(bool dirty)
         QListWidgetItem* item = lookupItemByEditor(editor);
 
         if (item) {
-            const QString iconPath = dirty ? ":/icons/unsaved.png" : ":/icons/saved.png";
+            const QString iconPath = editor->canSaveToDisk() ? ":/icons/unsaved.png" : ":/icons/saved.png";
             item->setIcon(QIcon(iconPath));
         }
     }


### PR DESCRIPTION
This is a first attempt at saving/loading a user's session between application restarts.

This feature is **not** enabled by default. This needs enabled through the preferences dialog.

~~This feature does **not** currently save temporary files (that will come later). This base functionality is needed before temporary files can be properly saved/loaded.~~

TODO:
- [x] Make sure new files don't get named the same as existing files. E.g. since `New 1` can be loaded from the session, `File > New` would then also create `New 1`
- [x] Allow to files with the same name to be stored in the session. `C:\dir1\test.txt` and `C:\dir2\test.txt` both get saved as `text.txt` and will overwite each other.
- [x] Remove commented out code