### PR TITLE
Include cstdin in scintilla for GCC15 compatibility

### DIFF
--- a/src/scintilla/include/ScintillaTypes.h
+++ b/src/scintilla/include/ScintillaTypes.h
@@ -10,6 +10,7 @@
 
 #ifndef SCINTILLATYPES_H
 #define SCINTILLATYPES_H
+#include <cstdint>
 
 namespace Scintilla {
 

--- a/src/scintilla/qt/ScintillaEditBase/PlatQt.h
+++ b/src/scintilla/qt/ScintillaEditBase/PlatQt.h
@@ -10,6 +10,7 @@
 
 #ifndef PLATQT_H
 #define PLATQT_H
+#include <cstdint>
 
 #include <cstddef>
 

--- a/src/scintilla/qt/ScintillaEditBase/ScintillaEditBase.h
+++ b/src/scintilla/qt/ScintillaEditBase/ScintillaEditBase.h
@@ -11,6 +11,7 @@
 
 #ifndef SCINTILLAEDITBASE_H
 #define SCINTILLAEDITBASE_H
+#include <cstdint>
 
 #include <cstddef>
 


### PR DESCRIPTION
I had to add cstdin in 3 places to make it compile successfully with the upcoming gcc15, because cstdin is not automatically included anymore.  Reference: https://gcc.gnu.org/gcc-15/porting_to.html and https://sourceforge.net/p/scintilla/bugs/2458/

I am no expert, so I don't know what style guidelines are custom for the placement of those includes.  If necessary, I can adapt the commits. Let me know what you think, thanks

The corresponding bug report is #669 

