### PR TITLE
Add support load translation for linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
           cd build-linux
           make install INSTALL_ROOT=AppDir
           cd NotepadNext
+          lrelease ../../src/NotepadNext.pro
+          mkdir -p AppDir/usr/share/NotepadNext/NotepadNext/translations
+          cp ../../i18n/NotepadNext*.qm AppDir/usr/share/NotepadNext/NotepadNext/translations/
           wget --no-verbose "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
           wget --no-verbose "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
           chmod +x linuxdeploy*.AppImage

--- a/src/NotepadNext/NotepadNext.pro
+++ b/src/NotepadNext/NotepadNext.pro
@@ -268,6 +268,11 @@ unix {
     appicon.path = $$PREFIX/share/icons/hicolor/scalable/apps/
     appicon.files = ../../icon/NotepadNext.svg
     INSTALLS += appicon
+
+    system("lrelease i18n/*.ts")
+    i18n.path = $$PREFIX/share/NotepadNext/NotepadNext/translations/
+    i18n.files += ../../i18n/NotepadNext*.qm
+    INSTALLS += i18n
 }
 
 macx: {


### PR DESCRIPTION
Closes https://github.com/dail8859/NotepadNext/issues/155

Translation file should be installed in `XDG_DATA_DIRS`/`APPNAME`/translations， `XDG_DATA_DIRS` Should default to /usr/local/share:/usr/share.

QStandardPaths::AppDataLocation will read `xdgDataDirs/organizationName/applicationName`

https://github.com/qt/qtbase/blob/1c6bf3e09ea9722717caedcfcceaaf3d607615cf/src/corelib/io/qstandardpaths_unix.cpp#L385-L390
https://github.com/qt/qtbase/blob/1c6bf3e09ea9722717caedcfcceaaf3d607615cf/src/corelib/io/qstandardpaths_unix.cpp#L27-L38