### PR TITLE
(I18N) Chinese Simplified Translation Update

### DIFF
--- a/i18n/NotepadNext_zh_CN.ts
+++ b/i18n/NotepadNext_zh_CN.ts
@@ -34,7 +34,7 @@
     <message>
         <location filename="../src/NotepadNext/docks/DebugLogDock.ui" line="14"/>
         <source>Debug Log</source>
-        <translation>Debug日志</translation>
+        <translation>调试日志</translation>
     </message>
 </context>
 <context>
@@ -107,7 +107,7 @@
     <message>
         <location filename="../src/QSimpleUpdater/src/Downloader.cpp" line="210"/>
         <source>Click &quot;OK&quot; to begin installing the update</source>
-        <translation>点击“确定”按钮开始安装更新</translation>
+        <translation>点击“OK”按钮开始安装更新</translation>
     </message>
     <message>
         <location filename="../src/QSimpleUpdater/src/Downloader.cpp" line="212"/>
@@ -666,7 +666,7 @@
     <message>
         <location filename="../src/NotepadNext/docks/LanguageInspectorDock.ui" line="100"/>
         <source>Property</source>
-        <translation>性质</translation>
+        <translation>属性</translation>
     </message>
     <message>
         <location filename="../src/NotepadNext/docks/LanguageInspectorDock.ui" line="105"/>
@@ -1113,7 +1113,7 @@
     <message>
         <location filename="../src/NotepadNext/dialogs/MainWindow.ui" line="501"/>
         <source>Close the current file</source>
-        <translation>关闭当前</translation>
+        <translation>关闭当前文件</translation>
     </message>
     <message>
         <location filename="../src/NotepadNext/dialogs/MainWindow.ui" line="504"/>
@@ -1469,7 +1469,8 @@
     <message>
         <location filename="../src/NotepadNext/dialogs/MainWindow.ui" line="1145"/>
         <source>Invert Bookmarks</source>
-        <translation>置顶书签</translation>
+        <translatorcomment>书签顺序上下颠倒</translatorcomment>
+        <translation>反转书签</translation>
     </message>
     <message>
         <location filename="../src/NotepadNext/dialogs/MainWindow.ui" line="715"/>


### PR DESCRIPTION

# translation changes 
- [x] Translate `Invert Bookmarks` into `反转书签` and add comment (But my recommend is to translate it as `反向标注书签`)
- [x] `Debug日志`  > `调试日志`
- [x] `关闭当前` > `关闭当前文件`
- [x] `性质` > `属性`
- [x] Change `确定` into `OK` in update dialog
## optional changes
-  `̶书签`̶ ̶ ̶>̶ ̶`̶标签`̶ ̶ ̶(̶N̶e̶e̶d̶ ̶t̶o̶ ̶o̶n̶ ̶t̶h̶e̶ ̶s̶a̶m̶e̶ ̶p̶a̶g̶e̶)̶
- T̶r̶a̶n̶s̶l̶a̶t̶e̶ ̶`̶O̶p̶e̶n̶`̶ ̶i̶n̶t̶o̶ ̶`̶打开` i̶n̶
https://github.com/dail8859/NotepadNext/blob/b0ec36c1f6d9672dce0a505c06bbcdc6bcaae4f9/i18n/NotepadNext_zh_CN.ts#L124-L125
- [x] Maybe a lot more

Signed-off-by: yangyangdaji <1504305527@qq.com>