### PR TITLE
Check filename before save on Save a Copy As...

### DIFF
--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -1205,6 +1205,10 @@ bool MainWindow::saveCopyAsDialog()
     QString selectedFilter = app->getFileDialogFilterForLanguage(editor->languageName);
     QString fileName = FileDialogHelpers::getSaveFileName(this, tr("Save a Copy As"), dialogDir, filter, &selectedFilter);
 
+    if (fileName.size() == 0) {
+        return false;
+    }
+
     return saveCopyAs(fileName);
 }
 


### PR DESCRIPTION
Closes #506

Making the same check done on `MainWindow::saveCurrentFileAsDialog`