### PR TITLE
Fix Qt 5 compatibility and add Find All in Files button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,11 @@ CMakeLists.txt.user*
 /build
 /icon/*.png
 /icon/ImageMagick
+
+# JetBrains IDE prefs
+.idea/
+
+# macOS annoyances
+.DS_Store
+*DS_Store
+._*

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ CMakeLists.txt.user*
 *.pyc
 
 /build
+/build*
 /icon/*.png
 /icon/ImageMagick
 

--- a/src/NotepadNext/dialogs/FindReplaceDialog.ui
+++ b/src/NotepadNext/dialogs/FindReplaceDialog.ui
@@ -303,6 +303,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="buttonFindInFiles">
+         <property name="text">
+          <string>Find All In Files</string>
+         </property>
+         <property name="autoDefault">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="buttonClose">
          <property name="text">
           <string>Close</string>

--- a/src/NotepadNext/dialogs/FindReplaceDialog.ui
+++ b/src/NotepadNext/dialogs/FindReplaceDialog.ui
@@ -303,16 +303,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="buttonFindInFiles">
-         <property name="text">
-          <string>Find All In Files</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QPushButton" name="buttonClose">
          <property name="text">
           <string>Close</string>

--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -87,8 +87,6 @@
 
 #include "ActionUtils.h"
 
-#include <QtGlobal>
-#include <QDebug>
 
 MainWindow::MainWindow(NotepadNextApplication *app) :
     ui(new Ui::MainWindow),
@@ -867,26 +865,16 @@ void MainWindow::applyCustomShortcuts()
         for (const QString &shortcutString : value.toStringList()) {
             auto sequence = QKeySequence(shortcutString);
 
-            qDebug() << "QT version is" << QT_VERSION_MAJOR << "." << QT_VERSION_MINOR << "." << QT_VERSION_PATCH;
-            #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
                 if (sequence.count() > 0 && sequence[0].key() != Qt::Key_unknown) {
+#else
+                if (sequence.count() > 0 && (sequence[0] & ~Qt::KeyboardModifierMask) != Qt::Key_unknown) {
+#endif
                     shortcuts.append(sequence);
                 }
                 else {
                     qWarning() << "CustomShortcut: Cannot create QKeySequence(" << shortcutString << ") for " << actionName;
                 }
-            #elif QT_VERSION <= QT_VERSION_CHECK(6,0,0) && QT_VERSION >= QT_VERSION_CHECK(5,15,0)
-                int key = sequence[0] & ~Qt::KeyboardModifierMask;
-                if (sequence.count() > 0 && key != Qt::Key_unknown) {
-                    shortcuts.append(sequence);
-                }
-                else {
-                    qWarning() << "CustomShortcut: Cannot create QKeySequence(" << shortcutString << ") for " << actionName;
-                }
-            #else
-                qDebug() << "This version of Qt is not supported; the app will not launch.";
-                exit(1);
-            #endif
         }
 
         if (!shortcuts.empty()) {

--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -87,6 +87,8 @@
 
 #include "ActionUtils.h"
 
+#include <QtGlobal>
+#include <QDebug>
 
 MainWindow::MainWindow(NotepadNextApplication *app) :
     ui(new Ui::MainWindow),
@@ -865,12 +867,26 @@ void MainWindow::applyCustomShortcuts()
         for (const QString &shortcutString : value.toStringList()) {
             auto sequence = QKeySequence(shortcutString);
 
-            if (sequence.count() > 0 && sequence[0].key() != Qt::Key_unknown) {
-                shortcuts.append(sequence);
-            }
-            else {
-                qWarning() << "CustomShortcut: Cannot create QKeySequence(" << shortcutString << ") for " << actionName;
-            }
+            qDebug() << "QT version is" << QT_VERSION_MAJOR << "." << QT_VERSION_MINOR << "." << QT_VERSION_PATCH;
+            #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+                if (sequence.count() > 0 && sequence[0].key() != Qt::Key_unknown) {
+                    shortcuts.append(sequence);
+                }
+                else {
+                    qWarning() << "CustomShortcut: Cannot create QKeySequence(" << shortcutString << ") for " << actionName;
+                }
+            #elif QT_VERSION <= QT_VERSION_CHECK(6,0,0) && QT_VERSION >= QT_VERSION_CHECK(5,15,0)
+                int key = sequence[0] & ~Qt::KeyboardModifierMask;
+                if (sequence.count() > 0 && key != Qt::Key_unknown) {
+                    shortcuts.append(sequence);
+                }
+                else {
+                    qWarning() << "CustomShortcut: Cannot create QKeySequence(" << shortcutString << ") for " << actionName;
+                }
+            #else
+                qDebug() << "This version of Qt is not supported; the app will not launch.";
+                exit(1);
+            #endif
         }
 
         if (!shortcuts.empty()) {


### PR DESCRIPTION
This fixes issue #779 on Qt5 while retaining Qt6 compatibility. It now includes a separate block using the #if and #elif blocks to determine which block runs depending on Qt version. It also adds a Find All in Files button. Looks like most of what is needed to implement Find in Files is ready, so someone else can probably do the actual functionality, and therefore, I'll include this button in the Find and Replace dialog. The .gitignore is also updated to ignore cache files created by some popular C++ IDEs and all build folders (some people like me like to create numbered build folders to preserve older builds).