### PR TITLE
Adapt the Preference dialog UI for MAC 

### DIFF
--- a/src/NotepadNext/dialogs/FindReplaceDialog.ui
+++ b/src/NotepadNext/dialogs/FindReplaceDialog.ui
@@ -355,6 +355,18 @@
        </property>
        <item>
         <layout class="QFormLayout" name="formLayout">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetNoConstraint</enum>
+         </property>
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+         </property>
+         <property name="labelAlignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="formAlignment">
+          <set>Qt::AlignJustify|Qt::AlignTop</set>
+         </property>
          <property name="horizontalSpacing">
           <number>8</number>
          </property>

--- a/src/NotepadNext/dialogs/PreferencesDialog.ui
+++ b/src/NotepadNext/dialogs/PreferencesDialog.ui
@@ -77,6 +77,12 @@
    </item>
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="labelAlignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="formAlignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
      <item row="0" column="1">
       <widget class="QComboBox" name="comboBoxTranslation"/>
      </item>


### PR DESCRIPTION
The [ Translation ] option is not in the correct location on form.

Before:
<img width="838" alt="image" src="https://github.com/dail8859/NotepadNext/assets/62826892/26dfc992-9cba-477c-9c2c-580bff9339de">

After:
<img width="838" alt="image" src="https://github.com/dail8859/NotepadNext/assets/62826892/392659b7-90dc-4f1e-97c0-8e65dd9f3a63">
