### PR TITLE
Fix search result font size too small issue on Mac

### DIFF
--- a/src/NotepadNext/docks/SearchResultsDock.cpp
+++ b/src/NotepadNext/docks/SearchResultsDock.cpp
@@ -39,6 +39,13 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
 {
     ui->setupUi(this);
 
+    int fontSize = 10;
+#ifdef Q_OS_MACOS
+    fontSize = 14;
+#endif
+    QFont font("Courier New", fontSize);
+    ui->treeWidget->setFont(font);
+
     // Close the results when escape is pressed
     new QShortcut(QKeySequence::Cancel, this, this, &SearchResultsDock::close, Qt::WidgetWithChildrenShortcut);
 


### PR DESCRIPTION
# Problem

The search result font size is too small on Mac.
<img width="1737" alt="Snipaste_2023-05-17_20-56-14" src="https://github.com/dail8859/NotepadNext/assets/20141496/2fea4839-87eb-445c-ab53-1758ab92a9ed">

# Fix
Increasing the search result font size to 14 on Mac.
<img width="1737" alt="Snipaste_2023-05-17_20-59-18" src="https://github.com/dail8859/NotepadNext/assets/20141496/f94e0554-1a71-43df-83f3-06df8abd8f79">
