### PR TITLE
Fix Qt 6.9 compatibility: Replace qt_error_string() with enum mapping

### DIFF
--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -1883,7 +1883,29 @@ bool MainWindow::checkFileForModification(ScintillaNext *editor)
 void MainWindow::showSaveErrorMessage(ScintillaNext *editor, QFileDevice::FileError error)
 {
     const QString name = editor->isFile() ? editor->getFilePath() : editor->getName();
-    QMessageBox::warning(this, tr("Error Saving File"), tr("An error occurred when saving <b>%1</b><br><br>Error: %2").arg(name, qt_error_string(error)));
+
+    // Map error code to human-readable string
+    QString errorString;
+    switch (error) {
+        case QFileDevice::ReadError:        errorString = tr("Read error"); break;
+        case QFileDevice::WriteError:       errorString = tr("Write error"); break;
+        case QFileDevice::FatalError:       errorString = tr("Fatal error"); break;
+        case QFileDevice::ResourceError:    errorString = tr("Resource error"); break;
+        case QFileDevice::OpenError:        errorString = tr("Open error"); break;
+        case QFileDevice::AbortError:       errorString = tr("Abort error"); break;
+        case QFileDevice::TimeOutError:     errorString = tr("Timeout error"); break;
+        case QFileDevice::UnspecifiedError: errorString = tr("Unspecified error"); break;
+        case QFileDevice::RemoveError:      errorString = tr("Remove error"); break;
+        case QFileDevice::RenameError:      errorString = tr("Rename error"); break;
+        case QFileDevice::PositionError:    errorString = tr("Position error"); break;
+        case QFileDevice::ResizeError:      errorString = tr("Resize error"); break;
+        case QFileDevice::PermissionsError: errorString = tr("Permissions error"); break;
+        case QFileDevice::CopyError:        errorString = tr("Copy error"); break;
+        default:                            errorString = tr("Unknown error (%1)").arg(static_cast<int>(error)); break;
+    }
+
+    QMessageBox::warning(this, tr("Error Saving File"),
+        tr("An error occurred when saving <b>%1</b><br><br>Error: %2").arg(name, errorString));
 }
 
 void MainWindow::showEditorZoomLevelIndicator()


### PR DESCRIPTION
## Summary

Fixes compatibility with Qt 6.9+ by replacing the internal function `qt_error_string()` with an idiomatic switch statement for error message mapping.

## Problem

The internal Qt function `qt_error_string()` was moved from `qglobal.h` to `qlogging.h` in August 2022 (Qt 6.4+), causing build failures when compiling NotepadNext against newer Qt versions:

```
error: use of undeclared identifier 'qt_error_string'
```

## Solution Considered

Two approaches were evaluated:

1. **Add `#include <qlogging.h>`** (minimal fix)
   - Simple one-line change
   - Continues using `qt_error_string()`
   
2. **Replace with switch statement** (implemented)
   - Doesn't depend on Qt internal APIs that have moved before
   - Provides better localization control
   - More maintainable and self-documenting

The switch statement approach was chosen because `qt_error_string()` is not part of Qt's documented public API, has an unstable location history, and this solution provides better long-term maintainability.

## Implementation

Replaced `qt_error_string()` with a switch statement that maps `QFileDevice::FileError` enum values to human-readable, localizable strings.

### Benefits:
- Uses `tr()` for proper localization support
- Provides clear error messages (e.g., "Permissions error" instead of error codes)
- Standard C++ approach when Qt enums aren't Q_ENUM-registered
- All FileError cases covered with default fallback
- No dependency on internal Qt APIs

## Testing

- Tested with Qt 6.9.3 on macOS arm64 (Apple Silicon)
- Build completes successfully
- Application runs without issues

## Changed Files

- `src/NotepadNext/dialogs/MainWindow.cpp`: Updated `showSaveErrorMessage()` function

---

**Note on macOS arm64 builds**: When building on Apple Silicon with Homebrew Qt, qmake may attempt to create a universal binary but Qt libraries are arm64-only. Use `ARCHS=arm64 make` instead of just `make` to force an arm64-only build and avoid linker errors.