### PR TITLE
Increase search result column width

### DIFF
--- a/src/NotepadNext/docks/SearchResultsDock.cpp
+++ b/src/NotepadNext/docks/SearchResultsDock.cpp
@@ -39,6 +39,8 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
 {
     ui->setupUi(this);
 
+    ui->treeWidget->setColumnWidth(1, 10000);
+
     // Close the results when escape is pressed
     new QShortcut(QKeySequence::Cancel, this, this, &SearchResultsDock::close, Qt::WidgetWithChildrenShortcut);
 

--- a/src/NotepadNext/docks/SearchResultsDock.ui
+++ b/src/NotepadNext/docks/SearchResultsDock.ui
@@ -57,6 +57,9 @@
       <attribute name="headerVisible">
        <bool>false</bool>
       </attribute>
+      <attribute name="headerStretchLastSection">
+       <bool>false</bool>
+      </attribute>
       <column>
        <property name="text">
         <string notr="true">1</string>


### PR DESCRIPTION
# Before
The search result column is stretched according to the app's main window width.
![Snipaste_2023-05-17_21-55-52](https://github.com/dail8859/NotepadNext/assets/20141496/831dc39a-cc2e-48eb-ac16-555c290e9d2c)

# Now
Set the column width as 10000.
![Snipaste_2023-05-17_21-56-58](https://github.com/dail8859/NotepadNext/assets/20141496/0eb6cbe6-2f1b-481f-91ef-1c03e5ebd8c7)

