### PR TITLE
Optimize search results dock scroll on Mac

### DIFF
--- a/src/NotepadNext/docks/SearchResultsDock.ui
+++ b/src/NotepadNext/docks/SearchResultsDock.ui
@@ -45,6 +45,9 @@
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
       </property>
+      <property name="verticalScrollMode">
+       <enum>QAbstractItemView::ScrollPerItem</enum>
+      </property>
       <property name="indentation">
        <number>12</number>
       </property>


### PR DESCRIPTION
### Problem
In the search results dock, when hovering over the last line of the search results, the horizontal scrollbar will show and overlap with the last line, so it's hard to click the last line of the search results.
![issue](https://github.com/dail8859/NotepadNext/assets/20141496/83011acf-f67f-4800-887b-c45e3a3e2f10)

### Fix
Change the search results dock's vertical scroll mode from the default value QAbstractItemView::ScrollPerPixel to QAbstractItemView::ScrollPerItem.
![fix](https://github.com/dail8859/NotepadNext/assets/20141496/7901bd70-f563-47a6-aec2-3ad061422402)
