### PR TITLE
Allow overriding shortcut keys

### DIFF
--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -96,6 +96,8 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
 
     ui->setupUi(this);
 
+    applyCustomShortcuts();
+
     qInfo("setupUi Completed");
 
     connect(this, &MainWindow::aboutToClose, this, &MainWindow::saveSettings);
@@ -792,6 +794,27 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
 MainWindow::~MainWindow()
 {
     delete ui;
+}
+
+void MainWindow::applyCustomShortcuts()
+{
+    ApplicationSettings *settings = app->getSettings();
+
+    settings->beginGroup("Shortcuts");
+
+    for (const QString &actionName : settings->childKeys()) {
+        QAction *action = findChild<QAction *>(QStringLiteral("action") + actionName, Qt::FindDirectChildrenOnly);
+        const QString shortcutString = settings->value(actionName).toString();
+
+        if (action != Q_NULLPTR) {
+            action->setShortcut(QKeySequence(shortcutString));
+        }
+        else {
+            qWarning() << "Cannot find action" << actionName;
+        }
+    }
+
+    settings->endGroup();
 }
 
 void MainWindow::setupLanguageMenu()

--- a/src/NotepadNext/dialogs/MainWindow.h
+++ b/src/NotepadNext/dialogs/MainWindow.h
@@ -147,6 +147,7 @@ private:
 
     QScopedPointer<SearchResultsCollector> searchResults;
 
+    void applyCustomShortcuts();
     void initUpdateCheck();
     ScintillaNext *getInitialEditor();
     void openFileList(const QStringList &fileNames);


### PR DESCRIPTION
Closes #569. Adding a `[Shortcuts]` section in the ini file will override the default shortcuts. https://doc.qt.io/qt-6/qkeysequence.html#QKeySequence-1 is used to parse out the shortcut string. E.g.

```ini
[Shortcuts]
New=Ctrl+F1
```