### PR TITLE
Fix issue #374 No response when scrolling up and down

### DIFF
--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -19,7 +19,7 @@
 #include <QDesktopServices>
 #include <QTimer>
 #include <QUrl>
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include "URLFinder.h"
 
@@ -66,9 +66,8 @@ void URLFinder::findURLs()
         const int endPos = editor->lineEndPosition(currentLine);
         const QString lineText = editor->get_text_range(startPos, endPos);
 
-        static QRegExp regex(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
-        regex.indexIn(lineText);
-        QStringList matchedTexts = regex.capturedTexts();
+        static QRegularExpression regex(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
+        QStringList matchedTexts = regex.match(lineText).capturedTexts();
         matchedTexts.removeDuplicates();
         matchedTexts.removeAll(QString(""));
 

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -67,9 +67,15 @@ void URLFinder::findURLs()
         const QByteArray lineText = editor->get_text_range(startPos, endPos);
 
         static QRegularExpression regex(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
-        QStringList matchedTexts = regex.match(lineText).capturedTexts();
-        matchedTexts.removeDuplicates();
-        matchedTexts.removeAll(QString(""));
+        QStringList matchedTexts;
+        QRegularExpressionMatchIterator iterator = regex.globalMatch(lineText);
+        while (iterator.hasNext()) {
+            QRegularExpressionMatch match = iterator.next();
+            const QString matched = match.captured(0);
+            if (!matched.isEmpty() && !matchedTexts.contains(matched)) {
+                matchedTexts.append(matched);
+            }
+        }
 
         foreach (const QString &matchedText, matchedTexts) {
             int cpMin = startPos;

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -73,10 +73,13 @@ void URLFinder::findURLs()
         matchedTexts.removeAll(QString(""));
 
         foreach (const QString &matchedText, matchedTexts) {
-            Sci_TextToFind ttf {{startPos, (Sci_PositionCR)endPos}, matchedText.toLocal8Bit().constData(), {-1, -1}};
-            while (editor->send(SCI_FINDTEXT, SCFIND_MATCHCASE, (sptr_t)&ttf) != INVALID_POSITION) {
-                const int startUrl = ttf.chrgText.cpMin;
-                int endUrl = ttf.chrgText.cpMax;
+            QPair<int, int> pos = { 0, startPos };
+            do {
+                pos = editor->findText(SCFIND_MATCHCASE, matchedText.toLocal8Bit().constData(), pos.second, endPos);
+                qDebug() << currentLine << pos;
+
+                const int startUrl = pos.first;
+                int endUrl = pos.second;
 
                 if (startUrl > 0) {
                     const int prevChar = static_cast<int>(editor->charAt(startUrl - 1));
@@ -88,11 +91,10 @@ void URLFinder::findURLs()
                         (prevChar == '"' && nextChar == '"')) {
                         endUrl--;
                     }
-                }
 
-                editor->indicatorFillRange(startUrl, endUrl - startUrl);
-                ttf.chrg.cpMin = endUrl;
-            }
+                    editor->indicatorFillRange(startUrl, endUrl - startUrl);
+                }
+            } while (pos.first != -1);
         }
 
         // If a line is wrapped, skip however many lines it takes up on the screen

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -66,9 +66,9 @@ void URLFinder::findURLs()
         const int endPos = editor->lineEndPosition(currentLine);
         const QByteArray lineText = editor->get_text_range(startPos, endPos);
 
-        static QRegularExpression regex(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
+        static QRegularExpression re(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
         QStringList matchedTexts;
-        QRegularExpressionMatchIterator iterator = regex.globalMatch(lineText);
+        QRegularExpressionMatchIterator iterator = re.globalMatch(lineText);
         while (iterator.hasNext()) {
             QRegularExpressionMatch match = iterator.next();
             const QString matched = match.captured(0);

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -66,9 +66,11 @@ void URLFinder::findURLs()
         const int endPos = editor->lineEndPosition(currentLine);
         const QByteArray lineText = editor->get_text_range(startPos, endPos);
 
-        static QRegularExpression re(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
+        static QRegularExpression regex(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
         QStringList matchedTexts;
-        for (const QRegularExpressionMatch &match : re.globalMatch(lineText)) {
+        QRegularExpressionMatchIterator iterator = regex.globalMatch(lineText);
+        while (iterator.hasNext()) {
+            QRegularExpressionMatch match = iterator.next();
             const QString matched = match.captured(0);
             if (!matched.isEmpty() && !matchedTexts.contains(matched)) {
                 matchedTexts.append(matched);

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -72,16 +72,13 @@ void URLFinder::findURLs()
         matchedTexts.removeDuplicates();
         matchedTexts.removeAll(QString(""));
 
-        QPair<int, int> pos = { 0, startPos };
         foreach (const QString &matchedText, matchedTexts) {
+            int cpMin = startPos;
             while (true) {
-                pos = editor->findText(SCFIND_MATCHCASE, matchedText.toLocal8Bit().constData(), pos.second, endPos);
-                if (pos.first == INVALID_POSITION) {
+                auto [ startUrl, endUrl ] = editor->findText(SCFIND_MATCHCASE, matchedText.toLocal8Bit().constData(), cpMin, endPos);
+                if (startUrl == INVALID_POSITION) {
                     break;
                 }
-
-                const int startUrl = pos.first;
-                int endUrl = pos.second;
 
                 // Though technically certain characters are allowed in the URL such as brackets, parenthesis, etc
                 // this adds a bit of logic to trim off the end character based on if something is in front if it, for example
@@ -99,6 +96,7 @@ void URLFinder::findURLs()
                 }
 
                 editor->indicatorFillRange(startUrl, endUrl - startUrl);
+                cpMin = endUrl;
             }
         }
 

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -72,10 +72,13 @@ void URLFinder::findURLs()
         matchedTexts.removeDuplicates();
         matchedTexts.removeAll(QString(""));
 
+        QPair<int, int> pos = { 0, startPos };
         foreach (const QString &matchedText, matchedTexts) {
-            QPair<int, int> pos = { 0, startPos };
-            do {
+            while (true) {
                 pos = editor->findText(SCFIND_MATCHCASE, matchedText.toLocal8Bit().constData(), pos.second, endPos);
+                if (pos.first == INVALID_POSITION) {
+                    break;
+                }
 
                 const int startUrl = pos.first;
                 int endUrl = pos.second;
@@ -93,10 +96,10 @@ void URLFinder::findURLs()
                         (prevChar == '"' && nextChar == '"')) {
                         endUrl--;
                     }
-
-                    editor->indicatorFillRange(startUrl, endUrl - startUrl);
                 }
-            } while (pos.first != INVALID_POSITION);
+
+                editor->indicatorFillRange(startUrl, endUrl - startUrl);
+            }
         }
 
         // If a line is wrapped, skip however many lines it takes up on the screen

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -66,11 +66,9 @@ void URLFinder::findURLs()
         const int endPos = editor->lineEndPosition(currentLine);
         const QByteArray lineText = editor->get_text_range(startPos, endPos);
 
-        static QRegularExpression regex(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
+        static QRegularExpression re(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
         QStringList matchedTexts;
-        QRegularExpressionMatchIterator iterator = regex.globalMatch(lineText);
-        while (iterator.hasNext()) {
-            QRegularExpressionMatch match = iterator.next();
+        for (const QRegularExpressionMatch &match : re.globalMatch(lineText)) {
             const QString matched = match.captured(0);
             if (!matched.isEmpty() && !matchedTexts.contains(matched)) {
                 matchedTexts.append(matched);

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -75,7 +75,7 @@ void URLFinder::findURLs()
         foreach (const QString &matchedText, matchedTexts) {
             int cpMin = startPos;
             while (true) {
-                auto [ startUrl, endUrl ] = editor->findText(SCFIND_MATCHCASE, matchedText.toLocal8Bit().constData(), cpMin, endPos);
+                auto [startUrl, endUrl] = editor->findText(SCFIND_MATCHCASE, matchedText.toLocal8Bit().constData(), cpMin, endPos);
                 if (startUrl == INVALID_POSITION) {
                     break;
                 }

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -80,6 +80,9 @@ void URLFinder::findURLs()
                 const int startUrl = pos.first;
                 int endUrl = pos.second;
 
+                // Though technically certain characters are allowed in the URL such as brackets, parenthesis, etc
+                // this adds a bit of logic to trim off the end character based on if something is in front if it, for example
+                // [https://example.com] probably shouldn't include the last bracket since it starts with an opening bracket.
                 if (startUrl > 0) {
                     const int prevChar = static_cast<int>(editor->charAt(startUrl - 1));
                     const int nextChar = static_cast<int>(editor->charAt(endUrl - 1));

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -76,7 +76,6 @@ void URLFinder::findURLs()
             QPair<int, int> pos = { 0, startPos };
             do {
                 pos = editor->findText(SCFIND_MATCHCASE, matchedText.toLocal8Bit().constData(), pos.second, endPos);
-                qDebug() << currentLine << pos;
 
                 const int startUrl = pos.first;
                 int endUrl = pos.second;
@@ -94,7 +93,7 @@ void URLFinder::findURLs()
 
                     editor->indicatorFillRange(startUrl, endUrl - startUrl);
                 }
-            } while (pos.first != -1);
+            } while (pos.first != INVALID_POSITION);
         }
 
         // If a line is wrapped, skip however many lines it takes up on the screen

--- a/src/NotepadNext/decorators/URLFinder.cpp
+++ b/src/NotepadNext/decorators/URLFinder.cpp
@@ -64,7 +64,7 @@ void URLFinder::findURLs()
 
         const int startPos = editor->positionFromLine(currentLine);
         const int endPos = editor->lineEndPosition(currentLine);
-        const QString lineText = editor->get_text_range(startPos, endPos);
+        const QByteArray lineText = editor->get_text_range(startPos, endPos);
 
         static QRegularExpression regex(R"(\bhttps?://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))");
         QStringList matchedTexts = regex.match(lineText).capturedTexts();


### PR DESCRIPTION
# Description
Fix issue  #374 No response when scrolling up and down.

# Analysis
Scintilla runs the regex search too slowly, so `while (editor->send(SCI_FINDTEXT, flags, (sptr_t)&ttf) != -1)` takes a long, then blocks the main thread.

# Fix
Now decorate the link texts in a line as follows:
1. Get line text
2. Get all the link texts in the line with `QRegExp`;
3. Iterator the link texts, use `editor->findText(SCFIND_MATCHCASE, ...)` to find the link text, then pass the fond link text's position to `editor->indicatorFillRange`

Before the fix:
![reproduced_response_issue](https://github.com/dail8859/NotepadNext/assets/20141496/da5ab77a-d77e-4b3d-bbe4-c9e4cb8a7253)

After the fix: 
![fixed_response_issue](https://github.com/dail8859/NotepadNext/assets/20141496/40e85709-d45f-4bf6-b838-6bb415af19a1)
