### PR TITLE
removed --no-quarantine message

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ MacOS disk images can be downloaded from the [release](https://github.com/dail88
 It can also be installed using brew:
 ```bash
 brew tap dail8859/notepadnext
-brew install --no-quarantine notepadnext
+brew install notepadnext
 ```
 
 #### MacOS Tweaks


### PR DESCRIPTION
This error is coming while installing on MacOS 26.1 using Brew Error: Calling the `--[no-]quarantine` switch is disabled! There is no replacement.