### PR TITLE
Fix multi-instance file path passing

### DIFF
--- a/src/NotepadNext/NotepadNextApplication.cpp
+++ b/src/NotepadNext/NotepadNextApplication.cpp
@@ -341,8 +341,19 @@ void NotepadNextApplication::sendInfoToPrimaryInstance()
 
     QByteArray buffer;
     QDataStream stream(&buffer, QIODevice::WriteOnly);
+    QStringList argsToSend;
+    QStringList toFilter = parser.positionalArguments();
+    for (const QString &arg : arguments()) {
+        if (toFilter.contains(arg)) {
+            QFileInfo fileInfo(arg);
+            argsToSend.push_back(fileInfo.absoluteFilePath());
+        }
+        else {
+            argsToSend.push_back(arg);
+        }
+    }
 
-    stream << arguments();
+    stream << argsToSend;
     const bool success = sendMessage(buffer);
 
     if (!success) {


### PR DESCRIPTION
I tried opening a file through the console while I had an instance running, but the primary instance looked for it in its own working directory.

Not sure if this code is up to standard, but it works. I haven't written in C++ in about 13 years.