### PR TITLE
Fix hex view font family issue

### DIFF
--- a/src/NotepadNext/docks/HexViewerDock.cpp
+++ b/src/NotepadNext/docks/HexViewerDock.cpp
@@ -16,6 +16,7 @@
  * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <QFontDatabase>
 
 #include "MainWindow.h"
 #include "ScintillaNext.h"
@@ -33,8 +34,7 @@ HexViewerDock::HexViewerDock(MainWindow *parent) :
     ui->setupUi(this);
 
     // Set the font of the table to a monospaced font...not sure how best to do this
-    QFont font("Courier New");
-    font.setStyleHint(QFont::TypeWriter);
+    QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont).family();
     ui->tblHexView->setFont(font);
 
     connect(this, &QDockWidget::visibilityChanged, this, [=](bool visible) {

--- a/src/NotepadNext/docks/HexViewerDock.cpp
+++ b/src/NotepadNext/docks/HexViewerDock.cpp
@@ -33,7 +33,7 @@ HexViewerDock::HexViewerDock(MainWindow *parent) :
     ui->setupUi(this);
 
     // Set the font of the table to a monospaced font...not sure how best to do this
-    QFont font("monospace");
+    QFont font("Courier New");
     font.setStyleHint(QFont::TypeWriter);
     ui->tblHexView->setFont(font);
 


### PR DESCRIPTION
# Problem
When opening Notepad Next on Mac, can always see this warning:
```
[     0.595] W: Populating font family aliases took 147 ms. Replace uses of missing font family "Monospace" with one that exists to avoid this cost.
```

# Fix
Changing hex view font family to "Courier New"