### PR TITLE
Fix English tranlation issue #370

### DIFF
--- a/src/NotepadNext/NotepadNextApplication.cpp
+++ b/src/NotepadNext/NotepadNextApplication.cpp
@@ -398,17 +398,17 @@ void NotepadNextApplication::loadTranslation(QLocale locale)
     const QString languagePath = QStringLiteral(":/i18n/");
 
     // Load translation for NotepadNext e.g. "i18n/NotepadNext.en.qm"
-    if (translatorNpn.load(locale, QApplication::applicationName(), QString("_"), languagePath)) {
+    if (translatorNpn.load(QLocale(locale.name()), QApplication::applicationName(), QString("_"), languagePath)) {
         installTranslator(&translatorNpn);
-        qInfo("Loaded %s translation for Notepad Next", qUtf8Printable(locale.name()));
+        qInfo("Loaded %s translation %s for Notepad Next", qUtf8Printable(locale.name()), qUtf8Printable(translatorNpn.filePath()));
     } else {
         qInfo("%s translation not found for Notepad Next", qUtf8Printable(locale.name()));
     }
 
     // Load translation for Qt components e.g. "i18n/qt_en.qm"
-    if (translatorQt.load(locale, QString("qt"), QString("_"), languagePath)) {
+    if (translatorQt.load(QLocale(locale.name()), QString("qt"), QString("_"), languagePath)) {
         installTranslator(&translatorQt);
-        qInfo("Loaded %s translation for Qt components", qUtf8Printable(locale.name()));
+        qInfo("Loaded %s translation %s for Qt components", qUtf8Printable(locale.name()), qUtf8Printable(translatorQt.filePath()));
     } else {
         qInfo("%s translation not found for Qt components", qUtf8Printable(locale.name()));
     }

--- a/src/NotepadNext/NotepadNextApplication.cpp
+++ b/src/NotepadNext/NotepadNextApplication.cpp
@@ -387,7 +387,7 @@ QString NotepadNextApplication::detectLanguageFromContents(ScintillaNext *editor
 
 void NotepadNextApplication::loadSystemDefaultTranslation()
 {
-    loadTranslation(QLocale::system());
+    loadTranslation(QLocale(QLocale::system().name()));
 }
 
 void NotepadNextApplication::loadTranslation(QLocale locale)
@@ -398,7 +398,7 @@ void NotepadNextApplication::loadTranslation(QLocale locale)
     const QString languagePath = QStringLiteral(":/i18n/");
 
     // Load translation for NotepadNext e.g. "i18n/NotepadNext.en.qm"
-    if (translatorNpn.load(QLocale(locale.name()), QApplication::applicationName(), QString("_"), languagePath)) {
+    if (translatorNpn.load(locale, QApplication::applicationName(), QString("_"), languagePath)) {
         installTranslator(&translatorNpn);
         qInfo("Loaded %s translation %s for Notepad Next", qUtf8Printable(locale.name()), qUtf8Printable(translatorNpn.filePath()));
     } else {
@@ -406,7 +406,7 @@ void NotepadNextApplication::loadTranslation(QLocale locale)
     }
 
     // Load translation for Qt components e.g. "i18n/qt_en.qm"
-    if (translatorQt.load(QLocale(locale.name()), QString("qt"), QString("_"), languagePath)) {
+    if (translatorQt.load(locale, QString("qt"), QString("_"), languagePath)) {
         installTranslator(&translatorQt);
         qInfo("Loaded %s translation %s for Qt components", qUtf8Printable(locale.name()), qUtf8Printable(translatorQt.filePath()));
     } else {

--- a/src/NotepadNext/NotepadNextApplication.cpp
+++ b/src/NotepadNext/NotepadNextApplication.cpp
@@ -387,6 +387,7 @@ QString NotepadNextApplication::detectLanguageFromContents(ScintillaNext *editor
 
 void NotepadNextApplication::loadSystemDefaultTranslation()
 {
+    // The wrong translation file may be loaded when passing Locale::system() to loadTranslation function, e.g. "zh_CN" translation file will be loaded when the locale is "en_US". It's probably a Qt bug.
     loadTranslation(QLocale(QLocale::system().name()));
 }
 


### PR DESCRIPTION
# Analysis
It should be a `QLocale::system`'s bug, when the Windows region is "English(United States)", the `QLocale::system` detects the region correctly. However when passing the locale object to `QTranslator::load`, it wrongly loads the zh_CN translation file.
# Fix
Actually, it's a workaround by constructing a new `QLocale` object with a given name obtained from `QLocale::system`.
# Before the fix
## Locale - zh_CN
### Screenshots
![image](https://user-images.githubusercontent.com/20141496/236631608-0a0556bb-0573-48d6-b4bd-03987bbc76e6.png)
![image](https://user-images.githubusercontent.com/20141496/236631621-acc2a603-deca-43bc-86d8-876910b4fd4c.png)
### Logs
```
[     0.064] I: =============================
[     0.064] I: Notepad Next v0.6.1.0
[     0.064] I: Build Date/Time: May  6 2023 22:42:49
[     0.064] I: Qt: 6.5.0
[     0.064] I: OS: Windows 10 Version 22H2
[     0.064] I: Locale: zh_CN
[     0.064] I: CPU: x86_64
[     0.064] I: File Path: C:/dev/NotepadNext/build-NotepadNext-Desktop_Qt_6_5_0_MSVC2019_64bit-Debug/NotepadNext/NotepadNext.exe
[     0.064] I: Arguments: C:\dev\NotepadNext\build-NotepadNext-Desktop_Qt_6_5_0_MSVC2019_64bit-Debug\NotepadNext\NotepadNext.exe
[     0.064] I: =============================
[     0.065] I: bool __cdecl NotepadNextApplication::init(void)
[     0.082] I: void __cdecl NotepadNextApplication::loadTranslation(class QLocale)
[     0.084] I: Loaded zh_CN translation for Notepad Next
[     0.085] I: zh_CN translation not found for Qt components
```
## Locale - en_US
### Screenshots
![image](https://user-images.githubusercontent.com/20141496/236633393-6a0c57fa-3ce5-4a75-8e1e-095dbdc90bfd.png)
![image](https://user-images.githubusercontent.com/20141496/236631759-b2031f95-6a6c-4150-9829-adc341a310ef.png)
### Logs
```
[     0.057] I: =============================
[     0.057] I: Notepad Next v0.6.1.0
[     0.058] I: Build Date/Time: May  6 2023 22:42:49
[     0.058] I: Qt: 6.5.0
[     0.058] I: OS: Windows 10 Version 22H2
[     0.058] I: Locale: en_US
[     0.058] I: CPU: x86_64
[     0.058] I: File Path: C:/dev/NotepadNext/build-NotepadNext-Desktop_Qt_6_5_0_MSVC2019_64bit-Debug/NotepadNext/NotepadNext.exe
[     0.058] I: Arguments: C:\dev\NotepadNext\build-NotepadNext-Desktop_Qt_6_5_0_MSVC2019_64bit-Debug\NotepadNext\NotepadNext.exe
[     0.058] I: =============================
[     0.058] I: bool __cdecl NotepadNextApplication::init(void)
[     0.075] I: void __cdecl NotepadNextApplication::loadTranslation(class QLocale)
[     0.077] I: Loaded en_US translation for Notepad Next
[     0.077] I: en_US translation not found for Qt components
```
# After the fix
## Locale - zh_CN
### Screenshots
![image](https://user-images.githubusercontent.com/20141496/236631608-0a0556bb-0573-48d6-b4bd-03987bbc76e6.png)
![image](https://user-images.githubusercontent.com/20141496/236631621-acc2a603-deca-43bc-86d8-876910b4fd4c.png)
### Logs
```
[     0.166] I: =============================
[     0.166] I: Notepad Next v0.6.1.0
[     0.166] I: Build Date/Time: May  6 2023 22:42:49
[     0.166] I: Qt: 6.5.0
[     0.166] I: OS: Windows 10 Version 22H2
[     0.166] I: Locale: zh_CN
[     0.166] I: CPU: x86_64
[     0.166] I: File Path: C:/dev/NotepadNext/build-NotepadNext-Desktop_Qt_6_5_0_MSVC2019_64bit-Debug/NotepadNext/NotepadNext.exe
[     0.166] I: Arguments: C:\dev\NotepadNext\build-NotepadNext-Desktop_Qt_6_5_0_MSVC2019_64bit-Debug\NotepadNext\NotepadNext.exe
[     0.166] I: =============================
[     0.166] I: bool __cdecl NotepadNextApplication::init(void)
[     0.183] I: void __cdecl NotepadNextApplication::loadTranslation(class QLocale)
[     0.184] I: Loaded zh_CN translation :/i18n/NotepadNext_zh_CN.qm for Notepad Next
[     0.184] I: zh_CN translation not found for Qt components
```
## Locale - en_US
### Screenshots
![image](https://user-images.githubusercontent.com/20141496/236633393-6a0c57fa-3ce5-4a75-8e1e-095dbdc90bfd.png)![image](https://user-images.githubusercontent.com/20141496/236631569-bfb89e87-c51b-4bcf-a2f5-560258001562.png)
### Logs
```
[     0.045] I: =============================
[     0.045] I: Notepad Next v0.6.1.0
[     0.045] I: Build Date/Time: May  6 2023 22:42:49
[     0.045] I: Qt: 6.5.0
[     0.045] I: OS: Windows 10 Version 22H2
[     0.045] I: Locale: en_US
[     0.045] I: CPU: x86_64
[     0.045] I: File Path: C:/dev/NotepadNext/build-NotepadNext-Desktop_Qt_6_5_0_MSVC2019_64bit-Debug/NotepadNext/NotepadNext.exe
[     0.045] I: Arguments: C:\dev\NotepadNext\build-NotepadNext-Desktop_Qt_6_5_0_MSVC2019_64bit-Debug\NotepadNext\NotepadNext.exe
[     0.045] I: =============================
[     0.045] I: bool __cdecl NotepadNextApplication::init(void)
[     0.062] I: void __cdecl NotepadNextApplication::loadTranslation(class QLocale)
[     0.063] I: en_US translation not found for Notepad Next
[     0.063] I: en_US translation not found for Qt components
```