### PR TITLE
Fix issue #314 that on Mac a blank box will pop up when entering char…

### DIFF
--- a/src/NotepadNext/decorators/AutoCompletion.cpp
+++ b/src/NotepadNext/decorators/AutoCompletion.cpp
@@ -71,5 +71,7 @@ void AutoCompletion::showAutoCompletion()
         return end;
     }, { endPos, (Sci_PositionCR)editor->length()});
 
-    editor->autoCShow(current_word.length(), words.values().join(' '));
+    if (!words.isEmpty()) {
+        editor->autoCShow(current_word.length(), words.values().join(' '));
+    }
 }


### PR DESCRIPTION
…acters in the editer

# Description
Fix https://github.com/dail8859/NotepadNext/issues/314
<img width="618" alt="215931833-c8cb3c73-b7dd-497b-91fc-11831bb54392" src="https://user-images.githubusercontent.com/20141496/236660843-89dc4e81-90f1-4fb4-b8b6-54f7be2b8d81.png">

# Analysis
This is caused by auto-complete when no auto-complete words are matched.

# Fix
Don't call `editor->autoCShow` when no auto-complete words are matched.
With the fix, the blank box won't pop up anymore.
<img width="530" alt="image" src="https://user-images.githubusercontent.com/20141496/236660905-c60916f1-ca9e-41d9-b2e0-b4797dd3732f.png">

