### PR TITLE
Collapse top level items when a new search result is added

### DIFF
--- a/src/NotepadNext/docks/SearchResultsDock.cpp
+++ b/src/NotepadNext/docks/SearchResultsDock.cpp
@@ -81,7 +81,11 @@ void SearchResultsDock::newSearch(const QString searchTerm)
 
     this->searchTerm = searchTerm;
 
-    ui->treeWidget->collapseAll();
+    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i)
+    {
+        const QTreeWidgetItem* topLevelItem = ui->treeWidget->topLevelItem(i);
+        ui->treeWidget->collapseItem(topLevelItem);
+    }
 
     currentSearch = new QTreeWidgetItem(ui->treeWidget);
     currentSearch->setBackground(0, QColor(232, 232, 255));


### PR DESCRIPTION
### Problem
When a new search result is added, all the other search results will be collapsed, then always need to expand 2 times to check a previous search result.
![original](https://github.com/dail8859/NotepadNext/assets/20141496/009b03e0-0610-4ac3-a7fa-b315388c375e)

### Fix
Only collapse top levels when a new search result is added.
![optimized](https://github.com/dail8859/NotepadNext/assets/20141496/b4c5f026-ac70-47a8-b857-77787f1fbbd9)
