### PR TITLE
Fix spelling errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are numerous bugs and half working implementations. Pull requests are grea
 
 Packages are available for Windows, Linux, and MacOS.
 
-Below are the supported distribution mechanisms. There may be other ways to download/install the application, but this project will likely not be able to offer any support for those since they are made availble by other individuals.
+Below are the supported distribution mechanisms. There may be other ways to download/install the application, but this project will likely not be able to offer any support for those since they are made available by other individuals.
 
 ## Windows
 Windows packages are available as an installer or a stand-alone zip file on the [release](https://github.com/dail8859/NotepadNext/releases) page. The installer provides additional components such as an auto-updater and Windows context menu integration. You can easily install it with Winget:
@@ -50,7 +50,7 @@ defaults -currentHost write -g AppleFontSmoothing -int 0
 A restart is required for this to take effect.
 
 # Development
-Current development is done using QtCreator with the Microsft Visual C++ (msvc) compiler. Qt 6.5 is the currently supported Qt version. Older versions of Qt are likely to work but are not tested. Any fixes for older versions will be accepted as long as they do not introduce complex fixes. This application is also known to build successfully on various Linux distributions and macOS. Other platforms/compilers should be usable with minor modifications.
+Current development is done using QtCreator with the Microsoft Visual C++ (msvc) compiler. Qt 6.5 is the currently supported Qt version. Older versions of Qt are likely to work but are not tested. Any fixes for older versions will be accepted as long as they do not introduce complex fixes. This application is also known to build successfully on various Linux distributions and macOS. Other platforms/compilers should be usable with minor modifications.
 
 If you are familiar with building C++ Qt desktop applications with Qt Creator, then this should be as simple as opening `src/NotepadNext.pro` and build/run the project.
 


### PR DESCRIPTION
## Description
This PR fixes two spelling errors found in the README.md file:

1. **"availble" → "available"** in the installation section where it mentions distribution mechanisms
2. **"Microsft" → "Microsoft"** in the development section when referring to the Visual C++ compiler

## Changes Made
- Fixed typo in line discussing distribution support
- Corrected Microsoft company name spelling in development requirements

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- [x] Verified spelling corrections are accurate
- [x] Confirmed no other instances of these typos exist in the file

These are minor documentation improvements that enhance readability and professionalism of the project documentation.

## Additional Note
This is my first contribution to this project, but I wanted to make a small contribution by fixing this typo to help improve the project. 😊