### PR TITLE
Fix bug SearchResultsDock doesn't resize column to contents

### DIFF
--- a/src/NotepadNext/docks/SearchResultsDock.cpp
+++ b/src/NotepadNext/docks/SearchResultsDock.cpp
@@ -49,6 +49,7 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
     new QShortcut(QKeySequence::Cancel, this, this, &SearchResultsDock::close, Qt::WidgetWithChildrenShortcut);
 
     connect(ui->treeWidget, &QTreeWidget::itemActivated, this, &SearchResultsDock::itemActivated);
+    connect(ui->treeWidget, &QTreeWidget::itemExpanded, this, &SearchResultsDock::itemExpanded);
 
     connect(ui->treeWidget, &QTreeWidget::customContextMenuRequested, this, [=](const QPoint &pos) {
         QTreeWidgetItem *item = ui->treeWidget->itemAt(pos);
@@ -191,6 +192,11 @@ void SearchResultsDock::itemActivated(QTreeWidgetItem *item, int column)
             emit searchResultActivated(editor, lineNumber, startPositionFromBeginning, endPositionFromBeginning);
         }
     }
+}
+
+void SearchResultsDock::itemExpanded(QTreeWidgetItem *)
+{
+    ui->treeWidget->resizeColumnToContents(1);
 }
 
 void SearchResultsDock::updateSearchStatus()

--- a/src/NotepadNext/docks/SearchResultsDock.h
+++ b/src/NotepadNext/docks/SearchResultsDock.h
@@ -52,6 +52,7 @@ public slots:
 
 private slots:
     void itemActivated(QTreeWidgetItem *item, int column);
+    void itemExpanded(QTreeWidgetItem *item);
 
 signals:
     void searchResultActivated(ScintillaNext *editor, int lineNumber, int startPositionFromBeginning, int endPositionFromBeginning);


### PR DESCRIPTION
### Problem
Commit https://github.com/dail8859/NotepadNext/commit/940cc193ea730d0c54ec120ca353850726cfd1d2 optimized SearchResultsDock to make it resize the column to contents. However, it doesn't work well in this scenario that after a new short line is added in SearchResultsDock, the previous long line's column will be shortened.
![image](https://github.com/dail8859/NotepadNext/assets/20141496/9b04f6de-1f7c-4c3f-853d-63318df7f148)

### Fix
Call "ui->treeWidget->resizeColumnToContents(1)" to resize the column when the searched item is expanded.