### PR TITLE
fix: Support building in QT5, QByteArrayView compat

### DIFF
--- a/src/NotepadNext/ByteArrayUtils.h
+++ b/src/NotepadNext/ByteArrayUtils.h
@@ -18,9 +18,36 @@
 #pragma once
 
 #include <QByteArray>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QByteArrayView>
+#else
+#include <QtGlobal>
+#include <cstring>
+
+// WARNING: Dirty QT5 compat. Tested on Debian 13.
+class QByteArrayView
+{
+public:
+    QByteArrayView() : m_data(nullptr), m_size(0) {}
+    QByteArrayView(const char* data, qsizetype size) : m_data(data), m_size(size) {}
+    QByteArrayView(const QByteArray& ba) : m_data(ba.constData()), m_size(ba.size()) {}
+    const char* data() const { return m_data; }
+    qsizetype size() const { return m_size; }
+    bool isEmpty() const { return m_size == 0; }
+    bool operator==(const QByteArrayView& other) const
+    {
+        return m_size == other.m_size && (m_data == other.m_data || (m_size > 0 && std::memcmp(m_data, other.m_data, m_size) == 0));
+    }
+    bool operator!=(const QByteArrayView& other) const { return !(*this == other); }
+
+private:
+    const char* m_data;
+    qsizetype m_size;
+};
+#endif
 #include <QList>
 #include <QSet>
+#include <algorithm>
 #include <cstring>
 #include <unordered_set>
 


### PR DESCRIPTION
As of https://github.com/dail8859/NotepadNext/commit/637480688c7d879fb0e92d571717416089c315ab, the build will fail with `QByteArrayView: No such file or directory`:

```
In file included from ../../src/NotepadNext/ScintillaNext.cpp:24:
../../src/NotepadNext/ByteArrayUtils.h:21:10: fatal error: QByteArrayView: No such file or directory
   21 | #include <QByteArrayView>
      |          ^~~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:7065: build/obj/ScintillaNext.o] Error 1
make[1]: *** Waiting for unfinished jobs....
In file included from ../../src/NotepadNext/NotepadNextApplication.h:23,
                 from ../../src/NotepadNext/SessionManager.cpp:25:
../../src/NotepadNext/ApplicationSettings.h:47:12: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   47 |     inline const char * const key() const { return mKey; }
      |            ^~~~~
```

This makes it buildable on Debian 13 using the set of packages supplied in `Building.md`. 
`QByteArrayView` referenced in `ByteArrayUtils.h` was introduced in QT6.