### PR TITLE
Fix issue 194: Mac crash of ——

### DIFF
--- a/src/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
+++ b/src/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
@@ -267,17 +267,17 @@ void ScintillaEditBase::keyPressEvent(QKeyEvent *event)
 #endif
 
 		QString text = event->text();
-        if (input && !text.isEmpty() && text[0].isPrint()) {
-            const int strLen = text.length();
+		if (input && !text.isEmpty() && text[0].isPrint()) {
+			const int strLen = text.length();
 
-            for (int i = 0; i < strLen;) {
-                const int ucWidth = text.at(i).isHighSurrogate() ? 2 : 1;
-                const QString oneCharUTF16 = text.mid(i, ucWidth);
-                const QByteArray oneChar = sqt->BytesForDocument(oneCharUTF16);
+			for (int i = 0; i < strLen;) {
+				const int ucWidth = text.at(i).isHighSurrogate() ? 2 : 1;
+				const QString oneCharUTF16 = text.mid(i, ucWidth);
+				const QByteArray oneChar = sqt->BytesForDocument(oneCharUTF16);
 
-                sqt->InsertCharacter(std::string_view(oneChar.data(), oneChar.length()), CharacterSource::DirectInput);
-                i += ucWidth;
-            }
+				sqt->InsertCharacter(std::string_view(oneChar.data(), oneChar.length()), CharacterSource::DirectInput);
+				i += ucWidth;
+			}
 		} else {
 			event->ignore();
 		}

--- a/src/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
+++ b/src/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
@@ -267,9 +267,17 @@ void ScintillaEditBase::keyPressEvent(QKeyEvent *event)
 #endif
 
 		QString text = event->text();
-		if (input && !text.isEmpty() && text[0].isPrint()) {
-			QByteArray utext = sqt->BytesForDocument(text);
-			sqt->InsertCharacter(std::string_view(utext.data(), utext.size()), CharacterSource::DirectInput);
+        if (input && !text.isEmpty() && text[0].isPrint()) {
+            const int strLen = text.length();
+
+            for (int i = 0; i < strLen;) {
+                const int ucWidth = text.at(i).isHighSurrogate() ? 2 : 1;
+                const QString oneCharUTF16 = text.mid(i, ucWidth);
+                const QByteArray oneChar = sqt->BytesForDocument(oneCharUTF16);
+
+                sqt->InsertCharacter(std::string_view(oneChar.data(), oneChar.length()), CharacterSource::DirectInput);
+                i += ucWidth;
+            }
 		} else {
 			event->ignore();
 		}


### PR DESCRIPTION
# Description
Fix a crash issue on Mac: https://github.com/dail8859/NotepadNext/issues/194
# Analysis
`Scintilla::Internal::UTF32FromUTF8` throws an exception. 
![236634384-59fa8e4e-07fa-4096-8bbc-2c90906e49fd](https://user-images.githubusercontent.com/20141496/236656095-5d5883f4-3ac5-4c9f-a1f3-b8e454d55655.jpg)

`——` contains two characters `—`, so need to call `sqt->InsertCharacter` twice to insert the two characters, just like `ScintillaEditBase::inputMethodEvent`
# Fix
Calling `sqt->InsertCharacter` twice to insert the two characters `—`.
With the fix, can enter `——` on Mac now.
<img width="448" alt="image" src="https://user-images.githubusercontent.com/20141496/236656251-76df5c7e-c753-4dd0-b831-a6404c24740f.png">