### PR TITLE
CFBundleIdentifier

### DIFF
--- a/deploy/macos/info.plist
+++ b/deploy/macos/info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string>NotepadNext.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.yourcompany.NotepadNext</string>
+	<string>io.github.dail8859.NotepadNext</string>
 	<key>CFBundleShortVersionString</key>
 	<string>${QMAKE_FULL_VERSION}</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
Updated `CFBundleIdentifier` to follow the format used by some other OSS projects such as [OpenToonz](https://github.com/opentoonz/opentoonz): `io.github.opentoonz.OpenToonz`

Old: `~/Library/Saved Application State/com.yourcompany.NotepadNext.savedState` 

New: `~/Library/Saved Application State/io.github.dail8859.NotepadNext.savedState`