### PR TITLE
Change caret position to range end and anchor to range start

### DIFF
--- a/src/NotepadNext/ScintillaNext.cpp
+++ b/src/NotepadNext/ScintillaNext.cpp
@@ -135,7 +135,7 @@ void ScintillaNext::goToRange(const Sci_CharacterRange &range)
         ensureVisible(lineFromPosition(range.cpMin));
         ensureVisible(lineFromPosition(range.cpMax));
 
-        setSelection(range.cpMin, range.cpMax);
+        setSelection(range.cpMax, range.cpMin);
         scrollRange(range.cpMax, range.cpMin);
     }
 }


### PR DESCRIPTION
## Description
This PR is a part of modification approved to implement in #825 issue thread. In this PR double clicking on search result caret is placed at the end of selection.

## Changes Made
- In ScintillaNext goToRange function during selecting text the anchor and caret position are changed

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing - on Windows 11 and Debian 12 bookworm
- [x] Text return by ScintillaEdit::getSelText function stays the same
- [x] Text selected by item activation or find, replace, performLastSearch visualy stays the same