### PR TITLE
add homebrew cask file

### DIFF
--- a/Casks/notepad-next.rb
+++ b/Casks/notepad-next.rb
@@ -1,0 +1,20 @@
+cask "notepad-next" do
+  version "0.7"
+  sha256 "50db724e698ec0756fbbf4f5cd17aaed48d9b089a333a9820603729da32ff166"
+
+  url "https://github.com/dail8859/NotepadNext/releases/download/v#{version}/NotepadNext-v#{version}.dmg"
+  name "notepad-next"
+  desc "Cross-platform, reimplementation of Notepad++"
+  homepage "https://github.com/dail8859/NotepadNext"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Notepadnext.app"
+
+  # No zap stanza required
+end

--- a/Casks/notepadnext.rb
+++ b/Casks/notepadnext.rb
@@ -15,6 +15,7 @@ cask "notepadnext" do
   depends_on macos: ">= :big_sur"
 
   app "Notepadnext.app"
+  binary "#{appdir}/Notepadnext.app/Contents/MacOS/NotepadNext"
 
   # No zap stanza required
 end

--- a/Casks/notepadnext.rb
+++ b/Casks/notepadnext.rb
@@ -1,4 +1,4 @@
-cask "notepad-next" do
+cask "notepadnext" do
   version "0.7"
   sha256 "50db724e698ec0756fbbf4f5cd17aaed48d9b089a333a9820603729da32ff166"
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ Windows packages are available as an installer or a stand-alone zip file on the 
 winget install dail8859.NotepadNext
 ```
 
-or `Scoop`:
-
-```bash
-scoop bucket add extras
-scoop install extras/notepadnext
-```
-
 ## Linux
 
 Linux packages can be obtained by downloading the stand-alone AppImage on the [release](https://github.com/dail8859/NotepadNext/releases) page or by installing the [flatpak](https://flathub.org/apps/details/com.github.dail8859.NotepadNext) by executing:

--- a/README.md
+++ b/README.md
@@ -14,11 +14,22 @@ There are numerous bugs and half working implementations. Pull requests are grea
 
 Packages are available for Windows, Linux, and MacOS.
 
-Windows packages are available as an installer or a stand-alone zip file on the [release](https://github.com/dail8859/NotepadNext/releases) page. The installer provides additional components such as an auto-updater and Windows context menu integration. You can easily install it with Winget:
+## Windows
+
+Windows packages are available as an installer or a stand-alone zip file on the [release](https://github.com/dail8859/NotepadNext/releases) page. The installer provides additional components such as an auto-updater and Windows context menu integration. You can easily install it with `Winget`:
 
 ```powershell
 winget install dail8859.NotepadNext
 ```
+
+or `Scoop`:
+
+```bash
+scoop bucket add extras
+scoop install extras/notepadnext
+```
+
+## Linux
 
 Linux packages can be obtained by downloading the stand-alone AppImage on the [release](https://github.com/dail8859/NotepadNext/releases) page or by installing the [flatpak](https://flathub.org/apps/details/com.github.dail8859.NotepadNext) by executing:
 
@@ -26,7 +37,14 @@ Linux packages can be obtained by downloading the stand-alone AppImage on the [r
 flatpak install flathub com.github.dail8859.NotepadNext
 ```
 
-MacOS disk images can be downloaded from the [release](https://github.com/dail8859/NotepadNext/releases) page.
+## MacOS
+
+MacOS disk images can be downloaded from the [release](https://github.com/dail8859/NotepadNext/releases) page. You can easily install it with `Homebrew`:
+
+```bash
+brew tap dail8859/NotepadNext
+brew install --no-quarantine notepadnext
+```
 
 ## MacOS Tweaks
 


### PR DESCRIPTION
Here is the homebrew cask file for temporary use of `brew` command such as:
```
brew tap dail8859/NotepadNext
brew install --no-quarantine notepadnext
```
where the option `--no-quarantine` is used to ignore the macOS Gatekeeper.

The `.dmg` file is not yet code-signed and so the package cannot be registered `homebrew-cask`, so use your github as a custom tap and can install the package with `brew` command. Once you code-sign the package, I will add this to the `homebrew-cask` later.