### PR TITLE
Update portuguese translations

### DIFF
--- a/i18n/NotepadNext_pt.ts
+++ b/i18n/NotepadNext_pt.ts
@@ -1,2295 +1,2327 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="pt_BR" sourcelanguage="en">
-  <context>
+<TS version="2.1" language="pt" sourcelanguage="en_US">
+<context>
     <name>ColumnEditorDialog</name>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="20"/>
-      <source>Column Mode</source>
-      <translation>Modo de coluna</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="20"/>
+        <source>Column Mode</source>
+        <translation>Modo de coluna</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="32"/>
-      <source>Text</source>
-      <translation>Texto</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="32"/>
+        <source>Text</source>
+        <translation>Texto</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="47"/>
-      <source>Numbers</source>
-      <translation>Números</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="47"/>
+        <source>Numbers</source>
+        <translation>Números</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="59"/>
-      <source>Start:</source>
-      <translation>Iniciar:</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="59"/>
+        <source>Start:</source>
+        <translation>Iniciar:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="76"/>
-      <source>Step:</source>
-      <translation>Etapa:</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="76"/>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DebugLogDock</name>
     <message>
-      <location filename="../src/docks/DebugLogDock.ui" line="14"/>
-      <source>Debug Log</source>
-      <translation>Registro de depuração</translation>
+        <location filename="../src/docks/DebugLogDock.ui" line="14"/>
+        <source>Debug Log</source>
+        <translation>Registo de depuração</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>EditorInfoStatusBar</name>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="100"/>
-      <source>Length: %L1    Lines: %L2</source>
-      <translation>Comprimento: %L1  e  Quantidade de Linhas: %L2</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="100"/>
+        <source>Length: %L1    Lines: %L2</source>
+        <translation>Comprimento: %L1    Linhas: %L2</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="109"/>
-      <source>Sel: N/A</source>
-      <translation>Sel: N/D</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="109"/>
+        <source>Sel: N/A</source>
+        <translation>Sel: N/D</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="119"/>
-      <source>Sel: %L1 | %L2</source>
-      <translation>Sel: %L1 | %L2</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="119"/>
+        <source>Sel: %L1 | %L2</source>
+        <translation>Sel: %L1 | %L2</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="123"/>
-      <source>Ln: %L1    Col: %L2    </source>
-      <translation>Linha: %L1  e  Coluna: %L2    </translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="123"/>
+        <source>Ln: %L1    Col: %L2    </source>
+        <translation>Ln: %L1    Col: %L2    </translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="139"/>
-      <source>Macintosh (CR)</source>
-      <translation>Macintosh (CR)</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="139"/>
+        <source>Macintosh (CR)</source>
+        <translation>Macintosh (CR)</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="142"/>
-      <source>Windows (CR LF)</source>
-      <translation>Windows (CR LF)</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="142"/>
+        <source>Windows (CR LF)</source>
+        <translation>Windows (CR LF)</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="145"/>
-      <source>Unix (LF)</source>
-      <translation>Unix (LF)</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="145"/>
+        <source>Unix (LF)</source>
+        <translation>Unix (LF)</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="155"/>
-      <source>ANSI</source>
-      <translation>ANSI</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="155"/>
+        <source>ANSI</source>
+        <translation>ANSI</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="159"/>
-      <source>UTF-8</source>
-      <translation>UTF-8</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="159"/>
+        <source>UTF-8</source>
+        <translation>UTF-8</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="160"/>
-      <source>UTF-8 BOM</source>
-      <translation type="unfinished">UTF-8 BOM</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="160"/>
+        <source>UTF-8 BOM</source>
+        <translation>UTF-8 BOM</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="161"/>
-      <source>UTF-16LE BOM</source>
-      <translation type="unfinished">UTF-16LE BOM</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="161"/>
+        <source>UTF-16LE BOM</source>
+        <translation>UTF-16LE BOM</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="162"/>
-      <source>UTF-16BE BOM</source>
-      <translation type="unfinished">UTF-16BE BOM</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="162"/>
+        <source>UTF-16BE BOM</source>
+        <translation>UTF-16BE BOM</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="178"/>
-      <source>OVR</source>
-      <extracomment>This is a short abbreviation to indicate characters will be replaced when typing</extracomment>
-      <translation>Esta é uma abreviação para indicar que os caracteres serão substituídos ao digitar</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="178"/>
+        <source>OVR</source>
+        <extracomment>This is a short abbreviation to indicate characters will be replaced when typing</extracomment>
+        <translation>SUB</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="182"/>
-      <source>INS</source>
-      <extracomment>This is a short abbreviation to indicate characters will be inserted when typing</extracomment>
-      <translation>Esta é uma abreviação para indicar que os caracteres serão inseridos ao digitar</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="182"/>
+        <source>INS</source>
+        <extracomment>This is a short abbreviation to indicate characters will be inserted when typing</extracomment>
+        <translation>INS</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>EditorInspectorDock</name>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.ui" line="14"/>
-      <source>Editor Inspector</source>
-      <translation>Inpetor do editor</translation>
+        <location filename="../src/docks/EditorInspectorDock.ui" line="14"/>
+        <source>Editor Inspector</source>
+        <translation>Inpetor de editor</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="36"/>
-      <source>Position Information</source>
-      <translation>Informações da posição</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="36"/>
+        <source>Position Information</source>
+        <translation>Informação da posição</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="39"/>
-      <source>Current Position</source>
-      <translation>Posição atual</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="39"/>
+        <source>Current Position</source>
+        <translation>Posição atual</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="40"/>
-      <source>Current Position (x, y)</source>
-      <translation>Posição atual (x, y)</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="40"/>
+        <source>Current Position (x, y)</source>
+        <translation>Posição atual (x, y)</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="41"/>
-      <source>Column</source>
-      <translation>Coluna</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="41"/>
+        <source>Column</source>
+        <translation>Coluna</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="43"/>
-      <source>Current Style</source>
-      <translation>Estilo atual</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="43"/>
+        <source>Current Style</source>
+        <translation>Estilo atual</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="44"/>
-      <source>Current Line</source>
-      <translation>Linha atual</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="44"/>
+        <source>Current Line</source>
+        <translation>Linha atual</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="45"/>
-      <source>Line Length</source>
-      <translation>Comprimento da linha</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="45"/>
+        <source>Line Length</source>
+        <translation>Comprimento da linha</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="46"/>
-      <source>Line End Position</source>
-      <translation>Posição final da linha</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="46"/>
+        <source>Line End Position</source>
+        <translation>Posição final da linha</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="47"/>
-      <source>Line Indentation</source>
-      <translation>Indentação da linha</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="47"/>
+        <source>Line Indentation</source>
+        <translation>Indentação de linha</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="48"/>
-      <source>Line Indent Position</source>
-      <translation>Posição da indentação da linha</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="48"/>
+        <source>Line Indent Position</source>
+        <translation>Posição de indentação de linha</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="52"/>
-      <source>Selection Information</source>
-      <translation>Informações da seleção</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="52"/>
+        <source>Selection Information</source>
+        <translation>Informação de seleção</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="55"/>
-      <source>Mode</source>
-      <translation>Modo</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="55"/>
+        <source>Mode</source>
+        <translation>Modo</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="69"/>
-      <source>Is Rectangle</source>
-      <translation>É um retângulo</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="69"/>
+        <source>Is Rectangle</source>
+        <translation>É retângulo</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="70"/>
-      <source>Selection Empty</source>
-      <translation>A seleção está vazia</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="70"/>
+        <source>Selection Empty</source>
+        <translation>Seleção vazia</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="71"/>
-      <source>Main Selection</source>
-      <translation>A seleção principal de</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="71"/>
+        <source>Main Selection</source>
+        <translation>Seleção principal</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="72"/>
-      <source># of Selections</source>
-      <translation># seleções</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="72"/>
+        <source># of Selections</source>
+        <translation># de seleções</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="75"/>
-      <source>Multiple Selections</source>
-      <translation>Seleção de várias</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="75"/>
+        <source>Multiple Selections</source>
+        <translation>Seleções múltiplas</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="80"/>
-      <source>Document Information</source>
-      <translation>Informações do arquivo</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="80"/>
+        <source>Document Information</source>
+        <translation>Informação sobre o documento</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="83"/>
-      <source>Length</source>
-      <translation>Comprimento</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="83"/>
+        <source>Length</source>
+        <translation>Comprimento</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="84"/>
-      <source>Line Count</source>
-      <translation>Contagem de linhas</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="84"/>
+        <source>Line Count</source>
+        <translation>Contagem de linhas</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="88"/>
-      <source>View Information</source>
-      <translation>Visualizar as informações</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="88"/>
+        <source>View Information</source>
+        <translation>Ver informação</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="91"/>
-      <source>Lines on Screen</source>
-      <translation>Linhas na tela</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="91"/>
+        <source>Lines on Screen</source>
+        <translation>Linhas no ecrã</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="92"/>
-      <source>First Visible Line</source>
-      <translation>Visibilidade da primeira linha</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="92"/>
+        <source>First Visible Line</source>
+        <translation>Primeira linha visível</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="93"/>
-      <source>X Offset</source>
-      <translation>Desvio do X</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="93"/>
+        <source>X Offset</source>
+        <translation>Desvio X</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="97"/>
-      <source>Fold Information</source>
-      <translation>Informações sobre a dobra</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="97"/>
+        <source>Fold Information</source>
+        <translation>Informações sobre a dobra</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="100"/>
-      <source>Visible From Doc Line</source>
-      <translation>Visível a partir da linha do documento</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="100"/>
+        <source>Visible From Doc Line</source>
+        <translation>Visível a partir da linha Doc</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="101"/>
-      <source>Doc Line From Visible</source>
-      <translation>A linha do documento a partir da visível</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="101"/>
+        <source>Doc Line From Visible</source>
+        <translation>Linha Doc a partir de Visível</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="102"/>
-      <source>Fold Level</source>
-      <translation>Nível da dobra</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="102"/>
+        <source>Fold Level</source>
+        <translation>Nível de dobra</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="103"/>
-      <source>Is Fold Header</source>
-      <translation>É um cabeçalho da dobra</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="103"/>
+        <source>Is Fold Header</source>
+        <translation>É cabeçalho de dobra</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="104"/>
-      <source>Fold Parent</source>
-      <translation>Dobrar acima</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="104"/>
+        <source>Fold Parent</source>
+        <translation>Dobrar acima</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="105"/>
-      <source>Last Child</source>
-      <translation>Último abaixo</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="105"/>
+        <source>Last Child</source>
+        <translation>Último abaixo</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="106"/>
-      <source>Contracted Fold Next</source>
-      <translation>Dobrar a contratada seguinte</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="106"/>
+        <source>Contracted Fold Next</source>
+        <translation>Dobra contratada Seguinte</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="173"/>
-      <source>Caret</source>
-      <translation>Caractere</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="173"/>
+        <source>Caret</source>
+        <translation>Carácter</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="177"/>
-      <source>Anchor</source>
-      <translation>Ancoragem</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="177"/>
+        <source>Anchor</source>
+        <translation>Ancoragem</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="181"/>
-      <source>Caret Virtual Space</source>
-      <translation>Espaço virtual do caractere</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="181"/>
+        <source>Caret Virtual Space</source>
+        <translation>Espaço virtual do carácter</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="185"/>
-      <source>Anchor Virtual Space</source>
-      <translation>Espaço virtual da ancoragem</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="185"/>
+        <source>Anchor Virtual Space</source>
+        <translation>Espaço virtual da ancoragem</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>FileList</name>
     <message>
-      <location filename="../src/docks/FileListDock.ui" line="14"/>
-      <source>File List</source>
-      <translation>Lista de arquivos</translation>
+        <location filename="../src/docks/FileListDock.ui" line="14"/>
+        <source>File List</source>
+        <translation>Lista de ficheiros</translation>
     </message>
     <message>
-      <location filename="../src/docks/FileListDock.ui" line="51"/>
-      <source>...</source>
-      <translation>...</translation>
+        <location filename="../src/docks/FileListDock.ui" line="51"/>
+        <source>...</source>
+        <translation>...</translation>
     </message>
     <message>
-      <location filename="../src/docks/FileListDock.ui" line="90"/>
-      <source>Sort by File Name</source>
-      <translation>Ordenar pelo nome do arquivo</translation>
+        <location filename="../src/docks/FileListDock.ui" line="90"/>
+        <source>Sort by File Name</source>
+        <translation>Ordenar por nome de ficheiro</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>FindReplaceDialog</name>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="20"/>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="247"/>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="59"/>
-      <source>Find</source>
-      <translation>Localizar</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="20"/>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="247"/>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="59"/>
+        <source>Find</source>
+        <translation>Localizar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="69"/>
-      <source>Search Mode</source>
-      <translation>Modo de pesquisa</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="69"/>
+        <source>Search Mode</source>
+        <translation>Modo de pesquisa</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="90"/>
-      <source>&amp;Normal</source>
-      <translation>&amp;Normal</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="90"/>
+        <source>&amp;Normal</source>
+        <translation>&amp;Normal</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="106"/>
-      <source>E&amp;xtended (\n, \r, \t, \0, \x...)</source>
-      <translation>E&amp;stendida (\n, \r, \t, \0, \x...)</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="106"/>
+        <source>E&amp;xtended (\n, \r, \t, \0, \x...)</source>
+        <translation>A&amp;largada (\n, \r, \t, \0, \x...)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="124"/>
-      <source>Re&amp;gular expression</source>
-      <translation>Expressão re&amp;gular</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="124"/>
+        <source>Re&amp;gular expression</source>
+        <translation>Expressão re&amp;gular</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="140"/>
-      <source>&amp;. matches newline</source>
-      <translation>&amp;. corresponde a uma nova linha</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="140"/>
+        <source>&amp;. matches newline</source>
+        <translation>&amp;. corresponde a uma nova linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="179"/>
-      <source>Transparenc&amp;y</source>
-      <translation>Transparênc&amp;ia</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="179"/>
+        <source>Transparenc&amp;y</source>
+        <translation>Transparênc&amp;ia</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="200"/>
-      <source>On losing focus</source>
-      <translation>Ao perder o foco</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="200"/>
+        <source>On losing focus</source>
+        <translation>Sobre perder o foco</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="210"/>
-      <source>Always</source>
-      <translation>Sempre</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="210"/>
+        <source>Always</source>
+        <translation>Sempre</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="260"/>
-      <source>Coun&amp;t</source>
-      <translation>Con&amp;tar</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="260"/>
+        <source>Coun&amp;t</source>
+        <translation>Con&amp;tar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="270"/>
-      <source>&amp;Replace</source>
-      <translation>&amp;Substituir</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="270"/>
+        <source>&amp;Replace</source>
+        <translation>&amp;Substituir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="277"/>
-      <source>Replace &amp;All</source>
-      <translation>Substituir &amp;tudo</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="277"/>
+        <source>Replace &amp;All</source>
+        <translation>Substituir &amp;tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="284"/>
-      <source>Replace All in &amp;Opened Documents</source>
-      <translation>Substituir tudo nos arquivos &amp;abertos</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="284"/>
+        <source>Replace All in &amp;Opened Documents</source>
+        <translation>Substituir tudo em documentos &amp;abertos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="291"/>
-      <source>Find All in All &amp;Opened Documents</source>
-      <translation>Localizar tudo em todos os arquivos &amp;abertos</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="291"/>
+        <source>Find All in All &amp;Opened Documents</source>
+        <translation>Localizar tudo em todos os documentos &amp;abertos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="301"/>
-      <source>Find All in Current Document</source>
-      <translation>Localizar tudo no arquivo atual</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="301"/>
+        <source>Find All in Current Document</source>
+        <translation>Localizar tudo no documento atual</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="311"/>
-      <source>Close</source>
-      <translation>Fechar</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="311"/>
+        <source>Close</source>
+        <translation>Fechar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="367"/>
-      <source>&amp;Find:</source>
-      <translation>&amp;Localizar:</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="367"/>
+        <source>&amp;Find:</source>
+        <translation>&amp;Localizar:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="399"/>
-      <source>Replace:</source>
-      <translation>Substituir:</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="399"/>
+        <source>Replace:</source>
+        <translation>Substituir:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="445"/>
-      <source>Backward direction</source>
-      <translation>No sentido inverso</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="445"/>
+        <source>Backward direction</source>
+        <translation>Sentido inverso</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="452"/>
-      <source>Match &amp;whole word only</source>
-      <translation>Corresponder apenas à palavra &amp;inteira</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="452"/>
+        <source>Match &amp;whole word only</source>
+        <translation>Corresponder apenas à palavra &amp;inteira</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="459"/>
-      <source>Match &amp;case</source>
-      <translation>Corresponder as letras &amp;minúsculas/maiúsculas</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="459"/>
+        <source>Match &amp;case</source>
+        <translation>Corresponder &amp;minúsculas/maiúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="466"/>
-      <source>Wra&amp;p Around</source>
-      <translation>Pesquisar e circular</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="466"/>
+        <source>Wra&amp;p Around</source>
+        <translation>En&amp;volvente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="60"/>
-      <source>Replace</source>
-      <translation>Substituir</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="60"/>
+        <source>Replace</source>
+        <translation>Substituir</translation>
     </message>
     <message numerus="yes">
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="144"/>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="341"/>
-      <source>Replaced %Ln matches</source>
-      <translation>
-        <numerusform>Foi substituída %Ln correspondência</numerusform>
-        <numerusform>Foram substituídas %Ln correspondências</numerusform>
-      </translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="144"/>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="341"/>
+        <source>Replaced %Ln matches</source>
+        <translation>
+            <numerusform>Substituído %Ln  correspondência</numerusform>
+            <numerusform>Substituído %Ln  correspondências</numerusform>
+        </translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="239"/>
-      <source>The end of the document has been reached. Found 1st occurrence from the top.</source>
-      <translation>O fim do arquivo foi alcançado. Foi localizada a 1ª ocorrência de cima para baixo.</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="239"/>
+        <source>The end of the document has been reached. Found 1st occurrence from the top.</source>
+        <translation>O fim do documento foi atingido. Localizada a 1ª ocorrência a partir do topo.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="250"/>
-      <source>No matches found.</source>
-      <translation>Nenhuma correspondência foi encontrada</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="250"/>
+        <source>No matches found.</source>
+        <translation>Não foram localizadas correspondências.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="313"/>
-      <source>1 occurrence was replaced</source>
-      <translation>Uma ocorrência foi substituída</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="313"/>
+        <source>1 occurrence was replaced</source>
+        <translation>1 ocorrência foi substituída</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="322"/>
-      <source>No more occurrences were found</source>
-      <translation>Não foram localizadas outras ocorrências</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="322"/>
+        <source>No more occurrences were found</source>
+        <translation>Não foram encontradas mais ocorrências</translation>
     </message>
     <message numerus="yes">
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="352"/>
-      <source>Found %Ln matches</source>
-      <translation>
-        <numerusform>Foi localizada %Ln correspondência</numerusform>
-        <numerusform>Foram localizadas %Ln correspondências</numerusform>
-      </translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="352"/>
+        <source>Found %Ln matches</source>
+        <translation>
+            <numerusform>Localizado %Ln correspondência</numerusform>
+            <numerusform>Localizado %Ln correspondências</numerusform>
+        </translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>FolderAsWorkspaceDock</name>
     <message>
-      <location filename="../src/docks/FolderAsWorkspaceDock.ui" line="14"/>
-      <source>Folder as Workspace</source>
-      <translation>Pasta como área de trabalho</translation>
+        <location filename="../src/docks/FolderAsWorkspaceDock.ui" line="14"/>
+        <source>Folder as Workspace</source>
+        <translation>Pasta como área de trabalho</translation>
     </message>
-  </context>
-  <context>
-    <name>HexViewerDock</name>
-    <message>
-      <location filename="../src/docks/HexViewerDock.ui" line="14"/>
-      <source>Hex Viewer</source>
-      <translation>Visualizador de hexadecimal</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>LanguageInspectorDock</name>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="14"/>
-      <source>Language Inspector</source>
-      <translation>Inspetor da linguagem</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="14"/>
+        <source>Language Inspector</source>
+        <translation>Inspetor de linguagem</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="56"/>
-      <source>Language:</source>
-      <translation>Linguagem:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="56"/>
+        <source>Language:</source>
+        <translation>Linguagem:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="70"/>
-      <source>Lexer:</source>
-      <translation>Lexer:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="70"/>
+        <source>Lexer:</source>
+        <translation>Lexer:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="86"/>
-      <source>Properties:</source>
-      <translation>Propriedades:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="86"/>
+        <source>Properties:</source>
+        <translation>Propriedades:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="100"/>
-      <source>Property</source>
-      <translation>Propriedade</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="100"/>
+        <source>Property</source>
+        <translation>Propriedade</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="105"/>
-      <source>Type</source>
-      <translation>Tipo</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="105"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="110"/>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="151"/>
-      <source>Description</source>
-      <translation>Descrição</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="110"/>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="151"/>
+        <source>Description</source>
+        <translation>Descrição</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="115"/>
-      <source>Value</source>
-      <translation>Valor</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="115"/>
+        <source>Value</source>
+        <translation>Valor</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="123"/>
-      <source>Keywords:</source>
-      <translation>Palavras-chave:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="123"/>
+        <source>Keywords:</source>
+        <translation>Palavras-chave:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="146"/>
-      <source>ID</source>
-      <translation>Identidade</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="146"/>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="159"/>
-      <source>Styles:</source>
-      <translation>Estilos:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="159"/>
+        <source>Styles:</source>
+        <translation>Estilos:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="166"/>
-      <source>TextLabel</source>
-      <translation>Legenda do texto</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="166"/>
+        <source>TextLabel</source>
+        <translation>Legenda do texto</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.cpp" line="146"/>
-      <source>Position %1 Style %2</source>
-      <translation>Posição %1 e Estilo %2</translation>
+        <location filename="../src/docks/LanguageInspectorDock.cpp" line="146"/>
+        <source>Position %1 Style %2</source>
+        <translation>Posição %1 Estilo %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>LuaConsoleDock</name>
     <message>
-      <location filename="../src/docks/LuaConsoleDock.ui" line="17"/>
-      <source>Lua Console</source>
-      <translation>Console da lua</translation>
+        <location filename="../src/docks/LuaConsoleDock.ui" line="17"/>
+        <source>Lua Console</source>
+        <translation>Consola Lua</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MacroEditorDialog</name>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="14"/>
-      <source>Macro Editor</source>
-      <translation>Editor de macros</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="14"/>
+        <source>Macro Editor</source>
+        <translation>Editor de macros</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="48"/>
-      <source>Name</source>
-      <translation>Nome</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="48"/>
+        <source>Name</source>
+        <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="58"/>
-      <source>Shortcut</source>
-      <translation>Atalho</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="58"/>
+        <source>Shortcut</source>
+        <translation>Atalho</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="67"/>
-      <source>Steps:</source>
-      <translation>Etapas:</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="67"/>
+        <source>Steps:</source>
+        <translation>Etapas:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="95"/>
-      <source>Insert Macro Step</source>
-      <translation>Inserir uma etapa no macro</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="95"/>
+        <source>Insert Macro Step</source>
+        <translation>Inserir etapa da macro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="110"/>
-      <source>Delete Selected Macro Step</source>
-      <translation>Apagar a etapa que foi selecionada no macro</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="110"/>
+        <source>Delete Selected Macro Step</source>
+        <translation>Eliminar a etapa da macro selecionada</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="125"/>
-      <source>Move Selected Macro Step Up</source>
-      <translation>Mover para cima a etapa que foi selecionada no macro</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="125"/>
+        <source>Move Selected Macro Step Up</source>
+        <translation>Mover a etapa da macro selecionada para cima</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="140"/>
-      <source>Move Selected Macro Step Down</source>
-      <translation>Mover para baixo a etapa que foi selecionada no macro</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="140"/>
+        <source>Move Selected Macro Step Down</source>
+        <translation>Mover a etapa da macro selecionada para baixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="176"/>
-      <source>Copy Selected Macro</source>
-      <translation>Copiar o macro que foi selecionado</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="176"/>
+        <source>Copy Selected Macro</source>
+        <translation>Copiar a macro selecionada</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="191"/>
-      <source>Delete Selected Macro</source>
-      <translation>Apagar o macro que foi selecionado</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="191"/>
+        <source>Delete Selected Macro</source>
+        <translation>Eliminar a macro selecionada</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
-      <source>Delete Macro</source>
-      <translation>Apagar o macro</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
+        <source>Delete Macro</source>
+        <translation>Eliminar macro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
-      <source>Are you sure you want to delete &lt;b&gt;%1&lt;/b&gt;?</source>
-      <translation>Você tem certeza de que quer apagar o &lt;b&gt;%1&lt;/b&gt;?</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
+        <source>Are you sure you want to delete &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Tem a certeza de que pretende eliminar &lt;b&gt;%1&lt;/b&gt;?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.cpp" line="150"/>
-      <source>(Copy)</source>
-      <translation>(Copiar)</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.cpp" line="150"/>
+        <source>(Copy)</source>
+        <translation>(Copiar)</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MacroRunDialog</name>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="14"/>
-      <source>Run a Macro Multiple Times</source>
-      <translation>Executar um macro várias vezes</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="14"/>
+        <source>Run a Macro Multiple Times</source>
+        <translation>Executar uma macro várias vezes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="31"/>
-      <source>Macro:</source>
-      <translation>Macro:</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="31"/>
+        <source>Macro:</source>
+        <translation>Macro:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="56"/>
-      <source>Run Until End of File</source>
-      <translation>Executar até ao fim do arquivo</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="56"/>
+        <source>Run Until End of File</source>
+        <translation>Executar até ao fim do ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="63"/>
-      <source>Execute...</source>
-      <translation>Executar...</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="63"/>
+        <source>Execute...</source>
+        <translation>Executar...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="116"/>
-      <source>times</source>
-      <translation>vezes</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="116"/>
+        <source>times</source>
+        <translation>vezes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="166"/>
-      <source>Run</source>
-      <translation>Executar</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="166"/>
+        <source>Run</source>
+        <translation>Executar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="173"/>
-      <source>Cancel</source>
-      <translation>Cancelar</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="173"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MacroSaveDialog</name>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="14"/>
-      <source>Save Macro</source>
-      <translation>Salvar o macro</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="14"/>
+        <source>Save Macro</source>
+        <translation>Guardar macro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="25"/>
-      <source>Name:</source>
-      <translation>Nome:</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="25"/>
+        <source>Name:</source>
+        <translation>Nome:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="39"/>
-      <source>Shortcut:</source>
-      <translation>Atalho:</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="39"/>
+        <source>Shortcut:</source>
+        <translation>Atalho:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="82"/>
-      <source>OK</source>
-      <translation>OK</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="82"/>
+        <source>OK</source>
+        <translation>OK</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="89"/>
-      <source>Cancel</source>
-      <translation>Cancelar</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="89"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MacroStepTableModel</name>
     <message>
-      <location filename="../src/MacroStepTableModel.cpp" line="34"/>
-      <source>Name</source>
-      <translation>Nome</translation>
+        <location filename="../src/MacroStepTableModel.cpp" line="34"/>
+        <source>Name</source>
+        <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../src/MacroStepTableModel.cpp" line="36"/>
-      <source>Text</source>
-      <translation>Texto</translation>
+        <location filename="../src/MacroStepTableModel.cpp" line="36"/>
+        <source>Text</source>
+        <translation>Texto</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="17"/>
-      <source>Notepad Next[*]</source>
-      <translation>Notepad Next [*]</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="17"/>
+        <source>Notepad Next[*]</source>
+        <translation>Notepad Next[*]</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="33"/>
-      <source>+</source>
-      <translation>+</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="33"/>
+        <source>+</source>
+        <translation>+</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="48"/>
-      <source>&amp;File</source>
-      <translation>&amp;Arquivo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="48"/>
+        <source>&amp;File</source>
+        <translation>&amp;Ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="52"/>
-      <source>Close More</source>
-      <translation>Fechar mais</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="52"/>
+        <source>Close More</source>
+        <translation>Fechar mais</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="60"/>
-      <source>&amp;Recent Files</source>
-      <translation>Arquivos &amp;recentes</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="60"/>
+        <source>&amp;Recent Files</source>
+        <translation>Ficheiros &amp;recentes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="69"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1408"/>
-      <source>Export As</source>
-      <translation>Exportar como</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="69"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1439"/>
+        <source>Export As</source>
+        <translation>Exportar como</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="97"/>
-      <source>&amp;Edit</source>
-      <translation>&amp;Editar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="97"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="101"/>
-      <source>Copy More</source>
-      <translation>Copiar mais</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="101"/>
+        <source>Copy More</source>
+        <translation>Copiar mais</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="109"/>
-      <source>Indent</source>
-      <translation>Indentar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="109"/>
+        <source>Indent</source>
+        <translation>Indentação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="116"/>
-      <source>EOL Conversion</source>
-      <translation>Conversão do fim da linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="116"/>
+        <source>EOL Conversion</source>
+        <translation>Conversão de fim de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="124"/>
-      <source>Convert Case</source>
-      <translation>Converter as letras maiúsculas/minúsculas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="124"/>
+        <source>Convert Case</source>
+        <translation>Converter maiúsculas/minúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="131"/>
-      <source>Line Operations</source>
-      <translation>Operações de linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="131"/>
+        <source>Line Operations</source>
+        <translation>Operações de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="145"/>
-      <source>Comment/Uncomment</source>
-      <translation>Comentar/Remover o comentário</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="154"/>
+        <source>Comment/Uncomment</source>
+        <translation>Comentar/Não comentar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="153"/>
-      <source>Copy As</source>
-      <translation>Copiar como</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="162"/>
+        <source>Copy As</source>
+        <translation>Copiar como</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="160"/>
-      <source>Encoding/Decoding</source>
-      <translation>Codificação/Decodificação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="169"/>
+        <source>Encoding/Decoding</source>
+        <translation>Codificação/Decodificação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="191"/>
-      <source>Search</source>
-      <translation>Pesquisar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="200"/>
+        <source>Search</source>
+        <translation>Procurar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="195"/>
-      <source>Bookmarks</source>
-      <translation>Favoritos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="204"/>
+        <source>Bookmarks</source>
+        <translation>Marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="211"/>
-      <source>Mark All Occurrences</source>
-      <translation>Selecionar todas as ocorrências</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="220"/>
+        <source>Mark All Occurrences</source>
+        <translation>Selecionar todas as ocorrências</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="219"/>
-      <source>Clear Marks</source>
-      <translation>Remover as seleções</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="228"/>
+        <source>Clear Marks</source>
+        <translation>Remover as seleções</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="242"/>
-      <source>&amp;View</source>
-      <translation>&amp;Visualizar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="251"/>
+        <source>&amp;View</source>
+        <translation>&amp;Ver</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="246"/>
-      <source>&amp;Zoom</source>
-      <translation>&amp;Ampliar ou Reduzir</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="255"/>
+        <source>&amp;Zoom</source>
+        <translation>&amp;Zoom</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="255"/>
-      <source>Show Symbol</source>
-      <translation>Exibir o símbolo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="264"/>
+        <source>Show Symbol</source>
+        <translation>Mostrar símbolo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="266"/>
-      <source>Fold Level</source>
-      <translation>Nível da dobra</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="275"/>
+        <source>Fold Level</source>
+        <translation>Nível de dobra</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="280"/>
-      <source>Unfold Level</source>
-      <translation>Nível da desdobra</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="289"/>
+        <source>Unfold Level</source>
+        <translation>Nível de desdobra</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="306"/>
-      <source>Language</source>
-      <translation>Linguagem</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="315"/>
+        <source>Language</source>
+        <translation>Linguagem</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="311"/>
-      <source>Settings</source>
-      <translation>Configurações</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="320"/>
+        <source>Settings</source>
+        <translation>Definições</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="317"/>
-      <source>Macro</source>
-      <translation>Macro</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="326"/>
+        <source>Macro</source>
+        <translation>Macro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="328"/>
-      <source>Help</source>
-      <translation>Ajuda</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="337"/>
+        <source>Help</source>
+        <translation>Ajuda</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="339"/>
-      <source>Encoding</source>
-      <translation>Codificação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="348"/>
+        <source>Encoding</source>
+        <translation>Codificação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="355"/>
-      <source>Main Tool Bar</source>
-      <translation>Barra de ferramentas principal</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="364"/>
+        <source>Main Tool Bar</source>
+        <translation>Barra de ferramentas principal</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="415"/>
-      <source>&amp;New</source>
-      <translation>&amp;Novo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="424"/>
+        <source>&amp;New</source>
+        <translation>&amp;Novo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="418"/>
-      <source>Create a new file</source>
-      <translation>Criar um novo arquivo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="427"/>
+        <source>Create a new file</source>
+        <translation>Criar um novo ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="421"/>
-      <source>Ctrl+N</source>
-      <translation>Ctrl+N</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="430"/>
+        <source>Ctrl+N</source>
+        <translation>Ctrl+N</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="431"/>
-      <source>&amp;Open...</source>
-      <translation>&amp;Abrir...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="440"/>
+        <source>&amp;Open...</source>
+        <translation>&amp;Abrir...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="434"/>
-      <source>Ctrl+O</source>
-      <translation>Ctrl+O</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="443"/>
+        <source>Ctrl+O</source>
+        <translation>Ctrl+O</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="447"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Salvar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="456"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Guardar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="450"/>
-      <source>Save</source>
-      <translation>Salvar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="459"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="453"/>
-      <source>Ctrl+S</source>
-      <translation>Ctrl+S</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="462"/>
+        <source>Ctrl+S</source>
+        <translation>Ctrl+S</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="458"/>
-      <source>E&amp;xit</source>
-      <translation>Sa&amp;ir</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="467"/>
+        <source>E&amp;xit</source>
+        <translation>Sa&amp;ir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="471"/>
-      <source>&amp;Undo</source>
-      <translation>Des&amp;fazer</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="480"/>
+        <source>&amp;Undo</source>
+        <translation>An&amp;ular</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="474"/>
-      <source>Ctrl+Z</source>
-      <translation>Ctrl+Z</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="483"/>
+        <source>Ctrl+Z</source>
+        <translation>Ctrl+Z</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="484"/>
-      <source>&amp;Redo</source>
-      <translation>&amp;Refazer</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="493"/>
+        <source>&amp;Redo</source>
+        <translation>&amp;Refazer</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="487"/>
-      <source>Ctrl+Y</source>
-      <translation>Ctrl+Y</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="496"/>
+        <source>Ctrl+Y</source>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="497"/>
-      <source>Cu&amp;t</source>
-      <translation>Cor&amp;tar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="506"/>
+        <source>Cu&amp;t</source>
+        <translation>Cor&amp;tar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="500"/>
-      <source>Ctrl+X</source>
-      <translation>Ctrl+X</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="509"/>
+        <source>Ctrl+X</source>
+        <translation>Ctrl+X</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="510"/>
-      <source>&amp;Copy</source>
-      <translation>&amp;Copiar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="519"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Copiar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="513"/>
-      <source>Ctrl+C</source>
-      <translation>Ctrl+C</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="522"/>
+        <source>Ctrl+C</source>
+        <translation>Ctrl+C</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="523"/>
-      <source>&amp;Paste</source>
-      <translation>&amp;Colar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="532"/>
+        <source>&amp;Paste</source>
+        <translation>&amp;Colar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="526"/>
-      <source>Ctrl+V</source>
-      <translation>Ctrl+V</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="535"/>
+        <source>Ctrl+V</source>
+        <translation>Ctrl+V</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="531"/>
-      <source>&amp;Delete</source>
-      <translation>&amp;Apagar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="540"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Eliminar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="534"/>
-      <source>Del</source>
-      <translation>Del ou Delete</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="543"/>
+        <source>Del</source>
+        <translation>Ctrl+V</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="539"/>
-      <source>Copy Full Path</source>
-      <translation>Copiar o caminho completo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="548"/>
+        <source>Copy Full Path</source>
+        <translation>Copiar localização completa</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="544"/>
-      <source>Copy File Name</source>
-      <translation>Copiar o nome do arquivo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="553"/>
+        <source>Copy File Name</source>
+        <translation>Copiar nome de ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="549"/>
-      <source>Copy File Directory</source>
-      <translation>Copiar a pasta de arquivos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="558"/>
+        <source>Copy File Directory</source>
+        <translation>Copiar diretório de ficheiros</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="558"/>
-      <source>&amp;Close</source>
-      <translation>&amp;Fechar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="567"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="561"/>
-      <source>Close the current file</source>
-      <translation>Fechar o arquivo atual</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="570"/>
+        <source>Close the current file</source>
+        <translation>Fechar o ficheiro atual</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="564"/>
-      <source>Ctrl+W</source>
-      <translation>Ctrl+W</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="573"/>
+        <source>Ctrl+W</source>
+        <translation>Ctrl+W</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="569"/>
-      <source>Save &amp;As...</source>
-      <translation>Salvar &amp;como...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="578"/>
+        <source>Save &amp;As...</source>
+        <translation>Guardar &amp;como...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="572"/>
-      <source>Ctrl+Alt+S</source>
-      <translation>Ctrl+Alt+S</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="581"/>
+        <source>Ctrl+Alt+S</source>
+        <translation>Ctrl+Alt+S</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="577"/>
-      <source>Save a Copy As...</source>
-      <translation>Salvar uma cópia como...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="586"/>
+        <source>Save a Copy As...</source>
+        <translation>Guardar uma cópia como...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="586"/>
-      <source>Sav&amp;e All</source>
-      <translation>Sal&amp;var todos os arquivos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="595"/>
+        <source>Sav&amp;e All</source>
+        <translation>Guar&amp;dar tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="589"/>
-      <source>Ctrl+Shift+S</source>
-      <translation>Ctrl+Shift+S</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="598"/>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="594"/>
-      <source>Select A&amp;ll</source>
-      <translation>Selecionar t&amp;udo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="603"/>
+        <source>Select A&amp;ll</source>
+        <translation>Selecionar t&amp;udo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="597"/>
-      <source>Ctrl+A</source>
-      <translation>Ctrl+A</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="606"/>
+        <source>Ctrl+A</source>
+        <translation>Ctrl+A</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="606"/>
-      <source>Increase Indent</source>
-      <translation>Aumentar o recuo da linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="615"/>
+        <source>Increase Indent</source>
+        <translation>Aumentar a indentação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="615"/>
-      <source>Decrease Indent</source>
-      <translation>Diminuir o recuo da linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="624"/>
+        <source>Decrease Indent</source>
+        <translation>Diminuir a indentação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="620"/>
-      <source>Rename...</source>
-      <translation>Renomear...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="629"/>
+        <source>Rename...</source>
+        <translation>Renomear...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="629"/>
-      <source>Re&amp;load</source>
-      <translation>Re&amp;carregar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="638"/>
+        <source>Re&amp;load</source>
+        <translation>Re&amp;carregar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="637"/>
-      <source>Windows (CR LF)</source>
-      <translation>Windows (CR LF)</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="646"/>
+        <source>Windows (CR LF)</source>
+        <translation>Windows (CR LF)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="645"/>
-      <source>Unix (LF)</source>
-      <translation>Unix (LF)</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="654"/>
+        <source>Unix (LF)</source>
+        <translation>Unix (LF)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="653"/>
-      <source>Macintosh (CR)</source>
-      <translation>Macintosh (CR)</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="662"/>
+        <source>Macintosh (CR)</source>
+        <translation>Macintosh (CR)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="658"/>
-      <source>UPPER CASE</source>
-      <translation>MAIÚSCULAS</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="667"/>
+        <source>UPPER CASE</source>
+        <translation>MAIÚSCULAS</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="661"/>
-      <source>Convert text to upper case</source>
-      <translation>Converter o texto em letras maiúsculas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="670"/>
+        <source>Convert text to upper case</source>
+        <translation>Converter texto em maiúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="666"/>
-      <source>lower case</source>
-      <translation>minúsculas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="675"/>
+        <source>lower case</source>
+        <translation>minúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="669"/>
-      <source>Convert text to lower case</source>
-      <translation>Converter o texto em letras minúsculas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="678"/>
+        <source>Convert text to lower case</source>
+        <translation>Converter texto em minúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="674"/>
-      <source>Duplicate Current Line</source>
-      <translation>Duplicar a linha atual</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="683"/>
+        <source>Duplicate Current Line</source>
+        <translation>Duplicar linha atual</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="677"/>
-      <source>Alt+Down</source>
-      <translation>Alt+Baixo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="686"/>
+        <source>Alt+Down</source>
+        <translation>Alt+Baixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="682"/>
-      <source>Split Lines</source>
-      <translation>Dividir as linhas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="691"/>
+        <source>Split Lines</source>
+        <translation>Dividir linhas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="687"/>
-      <source>Join Lines</source>
-      <translation>Juntar as linhas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="696"/>
+        <source>Join Lines</source>
+        <translation>Juntar linhas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="690"/>
-      <source>Ctrl+J</source>
-      <translation>Ctrl+J</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="699"/>
+        <source>Ctrl+J</source>
+        <translation>Ctrl+J</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="695"/>
-      <source>Move Selected Lines Up</source>
-      <translation>Mover as linhas selecionadas para cima</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="704"/>
+        <source>Move Selected Lines Up</source>
+        <translation>Mover as linhas selecionadas para cima</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="698"/>
-      <source>Ctrl+Shift+Up</source>
-      <translation>Ctrl+Shift+Cima</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="707"/>
+        <source>Ctrl+Shift+Up</source>
+        <translation>Ctrl+Shift+Cima</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="703"/>
-      <source>Move Selected Lines Down</source>
-      <translation>Mover as linhas selecionadas para baixo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="712"/>
+        <source>Move Selected Lines Down</source>
+        <translation>Mover as linhas selecionadas para baixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="706"/>
-      <source>Ctrl+Shift+Down</source>
-      <translation>Ctrl+Shift+Baixo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="715"/>
+        <source>Ctrl+Shift+Down</source>
+        <translation>Ctrl+Shift+Baixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="715"/>
-      <source>Clos&amp;e All</source>
-      <translation>Fechar &amp;todos os arquivos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="724"/>
+        <source>Clos&amp;e All</source>
+        <translation>Fechar &amp;tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="718"/>
-      <source>Close All files</source>
-      <translation>Fechar todos os arquivos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="727"/>
+        <source>Close All files</source>
+        <translation>Fechar todos os ficheiros</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="721"/>
-      <source>Ctrl+Shift+W</source>
-      <translation>Ctrl+Shift+W</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="730"/>
+        <source>Ctrl+Shift+W</source>
+        <translation>Ctrl+Shift+W</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="726"/>
-      <source>Close All Except Active Document</source>
-      <translation>Fechar todos os arquivos, exceto o atual</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="735"/>
+        <source>Close All Except Active Document</source>
+        <translation>Fechar tudo exceto o documento ativo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="731"/>
-      <source>Close All to the Left</source>
-      <translation>Fechar todos os arquivos à esquerda</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="740"/>
+        <source>Close All to the Left</source>
+        <translation>Fechar tudo à esquerda</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="736"/>
-      <source>Close All to the Right</source>
-      <translation>Fechar todos os arquivos à direita</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="745"/>
+        <source>Close All to the Right</source>
+        <translation>Fechar tudo à direita</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="746"/>
-      <source>Zoom &amp;In</source>
-      <translation>Ampl&amp;iar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="755"/>
+        <source>Zoom &amp;In</source>
+        <translation>A&amp;umentar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="749"/>
-      <source>Ctrl++</source>
-      <translation>Ctrl++</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="758"/>
+        <source>Ctrl++</source>
+        <translation>Ctrl++</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="759"/>
-      <source>Zoom &amp;Out</source>
-      <translation>Red&amp;uzir</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="768"/>
+        <source>Zoom &amp;Out</source>
+        <translation>&amp;Reduzir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="762"/>
-      <source>Ctrl+-</source>
-      <translation>Ctrl+-</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="771"/>
+        <source>Ctrl+-</source>
+        <translation>Ctrl+-</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="767"/>
-      <source>Reset Zoom</source>
-      <translation>Redefinir a visualização</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="776"/>
+        <source>Reset Zoom</source>
+        <translation>Repor</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="770"/>
-      <source>Ctrl+0</source>
-      <translation>Ctrl+0</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="779"/>
+        <source>Ctrl+0</source>
+        <translation>Ctrl+0</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="775"/>
-      <source>About Qt</source>
-      <translation>Sobre o Qt</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="784"/>
+        <source>About Qt</source>
+        <translation>Acerca do Qt</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="787"/>
-      <source>About Notepad Next</source>
-      <translation>Sobre o Notepad Next</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="796"/>
+        <source>About Notepad Next</source>
+        <translation>Acerca do Notepad Next</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="798"/>
-      <source>Show Whitespace</source>
-      <translation>Exibir os espaços em branco</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="807"/>
+        <source>Show Whitespace</source>
+        <translation>Mostrar espaço em branco</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="806"/>
-      <source>Show End of Line</source>
-      <translation>Exibir o fim da linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="815"/>
+        <source>Show End of Line</source>
+        <translation>Mostrar fim de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="819"/>
-      <source>Show All Characters</source>
-      <translation>Exibir todos os caracteres</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="828"/>
+        <source>Show All Characters</source>
+        <translation>Mostrar todos os caracteres</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="832"/>
-      <source>Show Indent Guide</source>
-      <translation>Exibir a guia de indentação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="841"/>
+        <source>Show Indent Guide</source>
+        <translation>Mostrar guia de indentação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="840"/>
-      <source>Show Wrap Symbol</source>
-      <translation>Exibir o símbolo da quebra de linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="849"/>
+        <source>Show Wrap Symbol</source>
+        <translation>Mostrar o símbolo de quebra de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="853"/>
-      <source>Word Wrap</source>
-      <translation>Quebra de palavras</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="862"/>
+        <source>Word Wrap</source>
+        <translation>Quebra de palavras</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="858"/>
-      <source>Restore Recently Closed File</source>
-      <translation>Restaurar o arquivo que foi fechado recentemente</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="867"/>
+        <source>Restore Recently Closed File</source>
+        <translation>Restaurar ficheiro fechado recentemente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="861"/>
-      <source>Ctrl+Shift+T</source>
-      <translation>Ctrl+Shift+T</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="870"/>
+        <source>Ctrl+Shift+T</source>
+        <translation>Ctrl+Shift+T</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="866"/>
-      <source>Open All Recent Files</source>
-      <translation>Abrir todos os arquivos recentes</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="875"/>
+        <source>Open All Recent Files</source>
+        <translation>Abrir todos os ficheiros recentes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="871"/>
-      <source>Clear Recent Files List</source>
-      <translation>Limpar a lista dos arquivos recentes</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="880"/>
+        <source>Clear Recent Files List</source>
+        <translation>Limpar a lista dos ficheiros recentes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="881"/>
-      <source>&amp;Find...</source>
-      <translation>&amp;Localizar...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="890"/>
+        <source>&amp;Find...</source>
+        <translation>&amp;Localizar...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="884"/>
-      <source>Ctrl+F</source>
-      <translation>Ctrl+F</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="893"/>
+        <source>Ctrl+F</source>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="889"/>
-      <source>Find in Files...</source>
-      <translation>Localizar nos arquivos...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="898"/>
+        <source>Find in Files...</source>
+        <translation>Localizar em Ficheiros...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="894"/>
-      <source>Find &amp;Next</source>
-      <translation>Localizar o &amp;próximo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="903"/>
+        <source>Find &amp;Next</source>
+        <translation>Localizar &amp;seguinte</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="897"/>
-      <source>F3</source>
-      <translation>F3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="906"/>
+        <source>F3</source>
+        <translation>F3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="902"/>
-      <source>Find &amp;Previous</source>
-      <translation>Localizar o &amp;anterior</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="911"/>
+        <source>Find &amp;Previous</source>
+        <translation>Localizar &amp;anterior</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="912"/>
-      <source>&amp;Replace...</source>
-      <translation>&amp;Substituir...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="914"/>
+        <source>Shift+F3</source>
+        <translation>Shift+F3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="915"/>
-      <source>Ctrl+H</source>
-      <translation>Ctrl+H</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="924"/>
+        <source>&amp;Replace...</source>
+        <translation>&amp;Substituir...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="923"/>
-      <source>Full Screen</source>
-      <translation>Tela inteira</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="927"/>
+        <source>Ctrl+H</source>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="926"/>
-      <source>F11</source>
-      <translation>F11</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="935"/>
+        <source>Full Screen</source>
+        <translation>Ecrã inteiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="939"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="717"/>
-      <source>Start Recording</source>
-      <translation>Iniciar a gravação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="938"/>
+        <source>F11</source>
+        <translation>F11</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="951"/>
-      <source>Playback</source>
-      <translation>Reproduzir</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="951"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="753"/>
+        <source>Start Recording</source>
+        <translation>Iniciar gravação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="954"/>
-      <source>Ctrl+Shift+P</source>
-      <translation>Ctrl+Shift+P</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="963"/>
+        <source>Playback</source>
+        <translation>Reproduzir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="966"/>
-      <source>Save Current Recorded Macro...</source>
-      <translation>Salvar o macro atual que foi gravado...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="966"/>
+        <source>Ctrl+Shift+P</source>
+        <translation>Ctrl+Shift+P</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="978"/>
-      <source>Run a Macro Multiple Times...</source>
-      <translation>Executar um macro várias vezes...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="978"/>
+        <source>Save Current Recorded Macro...</source>
+        <translation>Guardar a macro gravada atual...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="987"/>
-      <source>Preferences...</source>
-      <translation>Preferências...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="990"/>
+        <source>Run a Macro Multiple Times...</source>
+        <translation>Executar uma macro várias vezes...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="995"/>
-      <source>Quick Find</source>
-      <translation>Localizar rapidamente</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="999"/>
+        <source>Preferences...</source>
+        <translation>Preferências...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="998"/>
-      <source>Ctrl+Alt+I</source>
-      <translation>Ctrl+Alt+I</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1007"/>
+        <source>Quick Find</source>
+        <translation>Pesquisa rápida</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1003"/>
-      <source>Select Next Instance</source>
-      <translation>Selecionar a próxima instância</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1010"/>
+        <source>Ctrl+Alt+I</source>
+        <translation>Ctrl+Alt+I</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1006"/>
-      <source>Ctrl+D</source>
-      <translation>Ctrl+D</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1015"/>
+        <source>Select Next Instance</source>
+        <translation>Selecionar a instância seguinte</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1015"/>
-      <source>Move to Trash...</source>
-      <translation>Mover para a lixeira...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1018"/>
+        <source>Ctrl+D</source>
+        <translation>Ctrl+D</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1018"/>
-      <source>Move to Trash</source>
-      <translation>Mover para a lixeira</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1027"/>
+        <source>Move to Trash...</source>
+        <translation>Mover para o Lixo...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1023"/>
-      <source>Check for Updates...</source>
-      <translation>Procurar por atualizações...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1030"/>
+        <source>Move to Trash</source>
+        <translation>Mover para o Lixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1028"/>
-      <source>&amp;Go to Line...</source>
-      <translation>&amp;Ir para a linha...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1035"/>
+        <source>Check for Updates...</source>
+        <translation>Procurar por atualizações...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1031"/>
-      <source>Ctrl+G</source>
-      <translation>Ctrl+G</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1040"/>
+        <source>&amp;Go to Line...</source>
+        <translation>&amp;Ir para a linha...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1040"/>
-      <source>Print...</source>
-      <translation>Imprimir...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1043"/>
+        <source>Ctrl+G</source>
+        <translation>Ctrl+G</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1043"/>
-      <source>Ctrl+P</source>
-      <translation>Ctrl+P</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1052"/>
+        <source>Print...</source>
+        <translation>Imprimir...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1048"/>
-      <source>Open Folder as Workspace...</source>
-      <translation>Abrir uma pasta como área de trabalho...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1055"/>
+        <source>Ctrl+P</source>
+        <translation>Ctrl+P</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1053"/>
-      <source>Toggle Single Line Comment</source>
-      <translation>Adicionar ou remover o comentário da linha única</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1060"/>
+        <source>Open Folder as Workspace...</source>
+        <translation>Abrir pasta como área de trabalho...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1056"/>
-      <source>Ctrl+/</source>
-      <translation>Ctrl+/</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1065"/>
+        <source>Toggle Single Line Comment</source>
+        <translation>Alternar comentário de linha única</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1061"/>
-      <source>Single Line Comment</source>
-      <translation>Comentário da linha única</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1068"/>
+        <source>Ctrl+/</source>
+        <translation>Ctrl+/</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1064"/>
-      <source>Ctrl+K</source>
-      <translation>Ctrl+K</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1073"/>
+        <source>Single Line Comment</source>
+        <translation>Comentário de linha única</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1069"/>
-      <source>Single Line Uncomment</source>
-      <translation>Remover o comentário da linha única</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1076"/>
+        <source>Ctrl+K</source>
+        <translation>Ctrl+K</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1072"/>
-      <source>Ctrl+Shift+K</source>
-      <translation>Ctrl+Shift+K</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1081"/>
+        <source>Single Line Uncomment</source>
+        <translation>Sem comentário de linha única</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1084"/>
-      <source>Edit Macros...</source>
-      <translation>Editar os macros...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1084"/>
+        <source>Ctrl+Shift+K</source>
+        <translation>Ctrl+Shift+K</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1092"/>
-      <source>This is not currently implemented</source>
-      <translation>Esta funcionalidade ainda não está implementada</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1096"/>
+        <source>Edit Macros...</source>
+        <translation>Editar macros...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1097"/>
-      <source>Column Mode...</source>
-      <translation>Modo de coluna...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1104"/>
+        <source>This is not currently implemented</source>
+        <translation>Atualmente não está implementado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1102"/>
-      <source>Export as HTML...</source>
-      <translation>Exportar como HTML...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1109"/>
+        <source>Column Mode...</source>
+        <translation>Modo de coluna...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1107"/>
-      <source>Export as RTF...</source>
-      <translation>Exportar como RTF...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1114"/>
+        <source>Export as HTML...</source>
+        <translation>Exportar como HTML...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1112"/>
-      <source>Copy as HTML</source>
-      <translation>Copiar como HTML</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1119"/>
+        <source>Export as RTF...</source>
+        <translation>Exportar como RTF...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1117"/>
-      <source>Copy as RTF</source>
-      <translation>Copiar como RTF</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1124"/>
+        <source>Copy as HTML</source>
+        <translation>Copiar como HTML</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1122"/>
-      <source>Base 64 Encode</source>
-      <translation>Codificar para a base 64</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1129"/>
+        <source>Copy as RTF</source>
+        <translation>Copiar como RTF</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1127"/>
-      <source>URL Encode</source>
-      <translation>Codificar para o URL</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1134"/>
+        <source>Base 64 Encode</source>
+        <translation>Codificação Base 64</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1132"/>
-      <source>Base 64 Decode</source>
-      <translation>Decodificar a partir da base 64</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1139"/>
+        <source>URL Encode</source>
+        <translation>Codificação URL</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1137"/>
-      <source>URL Decode</source>
-      <translation>Decodificar a partir do URL</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1144"/>
+        <source>Base 64 Decode</source>
+        <translation>Descodificação Base 64</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1142"/>
-      <source>Copy URL</source>
-      <translation>Copiar o URL</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1149"/>
+        <source>URL Decode</source>
+        <translation>Descodificação URL</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1147"/>
-      <source>Remove Empty Lines</source>
-      <translation>Remover as linhas vazias</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1154"/>
+        <source>Copy URL</source>
+        <translation>Copiar URL</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1156"/>
-      <location filename="../src/dialogs/MainWindow.ui" line="1159"/>
-      <source>Show in Explorer</source>
-      <translation>Exibir no explorador</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1159"/>
+        <source>Remove Empty Lines</source>
+        <translation>Remover linhas vazias</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1168"/>
-      <source>Open %1 Here</source>
-      <translation>Abrir %1 aqui</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1168"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1171"/>
+        <source>Show in Explorer</source>
+        <translation>Mostrar no Explorador</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1173"/>
-      <source>Toggle Bookmark</source>
-      <translation>Ativar ou desativar os favoritos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1180"/>
+        <source>Open %1 Here</source>
+        <translation>Abrir %1 aqui</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1176"/>
-      <source>Ctrl+F2</source>
-      <translation>Ctrl+F2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1185"/>
+        <source>Toggle Bookmark</source>
+        <translation>Alternar marcador</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1181"/>
-      <source>Next Bookmark</source>
-      <translation>Próximo favorito</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1188"/>
+        <source>Ctrl+F2</source>
+        <translation>Ctrl+F2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1184"/>
-      <source>F2</source>
-      <translation>F2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1193"/>
+        <source>Next Bookmark</source>
+        <translation>Marcador seguinte</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1189"/>
-      <source>Previous Bookmark</source>
-      <translation>Favorito anterior</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1196"/>
+        <source>F2</source>
+        <translation>F2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1192"/>
-      <source>Shift+F2</source>
-      <translation>Shift+F2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1201"/>
+        <source>Previous Bookmark</source>
+        <translation>Marcador anterior</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1197"/>
-      <source>Clear Bookmarks</source>
-      <translation>Limpar os favoritos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1204"/>
+        <source>Shift+F2</source>
+        <translation>Shift+F2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1202"/>
-      <source>Invert Bookmarks</source>
-      <translation>Inverter os favoritos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1209"/>
+        <source>Clear Bookmarks</source>
+        <translation>Limpar marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1207"/>
-      <source>Next Tab</source>
-      <translation>Próxima aba</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1214"/>
+        <source>Invert Bookmarks</source>
+        <translation>Inverter marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1210"/>
-      <source>Ctrl+Tab</source>
-      <translation>Ctrl+Tab</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1219"/>
+        <source>Next Tab</source>
+        <translation>Separarador seguinte</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1218"/>
-      <source>Previous Tab</source>
-      <translation>Aba anterior</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1222"/>
+        <source>Ctrl+Tab</source>
+        <translation>Ctrl+Tab</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1221"/>
-      <source>Ctrl+Shift+Tab</source>
-      <translation>Ctrl+Shift+Tab</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1230"/>
+        <source>Previous Tab</source>
+        <translation>Separador anterior</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1229"/>
-      <source>Fold Level 1</source>
-      <translation>Nível da dobra 1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1233"/>
+        <source>Ctrl+Shift+Tab</source>
+        <translation>Ctrl+Shift+Tab</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1232"/>
-      <source>Alt+1</source>
-      <translation>Alt+1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1241"/>
+        <source>Fold Level 1</source>
+        <translation>Nível de dobra 1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1237"/>
-      <source>Fold Level 2</source>
-      <translation>Nível da dobra 2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1244"/>
+        <source>Alt+1</source>
+        <translation>Alt+1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1240"/>
-      <source>Alt+2</source>
-      <translation>Alt+2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1249"/>
+        <source>Fold Level 2</source>
+        <translation>Nível de dobra 2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1245"/>
-      <source>Fold Level 3</source>
-      <translation>Nível da dobra 3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1252"/>
+        <source>Alt+2</source>
+        <translation>Alt+2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1248"/>
-      <source>Alt+3</source>
-      <translation>Alt+3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1257"/>
+        <source>Fold Level 3</source>
+        <translation>Nível de dobra 3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1253"/>
-      <source>Fold Level 4</source>
-      <translation>Nível da dobra 4</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1260"/>
+        <source>Alt+3</source>
+        <translation>Alt+3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1256"/>
-      <source>Alt+4</source>
-      <translation>Alt+4</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1265"/>
+        <source>Fold Level 4</source>
+        <translation>Nível de dobra 4</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1261"/>
-      <source>Unfold Level 1</source>
-      <translation>Nível da desdobra 1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1268"/>
+        <source>Alt+4</source>
+        <translation>Alt+4</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1264"/>
-      <source>Alt+Shift+1</source>
-      <translation>Alt+Shift+1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1273"/>
+        <source>Unfold Level 1</source>
+        <translation>Nível de desdobra 1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1269"/>
-      <source>Unfold Level 2</source>
-      <translation>Nível da desdobra 2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1276"/>
+        <source>Alt+Shift+1</source>
+        <translation>Alt+Shift+1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1272"/>
-      <source>Alt+Shift+2</source>
-      <translation>Alt+Shift+2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1281"/>
+        <source>Unfold Level 2</source>
+        <translation>Nível de desdobra 2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1277"/>
-      <source>Unfold Level 3</source>
-      <translation>Nível da desdobra 3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1284"/>
+        <source>Alt+Shift+2</source>
+        <translation>Alt+Shift+2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1280"/>
-      <source>Alt+Shift+3</source>
-      <translation>Alt+Shift+3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1289"/>
+        <source>Unfold Level 3</source>
+        <translation>Nível de desdobra 3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1285"/>
-      <source>Unfold Level 4</source>
-      <translation>Nível da desdobra 4</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1292"/>
+        <source>Alt+Shift+3</source>
+        <translation>Alt+Shift+3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1288"/>
-      <source>Alt+Shift+4</source>
-      <translation>Alt+Shift+4</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1297"/>
+        <source>Unfold Level 4</source>
+        <translation>Nível de desdobra 4</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1293"/>
-      <source>Fold All</source>
-      <translation>Dobrar tudo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1300"/>
+        <source>Alt+Shift+4</source>
+        <translation>Alt+Shift+4</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1296"/>
-      <source>Alt+0</source>
-      <translation>Alt+0</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1305"/>
+        <source>Fold All</source>
+        <translation>Dobrar tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1301"/>
-      <source>Unfold All</source>
-      <translation>Desdobrar tudo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1308"/>
+        <source>Alt+0</source>
+        <translation>Alt+0</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1304"/>
-      <source>Alt+Shift+0</source>
-      <translation>Alt+Shift+0</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1313"/>
+        <source>Unfold All</source>
+        <translation>Desdobrar tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1309"/>
-      <source>Fold Level 5</source>
-      <translation>Nível da dobra 5</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1316"/>
+        <source>Alt+Shift+0</source>
+        <translation>Alt+Shift+0</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1312"/>
-      <source>Alt+5</source>
-      <translation>Alt+5</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1321"/>
+        <source>Fold Level 5</source>
+        <translation>Nível de dobra 5</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1317"/>
-      <source>Fold Level 6</source>
-      <translation>Nível da dobra 6</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1324"/>
+        <source>Alt+5</source>
+        <translation>Alt+5</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1320"/>
-      <source>Alt+6</source>
-      <translation>Alt+6</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1329"/>
+        <source>Fold Level 6</source>
+        <translation>Nível de dobra 6</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1325"/>
-      <source>Fold Level 7</source>
-      <translation>Nível da dobra 7</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1332"/>
+        <source>Alt+6</source>
+        <translation>Alt+6</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1328"/>
-      <source>Alt+7</source>
-      <translation>Alt+7</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1337"/>
+        <source>Fold Level 7</source>
+        <translation>Nível de dobra 7</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1333"/>
-      <source>Fold Level 8</source>
-      <translation>Nível da dobra 8</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1340"/>
+        <source>Alt+7</source>
+        <translation>Alt+7</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1336"/>
-      <source>Alt+8</source>
-      <translation>Alt+8</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1345"/>
+        <source>Fold Level 8</source>
+        <translation>Nível de dobra 8</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1341"/>
-      <source>Fold Level 9</source>
-      <translation>Nível da dobra 9</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1348"/>
+        <source>Alt+8</source>
+        <translation>Alt+8</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1344"/>
-      <source>Alt+9</source>
-      <translation>Alt+9</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1353"/>
+        <source>Fold Level 9</source>
+        <translation>Nível de dobra 9</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1349"/>
-      <source>Unfold Level 5</source>
-      <translation>Nível da desdobra 5</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1356"/>
+        <source>Alt+9</source>
+        <translation>Alt+9</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1352"/>
-      <source>Alt+Shift+5</source>
-      <translation>Alt+Shift+5</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1361"/>
+        <source>Unfold Level 5</source>
+        <translation>Nível de desdobra 5</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1357"/>
-      <source>Unfold Level 6</source>
-      <translation>Nível da desdobra 6</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1364"/>
+        <source>Alt+Shift+5</source>
+        <translation>Alt+Shift+5</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1360"/>
-      <source>Alt+Shift+6</source>
-      <translation>Alt+Shift+6</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1369"/>
+        <source>Unfold Level 6</source>
+        <translation>Nível de desdobra 6</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1365"/>
-      <source>Unfold Level 7</source>
-      <translation>Nível da desdobra 7</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1372"/>
+        <source>Alt+Shift+6</source>
+        <translation>Alt+Shift+6</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1368"/>
-      <source>Alt+Shift+7</source>
-      <translation>Alt+Shift+7</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1377"/>
+        <source>Unfold Level 7</source>
+        <translation>Nível de desdobra 7</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1373"/>
-      <source>Unfold Level 8</source>
-      <translation>Nível da desdobra 8</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1380"/>
+        <source>Alt+Shift+7</source>
+        <translation>Alt+Shift+7</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1376"/>
-      <source>Alt+Shift+8</source>
-      <translation>Alt+Shift+8</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1385"/>
+        <source>Unfold Level 8</source>
+        <translation>Nível de desdobra 8</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1381"/>
-      <source>Unfold Level 9</source>
-      <translation>Nível da desdobra 9</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1388"/>
+        <source>Alt+Shift+8</source>
+        <translation>Alt+Shift+8</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1384"/>
-      <source>Alt+Shift+9</source>
-      <translation>Alt+Shift+9</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1393"/>
+        <source>Unfold Level 9</source>
+        <translation>Nível de desdobra 9</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1389"/>
-      <location filename="../src/dialogs/MainWindow.ui" line="1392"/>
-      <source>Toggle Overtype</source>
-      <translation>Alternar entre os tipos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1396"/>
+        <source>Alt+Shift+9</source>
+        <translation>Alt+Shift+9</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1395"/>
-      <source>Ins</source>
-      <translation>Ins</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1401"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1404"/>
+        <source>Toggle Overtype</source>
+        <translation>Alternar entre tipos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1403"/>
-      <source>Debug Info...</source>
-      <translation>Informações da depuração...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1407"/>
+        <source>Ins</source>
+        <translation>Ins</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1408"/>
-      <source>Cut Bookmarked Lines</source>
-      <translation>Cortar as linhas dos favoritos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1415"/>
+        <source>Debug Info...</source>
+        <translation>Informações de depuração...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1413"/>
-      <source>Copy Bookmarked Lines</source>
-      <translation>Copiar as linhas dos favoritos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1420"/>
+        <source>Cut Bookmarked Lines</source>
+        <translation>Cortar linhas com marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1418"/>
-      <source>Delete Bookmarked Lines</source>
-      <translation>Apagar as linhas dos favoritos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1425"/>
+        <source>Copy Bookmarked Lines</source>
+        <translation>Copiar linhas com marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1423"/>
-      <source>Mark Style 1</source>
-      <translation>Estilo da seleção 1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1430"/>
+        <source>Delete Bookmarked Lines</source>
+        <translation>Eliminar linhas com marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1431"/>
-      <source>Mark Style 2</source>
-      <translation>Estilo da seleção 2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1435"/>
+        <source>Mark Style 1</source>
+        <translation>Estilo da seleção 1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1439"/>
-      <source>Clear Style 1</source>
-      <translation>Remover o estilo 1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1443"/>
+        <source>Mark Style 2</source>
+        <translation>Estilo da seleção 2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1447"/>
-      <source>Clear Style 2</source>
-      <translation>Remover o estilo 2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1451"/>
+        <source>Clear Style 1</source>
+        <translation>Remover o estilo 1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1455"/>
-      <source>Mark Style 3</source>
-      <translation>Estilo da seleção 3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1459"/>
+        <source>Clear Style 2</source>
+        <translation>Remover o estilo 2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1463"/>
-      <source>Clear Style 3</source>
-      <translation>Remover o estilo 3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1467"/>
+        <source>Mark Style 3</source>
+        <translation>Estilo da seleção 3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1471"/>
-      <location filename="../src/dialogs/MainWindow.ui" line="1474"/>
-      <source>Clear All Styles</source>
-      <translation>Remover todos os estilos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1475"/>
+        <source>Clear Style 3</source>
+        <translation>Remover o estilo 3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1479"/>
-      <source>Remove Duplicate Lines</source>
-      <translation type="unfinished">Remove Duplicate Lines</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1483"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1486"/>
+        <source>Clear All Styles</source>
+        <translation>Remover todos os estilos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1484"/>
-      <source>Remove Consecutive Duplicate Lines</source>
-      <translation type="unfinished">Remove Consecutive Duplicate Lines</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1491"/>
+        <source>Remove Duplicate Lines</source>
+        <translation>Remover linhas duplicadas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="375"/>
-      <source>Go to line</source>
-      <translation>Ir para a linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1496"/>
+        <source>Remove Consecutive Duplicate Lines</source>
+        <translation>Remover linhas duplicadas consecutivas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="375"/>
-      <source>Line Number (1 - %1)</source>
-      <translation>Número da linha (1 - %1)</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1501"/>
+        <source>Sort Lines Ascending</source>
+        <translation>Ordenar as linhas por ordem ascendente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="708"/>
-      <source>Stop Recording</source>
-      <translation>Parar a gravação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1506"/>
+        <source>Sort Lines Descending</source>
+        <translation>Ordenar as linhas por ordem descendente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="813"/>
-      <source>Debug Info</source>
-      <translation>Informações da depuração</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1511"/>
+        <source>Sort Lines Ascending (Case-Insensitive)</source>
+        <translation>Ordenar as linhas por ordem ascendente (sem distinção entre maiúsculas e minúsculas)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1016"/>
-      <source>New %1</source>
-      <translation>Novo %1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1516"/>
+        <source>Sort Lines Descending (Case-Insensitive)</source>
+        <translation>Ordenar as linhas por ordem descendente (sem distinção entre maiúsculas e minúsculas)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1076"/>
-      <source>Create File</source>
-      <translation>Criar um arquivo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1521"/>
+        <source>Sort Lines by Length Ascending</source>
+        <translation>Ordenar as linhas por comprimento, em ordem ascendente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1076"/>
-      <source>&lt;b&gt;%1&lt;/b&gt; does not exist. Do you want to create it?</source>
-      <translation>O &lt;b&gt;%1&lt;/b&gt; não existe. Você quer criá-lo agora?</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1526"/>
+        <source>Sort Lines by Length Descending</source>
+        <translation>Ordenar as linhas por comprimento, em ordem descendente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1117"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1208"/>
-      <source>Save file &lt;b&gt;%1&lt;/b&gt;?</source>
-      <translation>Salvar o arquivo &lt;b&gt;%1&lt;/b&gt;?</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1531"/>
+        <source>Reverse Line Order</source>
+        <translation>Inverter a ordem das linhas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1118"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1209"/>
-      <source>Save File</source>
-      <translation>Salvar o arquivo</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="411"/>
+        <source>Go to line</source>
+        <translation>Ir para a linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1159"/>
-      <source>Open Folder as Workspace</source>
-      <translation>Abrir a pasta como área de trabalho</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="411"/>
+        <source>Line Number (1 - %1)</source>
+        <translation>Número da linha (1 - %1)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1182"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1854"/>
-      <source>Reload File</source>
-      <translation>Recarregar o arquivo</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="744"/>
+        <source>Stop Recording</source>
+        <translation>Parar gravação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1182"/>
-      <source>Are you sure you want to reload &lt;b&gt;%1&lt;/b&gt;? Any unsaved changes will be lost.</source>
-      <translation>Você tem certeza de que quer recarregar o &lt;b&gt;%1&lt;/b&gt;? Todas as alterações que não foram salvas serão perdidas.</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="849"/>
+        <source>Debug Info</source>
+        <translation>Informações de depuração</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1373"/>
-      <source>Save a Copy As</source>
-      <translation>Salvar uma cópia como</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1047"/>
+        <source>New %1</source>
+        <translation>Novo %1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1449"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1466"/>
-      <source>Rename</source>
-      <translation>Renomear</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1107"/>
+        <source>Create File</source>
+        <translation>Criar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1466"/>
-      <source>Name:</source>
-      <translation>Nome:</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1107"/>
+        <source>&lt;b&gt;%1&lt;/b&gt; does not exist. Do you want to create it?</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt; não existe. Pretende criá-lo?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1486"/>
-      <source>Delete File</source>
-      <translation>Apagar o arquivo</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1148"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1239"/>
+        <source>Save file &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Guardar ficheiro &lt;b&gt;%1&lt;/b&gt;?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1486"/>
-      <source>Are you sure you want to move &lt;b&gt;%1&lt;/b&gt; to the trash?</source>
-      <translation>Você tem a certeza de que quer mover o &lt;b&gt;%1&lt;/b&gt; para a lixeira?</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1149"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1240"/>
+        <source>Save File</source>
+        <translation>Guardar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1496"/>
-      <source>Error Deleting File</source>
-      <translation>Ocorreu um erro ao apagar o arquivo</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1190"/>
+        <source>Open Folder as Workspace</source>
+        <translation>Abrir pasta como área de trabalho</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1496"/>
-      <source>Something went wrong deleting &lt;b&gt;%1&lt;/b&gt;?</source>
-      <translation>Ocorreu um problema ao tentar apagar o &lt;b&gt;%1&lt;/b&gt;.</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1213"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1885"/>
+        <source>Reload File</source>
+        <translation>Recarregar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1593"/>
-      <source>Administrator</source>
-      <translation>Administrador</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1213"/>
+        <source>Are you sure you want to reload &lt;b&gt;%1&lt;/b&gt;? Any unsaved changes will be lost.</source>
+        <translation>Tem certeza de que pretende recarregar o &lt;b&gt;%1&lt;/b&gt;? Todas as alterações não guardadas serão perdidas.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1854"/>
-      <source>&lt;b&gt;%1&lt;/b&gt; has been modified by another program. Do you want to reload it?</source>
-      <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; has been modified by another program. Do you want to reload it?</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1404"/>
+        <source>Save a Copy As</source>
+        <translation>Guardar uma cópia como</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1880"/>
-      <source>Read error</source>
-      <translation type="unfinished">Read error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1480"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1497"/>
+        <source>Rename</source>
+        <translation>Renomear</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1881"/>
-      <source>Write error</source>
-      <translation type="unfinished">Write error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1497"/>
+        <source>Name:</source>
+        <translation>Nome:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1882"/>
-      <source>Fatal error</source>
-      <translation type="unfinished">Fatal error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1517"/>
+        <source>Delete File</source>
+        <translation>Eliminar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1883"/>
-      <source>Resource error</source>
-      <translation type="unfinished">Resource error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1517"/>
+        <source>Are you sure you want to move &lt;b&gt;%1&lt;/b&gt; to the trash?</source>
+        <translation>Tem a certeza de que pretende mover &lt;b&gt;%1&lt;/b&gt; para o lixo?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1884"/>
-      <source>Open error</source>
-      <translation type="unfinished">Open error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1527"/>
+        <source>Error Deleting File</source>
+        <translation>Erro ao eliminar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1885"/>
-      <source>Abort error</source>
-      <translation type="unfinished">Abort error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1527"/>
+        <source>Something went wrong deleting &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Algo correu mal ao eliminar &lt;b&gt;%1&lt;/b&gt;?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1886"/>
-      <source>Timeout error</source>
-      <translation type="unfinished">Timeout error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1624"/>
+        <source>Administrator</source>
+        <translation>Administrador</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1887"/>
-      <source>Unspecified error</source>
-      <translation type="unfinished">Unspecified error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1885"/>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been modified by another program. Do you want to reload it?</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt; foi modificado por outro programa. Deseja recarregá-lo?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1888"/>
-      <source>Remove error</source>
-      <translation type="unfinished">Remove error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1911"/>
+        <source>Read error</source>
+        <translation>Erro de leitura</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1889"/>
-      <source>Rename error</source>
-      <translation type="unfinished">Rename error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1912"/>
+        <source>Write error</source>
+        <translation>Erro de gravação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1890"/>
-      <source>Position error</source>
-      <translation type="unfinished">Position error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1913"/>
+        <source>Fatal error</source>
+        <translation>Erro fatal</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1891"/>
-      <source>Resize error</source>
-      <translation type="unfinished">Resize error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1914"/>
+        <source>Resource error</source>
+        <translation>Erro de recurso</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1892"/>
-      <source>Permissions error</source>
-      <translation type="unfinished">Permissions error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1915"/>
+        <source>Open error</source>
+        <translation>Erro ao abrir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1893"/>
-      <source>Copy error</source>
-      <translation type="unfinished">Copy error</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1916"/>
+        <source>Abort error</source>
+        <translation>Erro ao abortar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1894"/>
-      <source>Unknown error (%1)</source>
-      <translation type="unfinished">Unknown error (%1)</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1917"/>
+        <source>Timeout error</source>
+        <translation>Erro de tempo limite</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1897"/>
-      <source>Error Saving File</source>
-      <translation>Ocorreu um erro ao tentar salvar o arquivo</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1918"/>
+        <source>Unspecified error</source>
+        <translation>Erro não especificado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1898"/>
-      <source>An error occurred when saving &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Error: %2</source>
-      <translation>Ocorreu um erro ao tentar salvar o &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;. Ocorreu o erro: %2</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1919"/>
+        <source>Remove error</source>
+        <translation>Erro ao remover</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1904"/>
-      <source>Zoom: %1%</source>
-      <translation>Ampliar ou reduzir: %1%</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1920"/>
+        <source>Rename error</source>
+        <translation>Erro ao renomear</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="2071"/>
-      <source>No updates are available at this time.</source>
-      <translation>Não existem atualizações disponíveis neste exato momento</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1921"/>
+        <source>Position error</source>
+        <translation>Erro ao posicionar</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1922"/>
+        <source>Resize error</source>
+        <translation>Erro ao redimensionar</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1923"/>
+        <source>Permissions error</source>
+        <translation>Erro de permissão</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1924"/>
+        <source>Copy error</source>
+        <translation>Erro ao copiar</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1925"/>
+        <source>Unknown error (%1)</source>
+        <translation>Erro desconhecido (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1928"/>
+        <source>Error Saving File</source>
+        <translation>Erro ao guardar ficheiro</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1929"/>
+        <source>An error occurred when saving &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Error: %2</source>
+        <translation>Ocorreu um erro ao guardar &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Erro: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1935"/>
+        <source>Zoom: %1%</source>
+        <translation>Zoom: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="2102"/>
+        <source>No updates are available at this time.</source>
+        <translation>De momento, não há atualizações disponíveis.</translation>
+    </message>
+</context>
+<context>
     <name>PreferencesDialog</name>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="14"/>
-      <source>Preferences</source>
-      <translation>Preferências</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="14"/>
+        <source>Preferences</source>
+        <translation>Preferências</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="37"/>
-      <source>Show menu bar</source>
-      <translation>Exibir a barra de menus</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="37"/>
+        <source>Show menu bar</source>
+        <translation>Mostrar barra de menus</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="44"/>
-      <source>Show toolbar</source>
-      <translation>Exibir a barra de ferramentas</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="44"/>
+        <source>Show toolbar</source>
+        <translation>Mostrar barra de ferramentas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="51"/>
-      <source>Show status bar</source>
-      <translation>Exibir a barra de estado</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="51"/>
+        <source>Show status bar</source>
+        <translation>Mostrar barra de estado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="58"/>
-      <source>Restore previous session</source>
-      <translation>Restaurar a sessão anterior</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="58"/>
+        <source>Restore previous session</source>
+        <translation>Restaurar a sessão anterior</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="70"/>
-      <source>Unsaved changes</source>
-      <translation>As alterações não foram salvas</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="70"/>
+        <source>Unsaved changes</source>
+        <translation>Alterações não guardadas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="77"/>
-      <source>Temporary files</source>
-      <translation>Arquivos temporários</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="77"/>
+        <source>Temporary files</source>
+        <translation>Ficheiros temporários</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="89"/>
-      <source>Recenter find/replace dialog when opened</source>
-      <translation>Centralizar a janela de pesquisar/substituir quando for aberta</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="89"/>
+        <source>Recenter find/replace dialog when opened</source>
+        <translation>Recolocar a janela localizar/substituir quando aberta</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="96"/>
-      <source>Combine search results</source>
-      <translation>Combinar os resultados da pesquisa</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="96"/>
+        <source>Combine search results</source>
+        <translation>Combinar resultados de pesquisa</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="114"/>
-      <source>Translation:</source>
-      <translation>Tradução:</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="114"/>
+        <source>Translation:</source>
+        <translation>Tradução:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="123"/>
-      <source>Exit on last tab closed</source>
-      <translation>Sair quando a última aba for fechada</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="123"/>
+        <source>Exit on last tab closed</source>
+        <translation>Sair no último separador fechado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="132"/>
-      <source>Default Font</source>
-      <translation>Tipo de letra padrão</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="132"/>
+        <source>Default Font</source>
+        <translation>Tipo de letra predefinida</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="138"/>
-      <source>Font</source>
-      <translation>Tipo de letra</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="138"/>
+        <source>Font</source>
+        <translation>Tipo de letra</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="148"/>
-      <source>Font Size</source>
-      <translation>Tamanho do tipo de letra</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="148"/>
+        <source>Font Size</source>
+        <translation>Tamanho do tipo de letra</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="155"/>
-      <source>pt</source>
-      <translation>pt</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="155"/>
+        <source>pt</source>
+        <translation>pt</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="188"/>
-      <source>Default Line Endings</source>
-      <translation>Finais de linha padrão</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="188"/>
+        <source>Default Line Endings</source>
+        <translation>Finais de linha predefinidos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="200"/>
-      <source>Highlight URLs</source>
-      <translation type="unfinished">Highlight URLs</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="200"/>
+        <source>Highlight URLs</source>
+        <translation>Destacar URLs</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="207"/>
-      <source>Show Line Numbers</source>
-      <translation type="unfinished">Show Line Numbers</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="207"/>
+        <source>Show Line Numbers</source>
+        <translation>Mostrar números de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="214"/>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="122"/>
-      <source>Default Directory</source>
-      <translation type="unfinished">Default Directory</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="214"/>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="122"/>
+        <source>Default Directory</source>
+        <translation>Diretório predefinido</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="220"/>
-      <source>Follow Current Document</source>
-      <translation type="unfinished">Follow Current Document</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="220"/>
+        <source>Follow Current Document</source>
+        <translation>Seguir o documento atual</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="227"/>
-      <source>Last Used Directory</source>
-      <translation type="unfinished">Last Used Directory</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="227"/>
+        <source>Last Used Directory</source>
+        <translation>Último diretório utilizado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="246"/>
-      <source>...</source>
-      <translation>...</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="246"/>
+        <source>...</source>
+        <translation>...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="277"/>
-      <source>TextLabel</source>
-      <translation>Legenda</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="277"/>
+        <source>TextLabel</source>
+        <translation>Legenda</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="289"/>
-      <source>An application restart is required to apply certain settings.</source>
-      <translation>É necessário reiniciar o programa para aplicar algumas configurações.</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="289"/>
+        <source>An application restart is required to apply certain settings.</source>
+        <translation>É necessário reiniciar a aplicação para aplicar determinadas definições.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
-      <source>Warning</source>
-      <translation>Aviso</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
+        <source>Warning</source>
+        <translation>Aviso</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
-      <source>This feature is experimental and it should not be considered safe for critically important work. It may lead to possible data loss. Use at your own risk.</source>
-      <translation>Esta funcionalidade é experimental e não deve ser considerada segura para os trabalhos de grande importância. Pode ocorrer a perda dos dados. Utilize-a por sua conta e risco.</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
+        <source>This feature is experimental and it should not be considered safe for critically important work. It may lead to possible data loss. Use at your own risk.</source>
+        <translation>Esta funcionalidade é experimental e não deve ser considerada segura para trabalhos de importância crítica. Pode levar a uma possível perda de dados. Utilize-a por sua conta e risco.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="85"/>
-      <source>System Default</source>
-      <translation>Padrão do sistema operacional</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="85"/>
+        <source>System Default</source>
+        <translation>Predefinição do sistema</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="86"/>
-      <source>Windows (CR LF)</source>
-      <translation>Windows (CR LF)</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="86"/>
+        <source>Windows (CR LF)</source>
+        <translation>Windows (CR LF)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="87"/>
-      <source>Linux (LF)</source>
-      <translation>GNU/Linux (LF)</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="87"/>
+        <source>Linux (LF)</source>
+        <translation>Linux (LF)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="88"/>
-      <source>Macintosh (CR)</source>
-      <translation>Macintosh (CR)</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="88"/>
+        <source>Macintosh (CR)</source>
+        <translation>Macintosh (CR)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="185"/>
-      <source>&lt;System Default&gt;</source>
-      <translation>&lt;Padrão do sistema operacional&gt;</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="185"/>
+        <source>&lt;System Default&gt;</source>
+        <translation>&lt;System Default&gt;</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>QuickFindWidget</name>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="17"/>
-      <source>Frame</source>
-      <translation>Moldura</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="17"/>
+        <source>Frame</source>
+        <translation>Moldura</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="32"/>
-      <source>Find...</source>
-      <translation>Localizar...</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="32"/>
+        <source>Find...</source>
+        <translation>Localizar...</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="44"/>
-      <source>Match case</source>
-      <translation>Corresponder as letras minúsculas/maiúsculas</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="44"/>
+        <source>Match case</source>
+        <translation>Corresponder minúsculas/maiúsculas</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="47"/>
-      <source>Aa</source>
-      <translation>Aa</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="47"/>
+        <source>Aa</source>
+        <translation>Aa</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="57"/>
-      <source>Match whole word</source>
-      <translation>Corresponder a palavra inteira</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="57"/>
+        <source>Match whole word</source>
+        <translation>Corresponder palavra inteira</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="60"/>
-      <source>|A|</source>
-      <translation>|A|</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="60"/>
+        <source>|A|</source>
+        <translation>|A|</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="70"/>
-      <source>Use regular expression</source>
-      <translation>Utilizar uma expressão regular</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="70"/>
+        <source>Use regular expression</source>
+        <translation>Usar expressão regular</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="73"/>
-      <source>. *</source>
-      <translation>. *</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="73"/>
+        <source>. *</source>
+        <translation>. *</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="76"/>
-      <source>Alt+E</source>
-      <translation>Alt+E</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="76"/>
+        <source>Alt+E</source>
+        <translation>Alt+E</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.cpp" line="238"/>
-      <source>%L1/%L2</source>
-      <translation>%L1/%L2</translation>
+        <location filename="../src/widgets/QuickFindWidget.cpp" line="238"/>
+        <source>%L1/%L2</source>
+        <translation>%L1/%L2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>SearchResultsDock</name>
     <message>
-      <location filename="../src/docks/SearchResultsDock.ui" line="14"/>
-      <source>Search Results</source>
-      <translation>Resultados da pesquisa</translation>
+        <location filename="../src/docks/SearchResultsDock.ui" line="14"/>
+        <source>Search Results</source>
+        <translation>Resultados da pesquisa</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.ui" line="38"/>
-      <source>Copy Results to Clipboard</source>
-      <translation>Copiar os resultados para a área de transferência</translation>
+        <location filename="../src/docks/SearchResultsDock.ui" line="38"/>
+        <source>Copy Results to Clipboard</source>
+        <translation>Copiar resultados para a área de transferência</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.cpp" line="57"/>
-      <source>Collapse All</source>
-      <translation>Recolher tudo</translation>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="57"/>
+        <source>Collapse All</source>
+        <translation>Recolher tudo</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.cpp" line="58"/>
-      <source>Expand All</source>
-      <translation>Expandir tudo</translation>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="58"/>
+        <source>Expand All</source>
+        <translation>Expandir tudo</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.cpp" line="60"/>
-      <source>Delete Entry</source>
-      <translation>Apagar a entrada</translation>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="60"/>
+        <source>Delete Entry</source>
+        <translation>Eliminar entrada</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.cpp" line="62"/>
-      <source>Delete All</source>
-      <translation>Apagar tudo</translation>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="62"/>
+        <source>Delete All</source>
+        <translation>Eliminar tudo</translation>
     </message>
-  </context>
+</context>
 </TS>

--- a/i18n/NotepadNext_pt.ts
+++ b/i18n/NotepadNext_pt.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="pt" sourcelanguage="en_US">
+<TS version="2.1" language="pt" sourcelanguage="en">
 <context>
     <name>ColumnEditorDialog</name>
     <message>

--- a/i18n/NotepadNext_pt_PT.ts
+++ b/i18n/NotepadNext_pt_PT.ts
@@ -1,2327 +1,2327 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="pt_PT" sourcelanguage="en">
-  <context>
+<TS version="2.1" language="pt_PT" sourcelanguage="en_US">
+<context>
     <name>ColumnEditorDialog</name>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="20"/>
-      <source>Column Mode</source>
-      <translation>Modo de coluna</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="20"/>
+        <source>Column Mode</source>
+        <translation>Modo de coluna</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="32"/>
-      <source>Text</source>
-      <translation>Texto</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="32"/>
+        <source>Text</source>
+        <translation>Texto</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="47"/>
-      <source>Numbers</source>
-      <translation>Números</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="47"/>
+        <source>Numbers</source>
+        <translation>Números</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="59"/>
-      <source>Start:</source>
-      <translation>Iniciar:</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="59"/>
+        <source>Start:</source>
+        <translation>Iniciar:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/ColumnEditorDialog.ui" line="76"/>
-      <source>Step:</source>
-      <translation>Etapa:</translation>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="76"/>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DebugLogDock</name>
     <message>
-      <location filename="../src/docks/DebugLogDock.ui" line="14"/>
-      <source>Debug Log</source>
-      <translation>Registo de depuração</translation>
+        <location filename="../src/docks/DebugLogDock.ui" line="14"/>
+        <source>Debug Log</source>
+        <translation>Registo de depuração</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>EditorInfoStatusBar</name>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="100"/>
-      <source>Length: %L1    Lines: %L2</source>
-      <translation>Comprimento: %L1    Linhas: %L2</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="100"/>
+        <source>Length: %L1    Lines: %L2</source>
+        <translation>Comprimento: %L1    Linhas: %L2</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="109"/>
-      <source>Sel: N/A</source>
-      <translation>Sel: N/D</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="109"/>
+        <source>Sel: N/A</source>
+        <translation>Sel: N/D</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="119"/>
-      <source>Sel: %L1 | %L2</source>
-      <translation>Sel: %L1 | %L2</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="119"/>
+        <source>Sel: %L1 | %L2</source>
+        <translation>Sel: %L1 | %L2</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="123"/>
-      <source>Ln: %L1    Col: %L2    </source>
-      <translation>Ln: %L1    Col: %L2    </translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="123"/>
+        <source>Ln: %L1    Col: %L2    </source>
+        <translation>Ln: %L1    Col: %L2    </translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="139"/>
-      <source>Macintosh (CR)</source>
-      <translation>Macintosh (CR)</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="139"/>
+        <source>Macintosh (CR)</source>
+        <translation>Macintosh (CR)</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="142"/>
-      <source>Windows (CR LF)</source>
-      <translation>Windows (CR LF)</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="142"/>
+        <source>Windows (CR LF)</source>
+        <translation>Windows (CR LF)</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="145"/>
-      <source>Unix (LF)</source>
-      <translation>Unix (LF)</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="145"/>
+        <source>Unix (LF)</source>
+        <translation>Unix (LF)</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="155"/>
-      <source>ANSI</source>
-      <translation>ANSI</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="155"/>
+        <source>ANSI</source>
+        <translation>ANSI</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="159"/>
-      <source>UTF-8</source>
-      <translation>UTF-8</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="159"/>
+        <source>UTF-8</source>
+        <translation>UTF-8</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="160"/>
-      <source>UTF-8 BOM</source>
-      <translation type="unfinished"/>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="160"/>
+        <source>UTF-8 BOM</source>
+        <translation>UTF-8 BOM</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="161"/>
-      <source>UTF-16LE BOM</source>
-      <translation type="unfinished"/>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="161"/>
+        <source>UTF-16LE BOM</source>
+        <translation>UTF-16LE BOM</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="162"/>
-      <source>UTF-16BE BOM</source>
-      <translation type="unfinished"/>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="162"/>
+        <source>UTF-16BE BOM</source>
+        <translation>UTF-16BE BOM</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="178"/>
-      <source>OVR</source>
-      <extracomment>This is a short abbreviation to indicate characters will be replaced when typing</extracomment>
-      <translation>SUB</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="178"/>
+        <source>OVR</source>
+        <extracomment>This is a short abbreviation to indicate characters will be replaced when typing</extracomment>
+        <translation>SUB</translation>
     </message>
     <message>
-      <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="182"/>
-      <source>INS</source>
-      <extracomment>This is a short abbreviation to indicate characters will be inserted when typing</extracomment>
-      <translation>INS</translation>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="182"/>
+        <source>INS</source>
+        <extracomment>This is a short abbreviation to indicate characters will be inserted when typing</extracomment>
+        <translation>INS</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>EditorInspectorDock</name>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.ui" line="14"/>
-      <source>Editor Inspector</source>
-      <translation>Inpetor de editor</translation>
+        <location filename="../src/docks/EditorInspectorDock.ui" line="14"/>
+        <source>Editor Inspector</source>
+        <translation>Inpetor de editor</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="36"/>
-      <source>Position Information</source>
-      <translation>Informação da posição</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="36"/>
+        <source>Position Information</source>
+        <translation>Informação da posição</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="39"/>
-      <source>Current Position</source>
-      <translation>Posição atual</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="39"/>
+        <source>Current Position</source>
+        <translation>Posição atual</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="40"/>
-      <source>Current Position (x, y)</source>
-      <translation>Posição atual (x, y)</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="40"/>
+        <source>Current Position (x, y)</source>
+        <translation>Posição atual (x, y)</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="41"/>
-      <source>Column</source>
-      <translation>Coluna</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="41"/>
+        <source>Column</source>
+        <translation>Coluna</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="43"/>
-      <source>Current Style</source>
-      <translation>Estilo atual</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="43"/>
+        <source>Current Style</source>
+        <translation>Estilo atual</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="44"/>
-      <source>Current Line</source>
-      <translation>Linha atual</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="44"/>
+        <source>Current Line</source>
+        <translation>Linha atual</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="45"/>
-      <source>Line Length</source>
-      <translation>Comprimento da linha</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="45"/>
+        <source>Line Length</source>
+        <translation>Comprimento da linha</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="46"/>
-      <source>Line End Position</source>
-      <translation>Posição final da linha</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="46"/>
+        <source>Line End Position</source>
+        <translation>Posição final da linha</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="47"/>
-      <source>Line Indentation</source>
-      <translation>Indentação de linha</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="47"/>
+        <source>Line Indentation</source>
+        <translation>Indentação de linha</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="48"/>
-      <source>Line Indent Position</source>
-      <translation>Posição de indentação de linha</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="48"/>
+        <source>Line Indent Position</source>
+        <translation>Posição de indentação de linha</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="52"/>
-      <source>Selection Information</source>
-      <translation>Informação de seleção</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="52"/>
+        <source>Selection Information</source>
+        <translation>Informação de seleção</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="55"/>
-      <source>Mode</source>
-      <translation>Modo</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="55"/>
+        <source>Mode</source>
+        <translation>Modo</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="69"/>
-      <source>Is Rectangle</source>
-      <translation>É retângulo</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="69"/>
+        <source>Is Rectangle</source>
+        <translation>É retângulo</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="70"/>
-      <source>Selection Empty</source>
-      <translation>Seleção vazia</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="70"/>
+        <source>Selection Empty</source>
+        <translation>Seleção vazia</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="71"/>
-      <source>Main Selection</source>
-      <translation>Seleção principal</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="71"/>
+        <source>Main Selection</source>
+        <translation>Seleção principal</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="72"/>
-      <source># of Selections</source>
-      <translation># de seleções</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="72"/>
+        <source># of Selections</source>
+        <translation># de seleções</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="75"/>
-      <source>Multiple Selections</source>
-      <translation>Seleções múltiplas</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="75"/>
+        <source>Multiple Selections</source>
+        <translation>Seleções múltiplas</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="80"/>
-      <source>Document Information</source>
-      <translation>Informação sobre o documento</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="80"/>
+        <source>Document Information</source>
+        <translation>Informação sobre o documento</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="83"/>
-      <source>Length</source>
-      <translation>Comprimento</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="83"/>
+        <source>Length</source>
+        <translation>Comprimento</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="84"/>
-      <source>Line Count</source>
-      <translation>Contagem de linhas</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="84"/>
+        <source>Line Count</source>
+        <translation>Contagem de linhas</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="88"/>
-      <source>View Information</source>
-      <translation>Ver informação</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="88"/>
+        <source>View Information</source>
+        <translation>Ver informação</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="91"/>
-      <source>Lines on Screen</source>
-      <translation>Linhas no ecrã</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="91"/>
+        <source>Lines on Screen</source>
+        <translation>Linhas no ecrã</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="92"/>
-      <source>First Visible Line</source>
-      <translation>Primeira linha visível</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="92"/>
+        <source>First Visible Line</source>
+        <translation>Primeira linha visível</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="93"/>
-      <source>X Offset</source>
-      <translation>Desvio X</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="93"/>
+        <source>X Offset</source>
+        <translation>Desvio X</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="97"/>
-      <source>Fold Information</source>
-      <translation>Informações sobre a dobra</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="97"/>
+        <source>Fold Information</source>
+        <translation>Informações sobre a dobra</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="100"/>
-      <source>Visible From Doc Line</source>
-      <translation>Visível a partir da linha Doc</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="100"/>
+        <source>Visible From Doc Line</source>
+        <translation>Visível a partir da linha Doc</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="101"/>
-      <source>Doc Line From Visible</source>
-      <translation>Linha Doc a partir de Visível</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="101"/>
+        <source>Doc Line From Visible</source>
+        <translation>Linha Doc a partir de Visível</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="102"/>
-      <source>Fold Level</source>
-      <translation>Nível de dobra</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="102"/>
+        <source>Fold Level</source>
+        <translation>Nível de dobra</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="103"/>
-      <source>Is Fold Header</source>
-      <translation>É cabeçalho de dobra</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="103"/>
+        <source>Is Fold Header</source>
+        <translation>É cabeçalho de dobra</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="104"/>
-      <source>Fold Parent</source>
-      <translation>Dobrar acima</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="104"/>
+        <source>Fold Parent</source>
+        <translation>Dobrar acima</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="105"/>
-      <source>Last Child</source>
-      <translation>Último abaixo</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="105"/>
+        <source>Last Child</source>
+        <translation>Último abaixo</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="106"/>
-      <source>Contracted Fold Next</source>
-      <translation>Dobra contratada Seguinte</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="106"/>
+        <source>Contracted Fold Next</source>
+        <translation>Dobra contratada Seguinte</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="173"/>
-      <source>Caret</source>
-      <translation>Carácter</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="173"/>
+        <source>Caret</source>
+        <translation>Carácter</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="177"/>
-      <source>Anchor</source>
-      <translation>Ancoragem</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="177"/>
+        <source>Anchor</source>
+        <translation>Ancoragem</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="181"/>
-      <source>Caret Virtual Space</source>
-      <translation>Espaço virtual do carácter</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="181"/>
+        <source>Caret Virtual Space</source>
+        <translation>Espaço virtual do carácter</translation>
     </message>
     <message>
-      <location filename="../src/docks/EditorInspectorDock.cpp" line="185"/>
-      <source>Anchor Virtual Space</source>
-      <translation>Espaço virtual da ancoragem</translation>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="185"/>
+        <source>Anchor Virtual Space</source>
+        <translation>Espaço virtual da ancoragem</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>FileList</name>
     <message>
-      <location filename="../src/docks/FileListDock.ui" line="14"/>
-      <source>File List</source>
-      <translation>Lista de ficheiros</translation>
+        <location filename="../src/docks/FileListDock.ui" line="14"/>
+        <source>File List</source>
+        <translation>Lista de ficheiros</translation>
     </message>
     <message>
-      <location filename="../src/docks/FileListDock.ui" line="51"/>
-      <source>...</source>
-      <translation>...</translation>
+        <location filename="../src/docks/FileListDock.ui" line="51"/>
+        <source>...</source>
+        <translation>...</translation>
     </message>
     <message>
-      <location filename="../src/docks/FileListDock.ui" line="90"/>
-      <source>Sort by File Name</source>
-      <translation>Ordenar por nome de ficheiro</translation>
+        <location filename="../src/docks/FileListDock.ui" line="90"/>
+        <source>Sort by File Name</source>
+        <translation>Ordenar por nome de ficheiro</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>FindReplaceDialog</name>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="20"/>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="247"/>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="59"/>
-      <source>Find</source>
-      <translation>Localizar</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="20"/>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="247"/>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="59"/>
+        <source>Find</source>
+        <translation>Localizar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="69"/>
-      <source>Search Mode</source>
-      <translation>Modo de pesquisa</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="69"/>
+        <source>Search Mode</source>
+        <translation>Modo de pesquisa</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="90"/>
-      <source>&amp;Normal</source>
-      <translation>&amp;Normal</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="90"/>
+        <source>&amp;Normal</source>
+        <translation>&amp;Normal</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="106"/>
-      <source>E&amp;xtended (\n, \r, \t, \0, \x...)</source>
-      <translation>A&amp;largada (\n, \r, \t, \0, \x...)</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="106"/>
+        <source>E&amp;xtended (\n, \r, \t, \0, \x...)</source>
+        <translation>A&amp;largada (\n, \r, \t, \0, \x...)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="124"/>
-      <source>Re&amp;gular expression</source>
-      <translation>Expressão re&amp;gular</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="124"/>
+        <source>Re&amp;gular expression</source>
+        <translation>Expressão re&amp;gular</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="140"/>
-      <source>&amp;. matches newline</source>
-      <translation>&amp;. corresponde a uma nova linha</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="140"/>
+        <source>&amp;. matches newline</source>
+        <translation>&amp;. corresponde a uma nova linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="179"/>
-      <source>Transparenc&amp;y</source>
-      <translation>Transparênc&amp;ia</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="179"/>
+        <source>Transparenc&amp;y</source>
+        <translation>Transparênc&amp;ia</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="200"/>
-      <source>On losing focus</source>
-      <translation>Sobre perder o foco</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="200"/>
+        <source>On losing focus</source>
+        <translation>Sobre perder o foco</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="210"/>
-      <source>Always</source>
-      <translation>Sempre</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="210"/>
+        <source>Always</source>
+        <translation>Sempre</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="260"/>
-      <source>Coun&amp;t</source>
-      <translation>Con&amp;tar</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="260"/>
+        <source>Coun&amp;t</source>
+        <translation>Con&amp;tar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="270"/>
-      <source>&amp;Replace</source>
-      <translation>&amp;Substituir</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="270"/>
+        <source>&amp;Replace</source>
+        <translation>&amp;Substituir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="277"/>
-      <source>Replace &amp;All</source>
-      <translation>Substituir &amp;tudo</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="277"/>
+        <source>Replace &amp;All</source>
+        <translation>Substituir &amp;tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="284"/>
-      <source>Replace All in &amp;Opened Documents</source>
-      <translation>Substituir tudo em documentos &amp;abertos</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="284"/>
+        <source>Replace All in &amp;Opened Documents</source>
+        <translation>Substituir tudo em documentos &amp;abertos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="291"/>
-      <source>Find All in All &amp;Opened Documents</source>
-      <translation>Localizar tudo em todos os documentos &amp;abertos</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="291"/>
+        <source>Find All in All &amp;Opened Documents</source>
+        <translation>Localizar tudo em todos os documentos &amp;abertos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="301"/>
-      <source>Find All in Current Document</source>
-      <translation>Localizar tudo no documento atual</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="301"/>
+        <source>Find All in Current Document</source>
+        <translation>Localizar tudo no documento atual</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="311"/>
-      <source>Close</source>
-      <translation>Fechar</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="311"/>
+        <source>Close</source>
+        <translation>Fechar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="367"/>
-      <source>&amp;Find:</source>
-      <translation>&amp;Localizar:</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="367"/>
+        <source>&amp;Find:</source>
+        <translation>&amp;Localizar:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="399"/>
-      <source>Replace:</source>
-      <translation>Substituir:</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="399"/>
+        <source>Replace:</source>
+        <translation>Substituir:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="445"/>
-      <source>Backward direction</source>
-      <translation>Sentido inverso</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="445"/>
+        <source>Backward direction</source>
+        <translation>Sentido inverso</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="452"/>
-      <source>Match &amp;whole word only</source>
-      <translation>Corresponder apenas à palavra &amp;inteira</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="452"/>
+        <source>Match &amp;whole word only</source>
+        <translation>Corresponder apenas à palavra &amp;inteira</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="459"/>
-      <source>Match &amp;case</source>
-      <translation>Corresponder &amp;minúsculas/maiúsculas</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="459"/>
+        <source>Match &amp;case</source>
+        <translation>Corresponder &amp;minúsculas/maiúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.ui" line="466"/>
-      <source>Wra&amp;p Around</source>
-      <translation>En&amp;volvente</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="466"/>
+        <source>Wra&amp;p Around</source>
+        <translation>En&amp;volvente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="60"/>
-      <source>Replace</source>
-      <translation>Substituir</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="60"/>
+        <source>Replace</source>
+        <translation>Substituir</translation>
     </message>
     <message numerus="yes">
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="144"/>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="341"/>
-      <source>Replaced %Ln matches</source>
-      <translation>
-        <numerusform>Substituído %Ln  correspondência</numerusform>
-        <numerusform>Substituído %Ln  correspondências</numerusform>
-      </translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="144"/>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="341"/>
+        <source>Replaced %Ln matches</source>
+        <translation>
+            <numerusform>Substituído %Ln  correspondência</numerusform>
+            <numerusform>Substituído %Ln  correspondências</numerusform>
+        </translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="239"/>
-      <source>The end of the document has been reached. Found 1st occurrence from the top.</source>
-      <translation>O fim do documento foi atingido. Localizada a 1ª ocorrência a partir do topo.</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="239"/>
+        <source>The end of the document has been reached. Found 1st occurrence from the top.</source>
+        <translation>O fim do documento foi atingido. Localizada a 1ª ocorrência a partir do topo.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="250"/>
-      <source>No matches found.</source>
-      <translation>Não foram localizadas correspondências.</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="250"/>
+        <source>No matches found.</source>
+        <translation>Não foram localizadas correspondências.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="313"/>
-      <source>1 occurrence was replaced</source>
-      <translation>1 ocorrência foi substituída</translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="313"/>
+        <source>1 occurrence was replaced</source>
+        <translation>1 ocorrência foi substituída</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="322"/>
-      <source>No more occurrences were found</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="322"/>
+        <source>No more occurrences were found</source>
+        <translation>Não foram encontradas mais ocorrências</translation>
     </message>
     <message numerus="yes">
-      <location filename="../src/dialogs/FindReplaceDialog.cpp" line="352"/>
-      <source>Found %Ln matches</source>
-      <translation>
-        <numerusform>Localizado %Ln correspondência</numerusform>
-        <numerusform>Localizado %Ln correspondências</numerusform>
-      </translation>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="352"/>
+        <source>Found %Ln matches</source>
+        <translation>
+            <numerusform>Localizado %Ln correspondência</numerusform>
+            <numerusform>Localizado %Ln correspondências</numerusform>
+        </translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>FolderAsWorkspaceDock</name>
     <message>
-      <location filename="../src/docks/FolderAsWorkspaceDock.ui" line="14"/>
-      <source>Folder as Workspace</source>
-      <translation>Pasta como área de trabalho</translation>
+        <location filename="../src/docks/FolderAsWorkspaceDock.ui" line="14"/>
+        <source>Folder as Workspace</source>
+        <translation>Pasta como área de trabalho</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>LanguageInspectorDock</name>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="14"/>
-      <source>Language Inspector</source>
-      <translation>Inspetor de linguagem</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="14"/>
+        <source>Language Inspector</source>
+        <translation>Inspetor de linguagem</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="56"/>
-      <source>Language:</source>
-      <translation>Linguagem:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="56"/>
+        <source>Language:</source>
+        <translation>Linguagem:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="70"/>
-      <source>Lexer:</source>
-      <translation>Lexer:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="70"/>
+        <source>Lexer:</source>
+        <translation>Lexer:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="86"/>
-      <source>Properties:</source>
-      <translation>Propriedades:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="86"/>
+        <source>Properties:</source>
+        <translation>Propriedades:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="100"/>
-      <source>Property</source>
-      <translation>Propriedade</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="100"/>
+        <source>Property</source>
+        <translation>Propriedade</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="105"/>
-      <source>Type</source>
-      <translation>Tipo</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="105"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="110"/>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="151"/>
-      <source>Description</source>
-      <translation>Descrição</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="110"/>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="151"/>
+        <source>Description</source>
+        <translation>Descrição</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="115"/>
-      <source>Value</source>
-      <translation>Valor</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="115"/>
+        <source>Value</source>
+        <translation>Valor</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="123"/>
-      <source>Keywords:</source>
-      <translation>Palavras-chave:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="123"/>
+        <source>Keywords:</source>
+        <translation>Palavras-chave:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="146"/>
-      <source>ID</source>
-      <translation>ID</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="146"/>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="159"/>
-      <source>Styles:</source>
-      <translation>Estilos:</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="159"/>
+        <source>Styles:</source>
+        <translation>Estilos:</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.ui" line="166"/>
-      <source>TextLabel</source>
-      <translation>Legenda do texto</translation>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="166"/>
+        <source>TextLabel</source>
+        <translation>Legenda do texto</translation>
     </message>
     <message>
-      <location filename="../src/docks/LanguageInspectorDock.cpp" line="146"/>
-      <source>Position %1 Style %2</source>
-      <translation>Posição %1 Estilo %2</translation>
+        <location filename="../src/docks/LanguageInspectorDock.cpp" line="146"/>
+        <source>Position %1 Style %2</source>
+        <translation>Posição %1 Estilo %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>LuaConsoleDock</name>
     <message>
-      <location filename="../src/docks/LuaConsoleDock.ui" line="17"/>
-      <source>Lua Console</source>
-      <translation>Consola Lua</translation>
+        <location filename="../src/docks/LuaConsoleDock.ui" line="17"/>
+        <source>Lua Console</source>
+        <translation>Consola Lua</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MacroEditorDialog</name>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="14"/>
-      <source>Macro Editor</source>
-      <translation>Editor de macros</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="14"/>
+        <source>Macro Editor</source>
+        <translation>Editor de macros</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="48"/>
-      <source>Name</source>
-      <translation>Nome</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="48"/>
+        <source>Name</source>
+        <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="58"/>
-      <source>Shortcut</source>
-      <translation>Atalho</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="58"/>
+        <source>Shortcut</source>
+        <translation>Atalho</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="67"/>
-      <source>Steps:</source>
-      <translation>Etapas:</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="67"/>
+        <source>Steps:</source>
+        <translation>Etapas:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="95"/>
-      <source>Insert Macro Step</source>
-      <translation>Inserir etapa da macro</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="95"/>
+        <source>Insert Macro Step</source>
+        <translation>Inserir etapa da macro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="110"/>
-      <source>Delete Selected Macro Step</source>
-      <translation>Eliminar a etapa da macro selecionada</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="110"/>
+        <source>Delete Selected Macro Step</source>
+        <translation>Eliminar a etapa da macro selecionada</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="125"/>
-      <source>Move Selected Macro Step Up</source>
-      <translation>Mover a etapa da macro selecionada para cima</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="125"/>
+        <source>Move Selected Macro Step Up</source>
+        <translation>Mover a etapa da macro selecionada para cima</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="140"/>
-      <source>Move Selected Macro Step Down</source>
-      <translation>Mover a etapa da macro selecionada para baixo</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="140"/>
+        <source>Move Selected Macro Step Down</source>
+        <translation>Mover a etapa da macro selecionada para baixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="176"/>
-      <source>Copy Selected Macro</source>
-      <translation>Copiar a macro selecionada</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="176"/>
+        <source>Copy Selected Macro</source>
+        <translation>Copiar a macro selecionada</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.ui" line="191"/>
-      <source>Delete Selected Macro</source>
-      <translation>Eliminar a macro selecionada</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="191"/>
+        <source>Delete Selected Macro</source>
+        <translation>Eliminar a macro selecionada</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
-      <source>Delete Macro</source>
-      <translation>Eliminar macro</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
+        <source>Delete Macro</source>
+        <translation>Eliminar macro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
-      <source>Are you sure you want to delete &lt;b&gt;%1&lt;/b&gt;?</source>
-      <translation>Tem a certeza de que pretende eliminar &lt;b&gt;%1&lt;/b&gt;?</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
+        <source>Are you sure you want to delete &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Tem a certeza de que pretende eliminar &lt;b&gt;%1&lt;/b&gt;?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroEditorDialog.cpp" line="150"/>
-      <source>(Copy)</source>
-      <translation>(Copiar)</translation>
+        <location filename="../src/dialogs/MacroEditorDialog.cpp" line="150"/>
+        <source>(Copy)</source>
+        <translation>(Copiar)</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MacroRunDialog</name>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="14"/>
-      <source>Run a Macro Multiple Times</source>
-      <translation>Executar uma macro várias vezes</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="14"/>
+        <source>Run a Macro Multiple Times</source>
+        <translation>Executar uma macro várias vezes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="31"/>
-      <source>Macro:</source>
-      <translation>Macro:</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="31"/>
+        <source>Macro:</source>
+        <translation>Macro:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="56"/>
-      <source>Run Until End of File</source>
-      <translation>Executar até ao fim do ficheiro</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="56"/>
+        <source>Run Until End of File</source>
+        <translation>Executar até ao fim do ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="63"/>
-      <source>Execute...</source>
-      <translation>Executar...</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="63"/>
+        <source>Execute...</source>
+        <translation>Executar...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="116"/>
-      <source>times</source>
-      <translation>vezes</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="116"/>
+        <source>times</source>
+        <translation>vezes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="166"/>
-      <source>Run</source>
-      <translation>Executar</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="166"/>
+        <source>Run</source>
+        <translation>Executar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroRunDialog.ui" line="173"/>
-      <source>Cancel</source>
-      <translation>Cancelar</translation>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="173"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MacroSaveDialog</name>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="14"/>
-      <source>Save Macro</source>
-      <translation>Guardar macro</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="14"/>
+        <source>Save Macro</source>
+        <translation>Guardar macro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="25"/>
-      <source>Name:</source>
-      <translation>Nome:</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="25"/>
+        <source>Name:</source>
+        <translation>Nome:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="39"/>
-      <source>Shortcut:</source>
-      <translation>Atalho:</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="39"/>
+        <source>Shortcut:</source>
+        <translation>Atalho:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="82"/>
-      <source>OK</source>
-      <translation>OK</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="82"/>
+        <source>OK</source>
+        <translation>OK</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MacroSaveDialog.ui" line="89"/>
-      <source>Cancel</source>
-      <translation>Cancelar</translation>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="89"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MacroStepTableModel</name>
     <message>
-      <location filename="../src/MacroStepTableModel.cpp" line="34"/>
-      <source>Name</source>
-      <translation>Nome</translation>
+        <location filename="../src/MacroStepTableModel.cpp" line="34"/>
+        <source>Name</source>
+        <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../src/MacroStepTableModel.cpp" line="36"/>
-      <source>Text</source>
-      <translation>Texto</translation>
+        <location filename="../src/MacroStepTableModel.cpp" line="36"/>
+        <source>Text</source>
+        <translation>Texto</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="17"/>
-      <source>Notepad Next[*]</source>
-      <translation>Notepad Next[*]</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="17"/>
+        <source>Notepad Next[*]</source>
+        <translation>Notepad Next[*]</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="33"/>
-      <source>+</source>
-      <translation>+</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="33"/>
+        <source>+</source>
+        <translation>+</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="48"/>
-      <source>&amp;File</source>
-      <translation>&amp;Ficheiro</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="48"/>
+        <source>&amp;File</source>
+        <translation>&amp;Ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="52"/>
-      <source>Close More</source>
-      <translation>Fechar mais</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="52"/>
+        <source>Close More</source>
+        <translation>Fechar mais</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="60"/>
-      <source>&amp;Recent Files</source>
-      <translation>Ficheiros &amp;recentes</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="60"/>
+        <source>&amp;Recent Files</source>
+        <translation>Ficheiros &amp;recentes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="69"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1439"/>
-      <source>Export As</source>
-      <translation>Exportar como</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="69"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1439"/>
+        <source>Export As</source>
+        <translation>Exportar como</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="97"/>
-      <source>&amp;Edit</source>
-      <translation>&amp;Editar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="97"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="101"/>
-      <source>Copy More</source>
-      <translation>Copiar mais</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="101"/>
+        <source>Copy More</source>
+        <translation>Copiar mais</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="109"/>
-      <source>Indent</source>
-      <translation>Indentação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="109"/>
+        <source>Indent</source>
+        <translation>Indentação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="116"/>
-      <source>EOL Conversion</source>
-      <translation>Conversão de fim de linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="116"/>
+        <source>EOL Conversion</source>
+        <translation>Conversão de fim de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="124"/>
-      <source>Convert Case</source>
-      <translation>Converter maiúsculas/minúsculas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="124"/>
+        <source>Convert Case</source>
+        <translation>Converter maiúsculas/minúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="131"/>
-      <source>Line Operations</source>
-      <translation>Operações de linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="131"/>
+        <source>Line Operations</source>
+        <translation>Operações de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="154"/>
-      <source>Comment/Uncomment</source>
-      <translation>Comentar/Não comentar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="154"/>
+        <source>Comment/Uncomment</source>
+        <translation>Comentar/Não comentar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="162"/>
-      <source>Copy As</source>
-      <translation>Copiar como</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="162"/>
+        <source>Copy As</source>
+        <translation>Copiar como</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="169"/>
-      <source>Encoding/Decoding</source>
-      <translation>Codificação/Decodificação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="169"/>
+        <source>Encoding/Decoding</source>
+        <translation>Codificação/Decodificação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="200"/>
-      <source>Search</source>
-      <translation>Procurar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="200"/>
+        <source>Search</source>
+        <translation>Procurar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="204"/>
-      <source>Bookmarks</source>
-      <translation>Marcadores</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="204"/>
+        <source>Bookmarks</source>
+        <translation>Marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="220"/>
-      <source>Mark All Occurrences</source>
-      <translation>Selecionar todas as ocorrências</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="220"/>
+        <source>Mark All Occurrences</source>
+        <translation>Selecionar todas as ocorrências</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="228"/>
-      <source>Clear Marks</source>
-      <translation>Remover as seleções</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="228"/>
+        <source>Clear Marks</source>
+        <translation>Remover as seleções</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="251"/>
-      <source>&amp;View</source>
-      <translation>&amp;Ver</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="251"/>
+        <source>&amp;View</source>
+        <translation>&amp;Ver</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="255"/>
-      <source>&amp;Zoom</source>
-      <translation>&amp;Zoom</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="255"/>
+        <source>&amp;Zoom</source>
+        <translation>&amp;Zoom</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="264"/>
-      <source>Show Symbol</source>
-      <translation>Mostrar símbolo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="264"/>
+        <source>Show Symbol</source>
+        <translation>Mostrar símbolo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="275"/>
-      <source>Fold Level</source>
-      <translation>Nível de dobra</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="275"/>
+        <source>Fold Level</source>
+        <translation>Nível de dobra</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="289"/>
-      <source>Unfold Level</source>
-      <translation>Nível de desdobra</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="289"/>
+        <source>Unfold Level</source>
+        <translation>Nível de desdobra</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="315"/>
-      <source>Language</source>
-      <translation>Linguagem</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="315"/>
+        <source>Language</source>
+        <translation>Linguagem</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="320"/>
-      <source>Settings</source>
-      <translation>Definições</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="320"/>
+        <source>Settings</source>
+        <translation>Definições</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="326"/>
-      <source>Macro</source>
-      <translation>Macro</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="326"/>
+        <source>Macro</source>
+        <translation>Macro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="337"/>
-      <source>Help</source>
-      <translation>Ajuda</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="337"/>
+        <source>Help</source>
+        <translation>Ajuda</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="348"/>
-      <source>Encoding</source>
-      <translation>Codificação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="348"/>
+        <source>Encoding</source>
+        <translation>Codificação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="364"/>
-      <source>Main Tool Bar</source>
-      <translation>Barra de ferramentas principal</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="364"/>
+        <source>Main Tool Bar</source>
+        <translation>Barra de ferramentas principal</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="424"/>
-      <source>&amp;New</source>
-      <translation>&amp;Novo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="424"/>
+        <source>&amp;New</source>
+        <translation>&amp;Novo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="427"/>
-      <source>Create a new file</source>
-      <translation>Criar um novo ficheiro</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="427"/>
+        <source>Create a new file</source>
+        <translation>Criar um novo ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="430"/>
-      <source>Ctrl+N</source>
-      <translation>Ctrl+N</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="430"/>
+        <source>Ctrl+N</source>
+        <translation>Ctrl+N</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="440"/>
-      <source>&amp;Open...</source>
-      <translation>&amp;Abrir...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="440"/>
+        <source>&amp;Open...</source>
+        <translation>&amp;Abrir...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="443"/>
-      <source>Ctrl+O</source>
-      <translation>Ctrl+O</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="443"/>
+        <source>Ctrl+O</source>
+        <translation>Ctrl+O</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="456"/>
-      <source>&amp;Save</source>
-      <translation>&amp;Guardar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="456"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Guardar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="459"/>
-      <source>Save</source>
-      <translation>Guardar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="459"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="462"/>
-      <source>Ctrl+S</source>
-      <translation>Ctrl+S</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="462"/>
+        <source>Ctrl+S</source>
+        <translation>Ctrl+S</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="467"/>
-      <source>E&amp;xit</source>
-      <translation>Sa&amp;ir</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="467"/>
+        <source>E&amp;xit</source>
+        <translation>Sa&amp;ir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="480"/>
-      <source>&amp;Undo</source>
-      <translation>An&amp;ular</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="480"/>
+        <source>&amp;Undo</source>
+        <translation>An&amp;ular</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="483"/>
-      <source>Ctrl+Z</source>
-      <translation>Ctrl+Z</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="483"/>
+        <source>Ctrl+Z</source>
+        <translation>Ctrl+Z</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="493"/>
-      <source>&amp;Redo</source>
-      <translation>&amp;Refazer</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="493"/>
+        <source>&amp;Redo</source>
+        <translation>&amp;Refazer</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="496"/>
-      <source>Ctrl+Y</source>
-      <translation>Ctrl+Y</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="496"/>
+        <source>Ctrl+Y</source>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="506"/>
-      <source>Cu&amp;t</source>
-      <translation>Cor&amp;tar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="506"/>
+        <source>Cu&amp;t</source>
+        <translation>Cor&amp;tar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="509"/>
-      <source>Ctrl+X</source>
-      <translation>Ctrl+X</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="509"/>
+        <source>Ctrl+X</source>
+        <translation>Ctrl+X</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="519"/>
-      <source>&amp;Copy</source>
-      <translation>&amp;Copiar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="519"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Copiar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="522"/>
-      <source>Ctrl+C</source>
-      <translation>Ctrl+C</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="522"/>
+        <source>Ctrl+C</source>
+        <translation>Ctrl+C</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="532"/>
-      <source>&amp;Paste</source>
-      <translation>&amp;Colar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="532"/>
+        <source>&amp;Paste</source>
+        <translation>&amp;Colar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="535"/>
-      <source>Ctrl+V</source>
-      <translation>Ctrl+V</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="535"/>
+        <source>Ctrl+V</source>
+        <translation>Ctrl+V</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="540"/>
-      <source>&amp;Delete</source>
-      <translation>&amp;Eliminar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="540"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Eliminar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="543"/>
-      <source>Del</source>
-      <translation>Ctrl+V</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="543"/>
+        <source>Del</source>
+        <translation>Ctrl+V</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="548"/>
-      <source>Copy Full Path</source>
-      <translation>Copiar localização completa</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="548"/>
+        <source>Copy Full Path</source>
+        <translation>Copiar localização completa</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="553"/>
-      <source>Copy File Name</source>
-      <translation>Copiar nome de ficheiro</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="553"/>
+        <source>Copy File Name</source>
+        <translation>Copiar nome de ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="558"/>
-      <source>Copy File Directory</source>
-      <translation>Copiar diretório de ficheiros</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="558"/>
+        <source>Copy File Directory</source>
+        <translation>Copiar diretório de ficheiros</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="567"/>
-      <source>&amp;Close</source>
-      <translation>&amp;Fechar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="567"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="570"/>
-      <source>Close the current file</source>
-      <translation>Fechar o ficheiro atual</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="570"/>
+        <source>Close the current file</source>
+        <translation>Fechar o ficheiro atual</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="573"/>
-      <source>Ctrl+W</source>
-      <translation>Ctrl+W</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="573"/>
+        <source>Ctrl+W</source>
+        <translation>Ctrl+W</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="578"/>
-      <source>Save &amp;As...</source>
-      <translation>Guardar &amp;como...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="578"/>
+        <source>Save &amp;As...</source>
+        <translation>Guardar &amp;como...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="581"/>
-      <source>Ctrl+Alt+S</source>
-      <translation>Ctrl+Alt+S</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="581"/>
+        <source>Ctrl+Alt+S</source>
+        <translation>Ctrl+Alt+S</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="586"/>
-      <source>Save a Copy As...</source>
-      <translation>Guardar uma cópia como...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="586"/>
+        <source>Save a Copy As...</source>
+        <translation>Guardar uma cópia como...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="595"/>
-      <source>Sav&amp;e All</source>
-      <translation>Guar&amp;dar tudo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="595"/>
+        <source>Sav&amp;e All</source>
+        <translation>Guar&amp;dar tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="598"/>
-      <source>Ctrl+Shift+S</source>
-      <translation>Ctrl+Shift+S</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="598"/>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="603"/>
-      <source>Select A&amp;ll</source>
-      <translation>Selecionar t&amp;udo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="603"/>
+        <source>Select A&amp;ll</source>
+        <translation>Selecionar t&amp;udo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="606"/>
-      <source>Ctrl+A</source>
-      <translation>Ctrl+A</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="606"/>
+        <source>Ctrl+A</source>
+        <translation>Ctrl+A</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="615"/>
-      <source>Increase Indent</source>
-      <translation>Aumentar a indentação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="615"/>
+        <source>Increase Indent</source>
+        <translation>Aumentar a indentação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="624"/>
-      <source>Decrease Indent</source>
-      <translation>Diminuir a indentação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="624"/>
+        <source>Decrease Indent</source>
+        <translation>Diminuir a indentação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="629"/>
-      <source>Rename...</source>
-      <translation>Renomear...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="629"/>
+        <source>Rename...</source>
+        <translation>Renomear...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="638"/>
-      <source>Re&amp;load</source>
-      <translation>Re&amp;carregar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="638"/>
+        <source>Re&amp;load</source>
+        <translation>Re&amp;carregar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="646"/>
-      <source>Windows (CR LF)</source>
-      <translation>Windows (CR LF)</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="646"/>
+        <source>Windows (CR LF)</source>
+        <translation>Windows (CR LF)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="654"/>
-      <source>Unix (LF)</source>
-      <translation>Unix (LF)</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="654"/>
+        <source>Unix (LF)</source>
+        <translation>Unix (LF)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="662"/>
-      <source>Macintosh (CR)</source>
-      <translation>Macintosh (CR)</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="662"/>
+        <source>Macintosh (CR)</source>
+        <translation>Macintosh (CR)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="667"/>
-      <source>UPPER CASE</source>
-      <translation>MAIÚSCULAS</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="667"/>
+        <source>UPPER CASE</source>
+        <translation>MAIÚSCULAS</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="670"/>
-      <source>Convert text to upper case</source>
-      <translation>Converter texto em maiúsculas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="670"/>
+        <source>Convert text to upper case</source>
+        <translation>Converter texto em maiúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="675"/>
-      <source>lower case</source>
-      <translation>minúsculas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="675"/>
+        <source>lower case</source>
+        <translation>minúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="678"/>
-      <source>Convert text to lower case</source>
-      <translation>Converter texto em minúsculas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="678"/>
+        <source>Convert text to lower case</source>
+        <translation>Converter texto em minúsculas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="683"/>
-      <source>Duplicate Current Line</source>
-      <translation>Duplicar linha atual</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="683"/>
+        <source>Duplicate Current Line</source>
+        <translation>Duplicar linha atual</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="686"/>
-      <source>Alt+Down</source>
-      <translation>Alt+Baixo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="686"/>
+        <source>Alt+Down</source>
+        <translation>Alt+Baixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="691"/>
-      <source>Split Lines</source>
-      <translation>Dividir linhas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="691"/>
+        <source>Split Lines</source>
+        <translation>Dividir linhas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="696"/>
-      <source>Join Lines</source>
-      <translation>Juntar linhas</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="696"/>
+        <source>Join Lines</source>
+        <translation>Juntar linhas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="699"/>
-      <source>Ctrl+J</source>
-      <translation>Ctrl+J</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="699"/>
+        <source>Ctrl+J</source>
+        <translation>Ctrl+J</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="704"/>
-      <source>Move Selected Lines Up</source>
-      <translation>Mover as linhas selecionadas para cima</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="704"/>
+        <source>Move Selected Lines Up</source>
+        <translation>Mover as linhas selecionadas para cima</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="707"/>
-      <source>Ctrl+Shift+Up</source>
-      <translation>Ctrl+Shift+Cima</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="707"/>
+        <source>Ctrl+Shift+Up</source>
+        <translation>Ctrl+Shift+Cima</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="712"/>
-      <source>Move Selected Lines Down</source>
-      <translation>Mover as linhas selecionadas para baixo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="712"/>
+        <source>Move Selected Lines Down</source>
+        <translation>Mover as linhas selecionadas para baixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="715"/>
-      <source>Ctrl+Shift+Down</source>
-      <translation>Ctrl+Shift+Baixo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="715"/>
+        <source>Ctrl+Shift+Down</source>
+        <translation>Ctrl+Shift+Baixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="724"/>
-      <source>Clos&amp;e All</source>
-      <translation>Fechar &amp;tudo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="724"/>
+        <source>Clos&amp;e All</source>
+        <translation>Fechar &amp;tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="727"/>
-      <source>Close All files</source>
-      <translation>Fechar todos os ficheiros</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="727"/>
+        <source>Close All files</source>
+        <translation>Fechar todos os ficheiros</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="730"/>
-      <source>Ctrl+Shift+W</source>
-      <translation>Ctrl+Shift+W</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="730"/>
+        <source>Ctrl+Shift+W</source>
+        <translation>Ctrl+Shift+W</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="735"/>
-      <source>Close All Except Active Document</source>
-      <translation>Fechar tudo exceto o documento ativo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="735"/>
+        <source>Close All Except Active Document</source>
+        <translation>Fechar tudo exceto o documento ativo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="740"/>
-      <source>Close All to the Left</source>
-      <translation>Fechar tudo à esquerda</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="740"/>
+        <source>Close All to the Left</source>
+        <translation>Fechar tudo à esquerda</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="745"/>
-      <source>Close All to the Right</source>
-      <translation>Fechar tudo à direita</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="745"/>
+        <source>Close All to the Right</source>
+        <translation>Fechar tudo à direita</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="755"/>
-      <source>Zoom &amp;In</source>
-      <translation>A&amp;umentar</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="755"/>
+        <source>Zoom &amp;In</source>
+        <translation>A&amp;umentar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="758"/>
-      <source>Ctrl++</source>
-      <translation>Ctrl++</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="758"/>
+        <source>Ctrl++</source>
+        <translation>Ctrl++</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="768"/>
-      <source>Zoom &amp;Out</source>
-      <translation>&amp;Reduzir</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="768"/>
+        <source>Zoom &amp;Out</source>
+        <translation>&amp;Reduzir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="771"/>
-      <source>Ctrl+-</source>
-      <translation>Ctrl+-</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="771"/>
+        <source>Ctrl+-</source>
+        <translation>Ctrl+-</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="776"/>
-      <source>Reset Zoom</source>
-      <translation>Repor</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="776"/>
+        <source>Reset Zoom</source>
+        <translation>Repor</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="779"/>
-      <source>Ctrl+0</source>
-      <translation>Ctrl+0</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="779"/>
+        <source>Ctrl+0</source>
+        <translation>Ctrl+0</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="784"/>
-      <source>About Qt</source>
-      <translation>Acerca do Qt</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="784"/>
+        <source>About Qt</source>
+        <translation>Acerca do Qt</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="796"/>
-      <source>About Notepad Next</source>
-      <translation>Acerca do Notepad Next</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="796"/>
+        <source>About Notepad Next</source>
+        <translation>Acerca do Notepad Next</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="807"/>
-      <source>Show Whitespace</source>
-      <translation>Mostrar espaço em branco</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="807"/>
+        <source>Show Whitespace</source>
+        <translation>Mostrar espaço em branco</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="815"/>
-      <source>Show End of Line</source>
-      <translation>Mostrar fim de linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="815"/>
+        <source>Show End of Line</source>
+        <translation>Mostrar fim de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="828"/>
-      <source>Show All Characters</source>
-      <translation>Mostrar todos os caracteres</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="828"/>
+        <source>Show All Characters</source>
+        <translation>Mostrar todos os caracteres</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="841"/>
-      <source>Show Indent Guide</source>
-      <translation>Mostrar guia de indentação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="841"/>
+        <source>Show Indent Guide</source>
+        <translation>Mostrar guia de indentação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="849"/>
-      <source>Show Wrap Symbol</source>
-      <translation>Mostrar o símbolo de quebra de linha</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="849"/>
+        <source>Show Wrap Symbol</source>
+        <translation>Mostrar o símbolo de quebra de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="862"/>
-      <source>Word Wrap</source>
-      <translation>Quebra de palavras</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="862"/>
+        <source>Word Wrap</source>
+        <translation>Quebra de palavras</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="867"/>
-      <source>Restore Recently Closed File</source>
-      <translation>Restaurar ficheiro fechado recentemente</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="867"/>
+        <source>Restore Recently Closed File</source>
+        <translation>Restaurar ficheiro fechado recentemente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="870"/>
-      <source>Ctrl+Shift+T</source>
-      <translation>Ctrl+Shift+T</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="870"/>
+        <source>Ctrl+Shift+T</source>
+        <translation>Ctrl+Shift+T</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="875"/>
-      <source>Open All Recent Files</source>
-      <translation>Abrir todos os ficheiros recentes</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="875"/>
+        <source>Open All Recent Files</source>
+        <translation>Abrir todos os ficheiros recentes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="880"/>
-      <source>Clear Recent Files List</source>
-      <translation>Limpar a lista dos ficheiros recentes</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="880"/>
+        <source>Clear Recent Files List</source>
+        <translation>Limpar a lista dos ficheiros recentes</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="890"/>
-      <source>&amp;Find...</source>
-      <translation>&amp;Localizar...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="890"/>
+        <source>&amp;Find...</source>
+        <translation>&amp;Localizar...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="893"/>
-      <source>Ctrl+F</source>
-      <translation>Ctrl+F</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="893"/>
+        <source>Ctrl+F</source>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="898"/>
-      <source>Find in Files...</source>
-      <translation>Localizar em Ficheiros...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="898"/>
+        <source>Find in Files...</source>
+        <translation>Localizar em Ficheiros...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="903"/>
-      <source>Find &amp;Next</source>
-      <translation>Localizar &amp;seguinte</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="903"/>
+        <source>Find &amp;Next</source>
+        <translation>Localizar &amp;seguinte</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="906"/>
-      <source>F3</source>
-      <translation>F3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="906"/>
+        <source>F3</source>
+        <translation>F3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="911"/>
-      <source>Find &amp;Previous</source>
-      <translation>Localizar &amp;anterior</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="911"/>
+        <source>Find &amp;Previous</source>
+        <translation>Localizar &amp;anterior</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="914"/>
-      <source>Shift+F3</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="914"/>
+        <source>Shift+F3</source>
+        <translation>Shift+F3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="924"/>
-      <source>&amp;Replace...</source>
-      <translation>&amp;Substituir...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="924"/>
+        <source>&amp;Replace...</source>
+        <translation>&amp;Substituir...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="927"/>
-      <source>Ctrl+H</source>
-      <translation>Ctrl+H</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="927"/>
+        <source>Ctrl+H</source>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="935"/>
-      <source>Full Screen</source>
-      <translation>Ecrã inteiro</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="935"/>
+        <source>Full Screen</source>
+        <translation>Ecrã inteiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="938"/>
-      <source>F11</source>
-      <translation>F11</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="938"/>
+        <source>F11</source>
+        <translation>F11</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="951"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="753"/>
-      <source>Start Recording</source>
-      <translation>Iniciar gravação</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="951"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="753"/>
+        <source>Start Recording</source>
+        <translation>Iniciar gravação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="963"/>
-      <source>Playback</source>
-      <translation>Reproduzir</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="963"/>
+        <source>Playback</source>
+        <translation>Reproduzir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="966"/>
-      <source>Ctrl+Shift+P</source>
-      <translation>Ctrl+Shift+P</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="966"/>
+        <source>Ctrl+Shift+P</source>
+        <translation>Ctrl+Shift+P</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="978"/>
-      <source>Save Current Recorded Macro...</source>
-      <translation>Guardar a macro gravada atual...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="978"/>
+        <source>Save Current Recorded Macro...</source>
+        <translation>Guardar a macro gravada atual...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="990"/>
-      <source>Run a Macro Multiple Times...</source>
-      <translation>Executar uma macro várias vezes...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="990"/>
+        <source>Run a Macro Multiple Times...</source>
+        <translation>Executar uma macro várias vezes...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="999"/>
-      <source>Preferences...</source>
-      <translation>Preferências...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="999"/>
+        <source>Preferences...</source>
+        <translation>Preferências...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1007"/>
-      <source>Quick Find</source>
-      <translation>Pesquisa rápida</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1007"/>
+        <source>Quick Find</source>
+        <translation>Pesquisa rápida</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1010"/>
-      <source>Ctrl+Alt+I</source>
-      <translation>Ctrl+Alt+I</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1010"/>
+        <source>Ctrl+Alt+I</source>
+        <translation>Ctrl+Alt+I</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1015"/>
-      <source>Select Next Instance</source>
-      <translation>Selecionar a instância seguinte</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1015"/>
+        <source>Select Next Instance</source>
+        <translation>Selecionar a instância seguinte</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1018"/>
-      <source>Ctrl+D</source>
-      <translation>Ctrl+D</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1018"/>
+        <source>Ctrl+D</source>
+        <translation>Ctrl+D</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1027"/>
-      <source>Move to Trash...</source>
-      <translation>Mover para o Lixo...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1027"/>
+        <source>Move to Trash...</source>
+        <translation>Mover para o Lixo...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1030"/>
-      <source>Move to Trash</source>
-      <translation>Mover para o Lixo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1030"/>
+        <source>Move to Trash</source>
+        <translation>Mover para o Lixo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1035"/>
-      <source>Check for Updates...</source>
-      <translation>Procurar por atualizações...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1035"/>
+        <source>Check for Updates...</source>
+        <translation>Procurar por atualizações...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1040"/>
-      <source>&amp;Go to Line...</source>
-      <translation>&amp;Ir para a linha...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1040"/>
+        <source>&amp;Go to Line...</source>
+        <translation>&amp;Ir para a linha...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1043"/>
-      <source>Ctrl+G</source>
-      <translation>Ctrl+G</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1043"/>
+        <source>Ctrl+G</source>
+        <translation>Ctrl+G</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1052"/>
-      <source>Print...</source>
-      <translation>Imprimir...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1052"/>
+        <source>Print...</source>
+        <translation>Imprimir...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1055"/>
-      <source>Ctrl+P</source>
-      <translation>Ctrl+P</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1055"/>
+        <source>Ctrl+P</source>
+        <translation>Ctrl+P</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1060"/>
-      <source>Open Folder as Workspace...</source>
-      <translation>Abrir pasta como área de trabalho...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1060"/>
+        <source>Open Folder as Workspace...</source>
+        <translation>Abrir pasta como área de trabalho...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1065"/>
-      <source>Toggle Single Line Comment</source>
-      <translation>Alternar comentário de linha única</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1065"/>
+        <source>Toggle Single Line Comment</source>
+        <translation>Alternar comentário de linha única</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1068"/>
-      <source>Ctrl+/</source>
-      <translation>Ctrl+/</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1068"/>
+        <source>Ctrl+/</source>
+        <translation>Ctrl+/</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1073"/>
-      <source>Single Line Comment</source>
-      <translation>Comentário de linha única</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1073"/>
+        <source>Single Line Comment</source>
+        <translation>Comentário de linha única</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1076"/>
-      <source>Ctrl+K</source>
-      <translation>Ctrl+K</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1076"/>
+        <source>Ctrl+K</source>
+        <translation>Ctrl+K</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1081"/>
-      <source>Single Line Uncomment</source>
-      <translation>Sem comentário de linha única</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1081"/>
+        <source>Single Line Uncomment</source>
+        <translation>Sem comentário de linha única</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1084"/>
-      <source>Ctrl+Shift+K</source>
-      <translation>Ctrl+Shift+K</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1084"/>
+        <source>Ctrl+Shift+K</source>
+        <translation>Ctrl+Shift+K</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1096"/>
-      <source>Edit Macros...</source>
-      <translation>Editar macros...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1096"/>
+        <source>Edit Macros...</source>
+        <translation>Editar macros...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1104"/>
-      <source>This is not currently implemented</source>
-      <translation>Atualmente não está implementado</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1104"/>
+        <source>This is not currently implemented</source>
+        <translation>Atualmente não está implementado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1109"/>
-      <source>Column Mode...</source>
-      <translation>Modo de coluna...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1109"/>
+        <source>Column Mode...</source>
+        <translation>Modo de coluna...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1114"/>
-      <source>Export as HTML...</source>
-      <translation>Exportar como HTML...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1114"/>
+        <source>Export as HTML...</source>
+        <translation>Exportar como HTML...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1119"/>
-      <source>Export as RTF...</source>
-      <translation>Exportar como RTF...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1119"/>
+        <source>Export as RTF...</source>
+        <translation>Exportar como RTF...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1124"/>
-      <source>Copy as HTML</source>
-      <translation>Copiar como HTML</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1124"/>
+        <source>Copy as HTML</source>
+        <translation>Copiar como HTML</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1129"/>
-      <source>Copy as RTF</source>
-      <translation>Copiar como RTF</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1129"/>
+        <source>Copy as RTF</source>
+        <translation>Copiar como RTF</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1134"/>
-      <source>Base 64 Encode</source>
-      <translation>Codificação Base 64</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1134"/>
+        <source>Base 64 Encode</source>
+        <translation>Codificação Base 64</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1139"/>
-      <source>URL Encode</source>
-      <translation>Codificação URL</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1139"/>
+        <source>URL Encode</source>
+        <translation>Codificação URL</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1144"/>
-      <source>Base 64 Decode</source>
-      <translation>Descodificação Base 64</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1144"/>
+        <source>Base 64 Decode</source>
+        <translation>Descodificação Base 64</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1149"/>
-      <source>URL Decode</source>
-      <translation>Descodificação URL</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1149"/>
+        <source>URL Decode</source>
+        <translation>Descodificação URL</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1154"/>
-      <source>Copy URL</source>
-      <translation>Copiar URL</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1154"/>
+        <source>Copy URL</source>
+        <translation>Copiar URL</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1159"/>
-      <source>Remove Empty Lines</source>
-      <translation>Remover linhas vazias</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1159"/>
+        <source>Remove Empty Lines</source>
+        <translation>Remover linhas vazias</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1168"/>
-      <location filename="../src/dialogs/MainWindow.ui" line="1171"/>
-      <source>Show in Explorer</source>
-      <translation>Mostrar no Explorador</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1168"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1171"/>
+        <source>Show in Explorer</source>
+        <translation>Mostrar no Explorador</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1180"/>
-      <source>Open %1 Here</source>
-      <translation>Abrir %1 aqui</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1180"/>
+        <source>Open %1 Here</source>
+        <translation>Abrir %1 aqui</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1185"/>
-      <source>Toggle Bookmark</source>
-      <translation>Alternar marcador</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1185"/>
+        <source>Toggle Bookmark</source>
+        <translation>Alternar marcador</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1188"/>
-      <source>Ctrl+F2</source>
-      <translation>Ctrl+F2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1188"/>
+        <source>Ctrl+F2</source>
+        <translation>Ctrl+F2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1193"/>
-      <source>Next Bookmark</source>
-      <translation>Marcador seguinte</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1193"/>
+        <source>Next Bookmark</source>
+        <translation>Marcador seguinte</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1196"/>
-      <source>F2</source>
-      <translation>F2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1196"/>
+        <source>F2</source>
+        <translation>F2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1201"/>
-      <source>Previous Bookmark</source>
-      <translation>Marcador anterior</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1201"/>
+        <source>Previous Bookmark</source>
+        <translation>Marcador anterior</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1204"/>
-      <source>Shift+F2</source>
-      <translation>Shift+F2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1204"/>
+        <source>Shift+F2</source>
+        <translation>Shift+F2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1209"/>
-      <source>Clear Bookmarks</source>
-      <translation>Limpar marcadores</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1209"/>
+        <source>Clear Bookmarks</source>
+        <translation>Limpar marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1214"/>
-      <source>Invert Bookmarks</source>
-      <translation>Inverter marcadores</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1214"/>
+        <source>Invert Bookmarks</source>
+        <translation>Inverter marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1219"/>
-      <source>Next Tab</source>
-      <translation>Separarador seguinte</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1219"/>
+        <source>Next Tab</source>
+        <translation>Separarador seguinte</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1222"/>
-      <source>Ctrl+Tab</source>
-      <translation>Ctrl+Tab</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1222"/>
+        <source>Ctrl+Tab</source>
+        <translation>Ctrl+Tab</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1230"/>
-      <source>Previous Tab</source>
-      <translation>Separador anterior</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1230"/>
+        <source>Previous Tab</source>
+        <translation>Separador anterior</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1233"/>
-      <source>Ctrl+Shift+Tab</source>
-      <translation>Ctrl+Shift+Tab</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1233"/>
+        <source>Ctrl+Shift+Tab</source>
+        <translation>Ctrl+Shift+Tab</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1241"/>
-      <source>Fold Level 1</source>
-      <translation>Nível de dobra 1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1241"/>
+        <source>Fold Level 1</source>
+        <translation>Nível de dobra 1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1244"/>
-      <source>Alt+1</source>
-      <translation>Alt+1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1244"/>
+        <source>Alt+1</source>
+        <translation>Alt+1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1249"/>
-      <source>Fold Level 2</source>
-      <translation>Nível de dobra 2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1249"/>
+        <source>Fold Level 2</source>
+        <translation>Nível de dobra 2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1252"/>
-      <source>Alt+2</source>
-      <translation>Alt+2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1252"/>
+        <source>Alt+2</source>
+        <translation>Alt+2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1257"/>
-      <source>Fold Level 3</source>
-      <translation>Nível de dobra 3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1257"/>
+        <source>Fold Level 3</source>
+        <translation>Nível de dobra 3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1260"/>
-      <source>Alt+3</source>
-      <translation>Alt+3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1260"/>
+        <source>Alt+3</source>
+        <translation>Alt+3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1265"/>
-      <source>Fold Level 4</source>
-      <translation>Nível de dobra 4</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1265"/>
+        <source>Fold Level 4</source>
+        <translation>Nível de dobra 4</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1268"/>
-      <source>Alt+4</source>
-      <translation>Alt+4</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1268"/>
+        <source>Alt+4</source>
+        <translation>Alt+4</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1273"/>
-      <source>Unfold Level 1</source>
-      <translation>Nível de desdobra 1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1273"/>
+        <source>Unfold Level 1</source>
+        <translation>Nível de desdobra 1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1276"/>
-      <source>Alt+Shift+1</source>
-      <translation>Alt+Shift+1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1276"/>
+        <source>Alt+Shift+1</source>
+        <translation>Alt+Shift+1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1281"/>
-      <source>Unfold Level 2</source>
-      <translation>Nível de desdobra 2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1281"/>
+        <source>Unfold Level 2</source>
+        <translation>Nível de desdobra 2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1284"/>
-      <source>Alt+Shift+2</source>
-      <translation>Alt+Shift+2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1284"/>
+        <source>Alt+Shift+2</source>
+        <translation>Alt+Shift+2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1289"/>
-      <source>Unfold Level 3</source>
-      <translation>Nível de desdobra 3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1289"/>
+        <source>Unfold Level 3</source>
+        <translation>Nível de desdobra 3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1292"/>
-      <source>Alt+Shift+3</source>
-      <translation>Alt+Shift+3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1292"/>
+        <source>Alt+Shift+3</source>
+        <translation>Alt+Shift+3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1297"/>
-      <source>Unfold Level 4</source>
-      <translation>Nível de desdobra 4</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1297"/>
+        <source>Unfold Level 4</source>
+        <translation>Nível de desdobra 4</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1300"/>
-      <source>Alt+Shift+4</source>
-      <translation>Alt+Shift+4</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1300"/>
+        <source>Alt+Shift+4</source>
+        <translation>Alt+Shift+4</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1305"/>
-      <source>Fold All</source>
-      <translation>Dobrar tudo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1305"/>
+        <source>Fold All</source>
+        <translation>Dobrar tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1308"/>
-      <source>Alt+0</source>
-      <translation>Alt+0</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1308"/>
+        <source>Alt+0</source>
+        <translation>Alt+0</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1313"/>
-      <source>Unfold All</source>
-      <translation>Desdobrar tudo</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1313"/>
+        <source>Unfold All</source>
+        <translation>Desdobrar tudo</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1316"/>
-      <source>Alt+Shift+0</source>
-      <translation>Alt+Shift+0</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1316"/>
+        <source>Alt+Shift+0</source>
+        <translation>Alt+Shift+0</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1321"/>
-      <source>Fold Level 5</source>
-      <translation>Nível de dobra 5</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1321"/>
+        <source>Fold Level 5</source>
+        <translation>Nível de dobra 5</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1324"/>
-      <source>Alt+5</source>
-      <translation>Alt+5</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1324"/>
+        <source>Alt+5</source>
+        <translation>Alt+5</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1329"/>
-      <source>Fold Level 6</source>
-      <translation>Nível de dobra 6</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1329"/>
+        <source>Fold Level 6</source>
+        <translation>Nível de dobra 6</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1332"/>
-      <source>Alt+6</source>
-      <translation>Alt+6</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1332"/>
+        <source>Alt+6</source>
+        <translation>Alt+6</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1337"/>
-      <source>Fold Level 7</source>
-      <translation>Nível de dobra 7</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1337"/>
+        <source>Fold Level 7</source>
+        <translation>Nível de dobra 7</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1340"/>
-      <source>Alt+7</source>
-      <translation>Alt+7</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1340"/>
+        <source>Alt+7</source>
+        <translation>Alt+7</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1345"/>
-      <source>Fold Level 8</source>
-      <translation>Nível de dobra 8</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1345"/>
+        <source>Fold Level 8</source>
+        <translation>Nível de dobra 8</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1348"/>
-      <source>Alt+8</source>
-      <translation>Alt+8</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1348"/>
+        <source>Alt+8</source>
+        <translation>Alt+8</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1353"/>
-      <source>Fold Level 9</source>
-      <translation>Nível de dobra 9</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1353"/>
+        <source>Fold Level 9</source>
+        <translation>Nível de dobra 9</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1356"/>
-      <source>Alt+9</source>
-      <translation>Alt+9</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1356"/>
+        <source>Alt+9</source>
+        <translation>Alt+9</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1361"/>
-      <source>Unfold Level 5</source>
-      <translation>Nível de desdobra 5</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1361"/>
+        <source>Unfold Level 5</source>
+        <translation>Nível de desdobra 5</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1364"/>
-      <source>Alt+Shift+5</source>
-      <translation>Alt+Shift+5</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1364"/>
+        <source>Alt+Shift+5</source>
+        <translation>Alt+Shift+5</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1369"/>
-      <source>Unfold Level 6</source>
-      <translation>Nível de desdobra 6</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1369"/>
+        <source>Unfold Level 6</source>
+        <translation>Nível de desdobra 6</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1372"/>
-      <source>Alt+Shift+6</source>
-      <translation>Alt+Shift+6</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1372"/>
+        <source>Alt+Shift+6</source>
+        <translation>Alt+Shift+6</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1377"/>
-      <source>Unfold Level 7</source>
-      <translation>Nível de desdobra 7</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1377"/>
+        <source>Unfold Level 7</source>
+        <translation>Nível de desdobra 7</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1380"/>
-      <source>Alt+Shift+7</source>
-      <translation>Alt+Shift+7</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1380"/>
+        <source>Alt+Shift+7</source>
+        <translation>Alt+Shift+7</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1385"/>
-      <source>Unfold Level 8</source>
-      <translation>Nível de desdobra 8</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1385"/>
+        <source>Unfold Level 8</source>
+        <translation>Nível de desdobra 8</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1388"/>
-      <source>Alt+Shift+8</source>
-      <translation>Alt+Shift+8</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1388"/>
+        <source>Alt+Shift+8</source>
+        <translation>Alt+Shift+8</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1393"/>
-      <source>Unfold Level 9</source>
-      <translation>Nível de desdobra 9</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1393"/>
+        <source>Unfold Level 9</source>
+        <translation>Nível de desdobra 9</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1396"/>
-      <source>Alt+Shift+9</source>
-      <translation>Alt+Shift+9</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1396"/>
+        <source>Alt+Shift+9</source>
+        <translation>Alt+Shift+9</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1401"/>
-      <location filename="../src/dialogs/MainWindow.ui" line="1404"/>
-      <source>Toggle Overtype</source>
-      <translation>Alternar entre tipos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1401"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1404"/>
+        <source>Toggle Overtype</source>
+        <translation>Alternar entre tipos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1407"/>
-      <source>Ins</source>
-      <translation>Ins</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1407"/>
+        <source>Ins</source>
+        <translation>Ins</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1415"/>
-      <source>Debug Info...</source>
-      <translation>Informações de depuração...</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1415"/>
+        <source>Debug Info...</source>
+        <translation>Informações de depuração...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1420"/>
-      <source>Cut Bookmarked Lines</source>
-      <translation>Cortar linhas com marcadores</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1420"/>
+        <source>Cut Bookmarked Lines</source>
+        <translation>Cortar linhas com marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1425"/>
-      <source>Copy Bookmarked Lines</source>
-      <translation>Copiar linhas com marcadores</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1425"/>
+        <source>Copy Bookmarked Lines</source>
+        <translation>Copiar linhas com marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1430"/>
-      <source>Delete Bookmarked Lines</source>
-      <translation>Eliminar linhas com marcadores</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1430"/>
+        <source>Delete Bookmarked Lines</source>
+        <translation>Eliminar linhas com marcadores</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1435"/>
-      <source>Mark Style 1</source>
-      <translation>Estilo da seleção 1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1435"/>
+        <source>Mark Style 1</source>
+        <translation>Estilo da seleção 1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1443"/>
-      <source>Mark Style 2</source>
-      <translation>Estilo da seleção 2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1443"/>
+        <source>Mark Style 2</source>
+        <translation>Estilo da seleção 2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1451"/>
-      <source>Clear Style 1</source>
-      <translation>Remover o estilo 1</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1451"/>
+        <source>Clear Style 1</source>
+        <translation>Remover o estilo 1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1459"/>
-      <source>Clear Style 2</source>
-      <translation>Remover o estilo 2</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1459"/>
+        <source>Clear Style 2</source>
+        <translation>Remover o estilo 2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1467"/>
-      <source>Mark Style 3</source>
-      <translation>Estilo da seleção 3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1467"/>
+        <source>Mark Style 3</source>
+        <translation>Estilo da seleção 3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1475"/>
-      <source>Clear Style 3</source>
-      <translation>Remover o estilo 3</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1475"/>
+        <source>Clear Style 3</source>
+        <translation>Remover o estilo 3</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1483"/>
-      <location filename="../src/dialogs/MainWindow.ui" line="1486"/>
-      <source>Clear All Styles</source>
-      <translation>Remover todos os estilos</translation>
+        <location filename="../src/dialogs/MainWindow.ui" line="1483"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1486"/>
+        <source>Clear All Styles</source>
+        <translation>Remover todos os estilos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1491"/>
-      <source>Remove Duplicate Lines</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1491"/>
+        <source>Remove Duplicate Lines</source>
+        <translation>Remover linhas duplicadas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1496"/>
-      <source>Remove Consecutive Duplicate Lines</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1496"/>
+        <source>Remove Consecutive Duplicate Lines</source>
+        <translation>Remover linhas duplicadas consecutivas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1501"/>
-      <source>Sort Lines Ascending</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1501"/>
+        <source>Sort Lines Ascending</source>
+        <translation>Ordenar as linhas por ordem ascendente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1506"/>
-      <source>Sort Lines Descending</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1506"/>
+        <source>Sort Lines Descending</source>
+        <translation>Ordenar as linhas por ordem descendente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1511"/>
-      <source>Sort Lines Ascending (Case-Insensitive)</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1511"/>
+        <source>Sort Lines Ascending (Case-Insensitive)</source>
+        <translation>Ordenar as linhas por ordem ascendente (sem distinção entre maiúsculas e minúsculas)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1516"/>
-      <source>Sort Lines Descending (Case-Insensitive)</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1516"/>
+        <source>Sort Lines Descending (Case-Insensitive)</source>
+        <translation>Ordenar as linhas por ordem descendente (sem distinção entre maiúsculas e minúsculas)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1521"/>
-      <source>Sort Lines by Length Ascending</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1521"/>
+        <source>Sort Lines by Length Ascending</source>
+        <translation>Ordenar as linhas por comprimento, em ordem ascendente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1526"/>
-      <source>Sort Lines by Length Descending</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1526"/>
+        <source>Sort Lines by Length Descending</source>
+        <translation>Ordenar as linhas por comprimento, em ordem descendente</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.ui" line="1531"/>
-      <source>Reverse Line Order</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1531"/>
+        <source>Reverse Line Order</source>
+        <translation>Inverter a ordem das linhas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="411"/>
-      <source>Go to line</source>
-      <translation>Ir para a linha</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="411"/>
+        <source>Go to line</source>
+        <translation>Ir para a linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="411"/>
-      <source>Line Number (1 - %1)</source>
-      <translation>Número da linha (1 - %1)</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="411"/>
+        <source>Line Number (1 - %1)</source>
+        <translation>Número da linha (1 - %1)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="744"/>
-      <source>Stop Recording</source>
-      <translation>Parar gravação</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="744"/>
+        <source>Stop Recording</source>
+        <translation>Parar gravação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="849"/>
-      <source>Debug Info</source>
-      <translation>Informações de depuração</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="849"/>
+        <source>Debug Info</source>
+        <translation>Informações de depuração</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1047"/>
-      <source>New %1</source>
-      <translation>Novo %1</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1047"/>
+        <source>New %1</source>
+        <translation>Novo %1</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1107"/>
-      <source>Create File</source>
-      <translation>Criar ficheiro</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1107"/>
+        <source>Create File</source>
+        <translation>Criar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1107"/>
-      <source>&lt;b&gt;%1&lt;/b&gt; does not exist. Do you want to create it?</source>
-      <translation>&lt;b&gt;%1&lt;/b&gt; não existe. Pretende criá-lo?</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1107"/>
+        <source>&lt;b&gt;%1&lt;/b&gt; does not exist. Do you want to create it?</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt; não existe. Pretende criá-lo?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1148"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1239"/>
-      <source>Save file &lt;b&gt;%1&lt;/b&gt;?</source>
-      <translation>Guardar ficheiro &lt;b&gt;%1&lt;/b&gt;?</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1148"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1239"/>
+        <source>Save file &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Guardar ficheiro &lt;b&gt;%1&lt;/b&gt;?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1149"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1240"/>
-      <source>Save File</source>
-      <translation>Guardar ficheiro</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1149"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1240"/>
+        <source>Save File</source>
+        <translation>Guardar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1190"/>
-      <source>Open Folder as Workspace</source>
-      <translation>Abrir pasta como área de trabalho</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1190"/>
+        <source>Open Folder as Workspace</source>
+        <translation>Abrir pasta como área de trabalho</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1213"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1885"/>
-      <source>Reload File</source>
-      <translation>Recarregar ficheiro</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1213"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1885"/>
+        <source>Reload File</source>
+        <translation>Recarregar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1213"/>
-      <source>Are you sure you want to reload &lt;b&gt;%1&lt;/b&gt;? Any unsaved changes will be lost.</source>
-      <translation>Tem certeza de que pretende recarregar o &lt;b&gt;%1&lt;/b&gt;? Todas as alterações não guardadas serão perdidas.</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1213"/>
+        <source>Are you sure you want to reload &lt;b&gt;%1&lt;/b&gt;? Any unsaved changes will be lost.</source>
+        <translation>Tem certeza de que pretende recarregar o &lt;b&gt;%1&lt;/b&gt;? Todas as alterações não guardadas serão perdidas.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1404"/>
-      <source>Save a Copy As</source>
-      <translation>Guardar uma cópia como</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1404"/>
+        <source>Save a Copy As</source>
+        <translation>Guardar uma cópia como</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1480"/>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1497"/>
-      <source>Rename</source>
-      <translation>Renomear</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1480"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1497"/>
+        <source>Rename</source>
+        <translation>Renomear</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1497"/>
-      <source>Name:</source>
-      <translation>Nome:</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1497"/>
+        <source>Name:</source>
+        <translation>Nome:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1517"/>
-      <source>Delete File</source>
-      <translation>Eliminar ficheiro</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1517"/>
+        <source>Delete File</source>
+        <translation>Eliminar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1517"/>
-      <source>Are you sure you want to move &lt;b&gt;%1&lt;/b&gt; to the trash?</source>
-      <translation>Tem a certeza de que pretende mover &lt;b&gt;%1&lt;/b&gt; para o lixo?</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1517"/>
+        <source>Are you sure you want to move &lt;b&gt;%1&lt;/b&gt; to the trash?</source>
+        <translation>Tem a certeza de que pretende mover &lt;b&gt;%1&lt;/b&gt; para o lixo?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1527"/>
-      <source>Error Deleting File</source>
-      <translation>Erro ao eliminar ficheiro</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1527"/>
+        <source>Error Deleting File</source>
+        <translation>Erro ao eliminar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1527"/>
-      <source>Something went wrong deleting &lt;b&gt;%1&lt;/b&gt;?</source>
-      <translation>Algo correu mal ao eliminar &lt;b&gt;%1&lt;/b&gt;?</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1527"/>
+        <source>Something went wrong deleting &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Algo correu mal ao eliminar &lt;b&gt;%1&lt;/b&gt;?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1624"/>
-      <source>Administrator</source>
-      <translation>Administrador</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1624"/>
+        <source>Administrator</source>
+        <translation>Administrador</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1885"/>
-      <source>&lt;b&gt;%1&lt;/b&gt; has been modified by another program. Do you want to reload it?</source>
-      <translation>&lt;b&gt;%1&lt;/b&gt; foi modificado por outro programa. Deseja recarregá-lo?</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1885"/>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been modified by another program. Do you want to reload it?</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt; foi modificado por outro programa. Deseja recarregá-lo?</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1911"/>
-      <source>Read error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1911"/>
+        <source>Read error</source>
+        <translation>Erro de leitura</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1912"/>
-      <source>Write error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1912"/>
+        <source>Write error</source>
+        <translation>Erro de gravação</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1913"/>
-      <source>Fatal error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1913"/>
+        <source>Fatal error</source>
+        <translation>Erro fatal</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1914"/>
-      <source>Resource error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1914"/>
+        <source>Resource error</source>
+        <translation>Erro de recurso</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1915"/>
-      <source>Open error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1915"/>
+        <source>Open error</source>
+        <translation>Erro ao abrir</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1916"/>
-      <source>Abort error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1916"/>
+        <source>Abort error</source>
+        <translation>Erro ao abortar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1917"/>
-      <source>Timeout error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1917"/>
+        <source>Timeout error</source>
+        <translation>Erro de tempo limite</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1918"/>
-      <source>Unspecified error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1918"/>
+        <source>Unspecified error</source>
+        <translation>Erro não especificado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1919"/>
-      <source>Remove error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1919"/>
+        <source>Remove error</source>
+        <translation>Erro ao remover</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1920"/>
-      <source>Rename error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1920"/>
+        <source>Rename error</source>
+        <translation>Erro ao renomear</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1921"/>
-      <source>Position error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1921"/>
+        <source>Position error</source>
+        <translation>Erro ao posicionar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1922"/>
-      <source>Resize error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1922"/>
+        <source>Resize error</source>
+        <translation>Erro ao redimensionar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1923"/>
-      <source>Permissions error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1923"/>
+        <source>Permissions error</source>
+        <translation>Erro de permissão</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1924"/>
-      <source>Copy error</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1924"/>
+        <source>Copy error</source>
+        <translation>Erro ao copiar</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1925"/>
-      <source>Unknown error (%1)</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1925"/>
+        <source>Unknown error (%1)</source>
+        <translation>Erro desconhecido (%1)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1928"/>
-      <source>Error Saving File</source>
-      <translation>Erro ao guardar ficheiro</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1928"/>
+        <source>Error Saving File</source>
+        <translation>Erro ao guardar ficheiro</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1929"/>
-      <source>An error occurred when saving &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Error: %2</source>
-      <translation>Ocorreu um erro ao guardar &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Erro: %2</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1929"/>
+        <source>An error occurred when saving &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Error: %2</source>
+        <translation>Ocorreu um erro ao guardar &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Erro: %2</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="1935"/>
-      <source>Zoom: %1%</source>
-      <translation>Zoom: %1%</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1935"/>
+        <source>Zoom: %1%</source>
+        <translation>Zoom: %1%</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/MainWindow.cpp" line="2102"/>
-      <source>No updates are available at this time.</source>
-      <translation>De momento, não há atualizações disponíveis.</translation>
+        <location filename="../src/dialogs/MainWindow.cpp" line="2102"/>
+        <source>No updates are available at this time.</source>
+        <translation>De momento, não há atualizações disponíveis.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>PreferencesDialog</name>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="14"/>
-      <source>Preferences</source>
-      <translation>Preferências</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="14"/>
+        <source>Preferences</source>
+        <translation>Preferências</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="37"/>
-      <source>Show menu bar</source>
-      <translation>Mostrar barra de menus</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="37"/>
+        <source>Show menu bar</source>
+        <translation>Mostrar barra de menus</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="44"/>
-      <source>Show toolbar</source>
-      <translation>Mostrar barra de ferramentas</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="44"/>
+        <source>Show toolbar</source>
+        <translation>Mostrar barra de ferramentas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="51"/>
-      <source>Show status bar</source>
-      <translation>Mostrar barra de estado</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="51"/>
+        <source>Show status bar</source>
+        <translation>Mostrar barra de estado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="58"/>
-      <source>Restore previous session</source>
-      <translation>Restaurar a sessão anterior</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="58"/>
+        <source>Restore previous session</source>
+        <translation>Restaurar a sessão anterior</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="70"/>
-      <source>Unsaved changes</source>
-      <translation>Alterações não guardadas</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="70"/>
+        <source>Unsaved changes</source>
+        <translation>Alterações não guardadas</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="77"/>
-      <source>Temporary files</source>
-      <translation>Ficheiros temporários</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="77"/>
+        <source>Temporary files</source>
+        <translation>Ficheiros temporários</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="89"/>
-      <source>Recenter find/replace dialog when opened</source>
-      <translation>Recolocar a janela localizar/substituir quando aberta</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="89"/>
+        <source>Recenter find/replace dialog when opened</source>
+        <translation>Recolocar a janela localizar/substituir quando aberta</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="96"/>
-      <source>Combine search results</source>
-      <translation>Combinar resultados de pesquisa</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="96"/>
+        <source>Combine search results</source>
+        <translation>Combinar resultados de pesquisa</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="114"/>
-      <source>Translation:</source>
-      <translation>Tradução:</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="114"/>
+        <source>Translation:</source>
+        <translation>Tradução:</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="123"/>
-      <source>Exit on last tab closed</source>
-      <translation>Sair no último separador fechado</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="123"/>
+        <source>Exit on last tab closed</source>
+        <translation>Sair no último separador fechado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="132"/>
-      <source>Default Font</source>
-      <translation>Tipo de letra predefinida</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="132"/>
+        <source>Default Font</source>
+        <translation>Tipo de letra predefinida</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="138"/>
-      <source>Font</source>
-      <translation>Tipo de letra</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="138"/>
+        <source>Font</source>
+        <translation>Tipo de letra</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="148"/>
-      <source>Font Size</source>
-      <translation>Tamanho do tipo de letra</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="148"/>
+        <source>Font Size</source>
+        <translation>Tamanho do tipo de letra</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="155"/>
-      <source>pt</source>
-      <translation>pt</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="155"/>
+        <source>pt</source>
+        <translation>pt</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="188"/>
-      <source>Default Line Endings</source>
-      <translation>Finais de linha predefinidos</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="188"/>
+        <source>Default Line Endings</source>
+        <translation>Finais de linha predefinidos</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="200"/>
-      <source>Highlight URLs</source>
-      <translation>Destacar URLs</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="200"/>
+        <source>Highlight URLs</source>
+        <translation>Destacar URLs</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="207"/>
-      <source>Show Line Numbers</source>
-      <translation>Mostrar números de linha</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="207"/>
+        <source>Show Line Numbers</source>
+        <translation>Mostrar números de linha</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="214"/>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="122"/>
-      <source>Default Directory</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="214"/>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="122"/>
+        <source>Default Directory</source>
+        <translation>Diretório predefinido</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="220"/>
-      <source>Follow Current Document</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="220"/>
+        <source>Follow Current Document</source>
+        <translation>Seguir o documento atual</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="227"/>
-      <source>Last Used Directory</source>
-      <translation type="unfinished"/>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="227"/>
+        <source>Last Used Directory</source>
+        <translation>Último diretório utilizado</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="246"/>
-      <source>...</source>
-      <translation>...</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="246"/>
+        <source>...</source>
+        <translation>...</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="277"/>
-      <source>TextLabel</source>
-      <translation>Legenda</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="277"/>
+        <source>TextLabel</source>
+        <translation>Legenda</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.ui" line="289"/>
-      <source>An application restart is required to apply certain settings.</source>
-      <translation>É necessário reiniciar a aplicação para aplicar determinadas definições.</translation>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="289"/>
+        <source>An application restart is required to apply certain settings.</source>
+        <translation>É necessário reiniciar a aplicação para aplicar determinadas definições.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
-      <source>Warning</source>
-      <translation>Aviso</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
+        <source>Warning</source>
+        <translation>Aviso</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
-      <source>This feature is experimental and it should not be considered safe for critically important work. It may lead to possible data loss. Use at your own risk.</source>
-      <translation>Esta funcionalidade é experimental e não deve ser considerada segura para trabalhos de importância crítica. Pode levar a uma possível perda de dados. Utilize-a por sua conta e risco.</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
+        <source>This feature is experimental and it should not be considered safe for critically important work. It may lead to possible data loss. Use at your own risk.</source>
+        <translation>Esta funcionalidade é experimental e não deve ser considerada segura para trabalhos de importância crítica. Pode levar a uma possível perda de dados. Utilize-a por sua conta e risco.</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="85"/>
-      <source>System Default</source>
-      <translation>Predefinição do sistema</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="85"/>
+        <source>System Default</source>
+        <translation>Predefinição do sistema</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="86"/>
-      <source>Windows (CR LF)</source>
-      <translation>Windows (CR LF)</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="86"/>
+        <source>Windows (CR LF)</source>
+        <translation>Windows (CR LF)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="87"/>
-      <source>Linux (LF)</source>
-      <translation>Linux (LF)</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="87"/>
+        <source>Linux (LF)</source>
+        <translation>Linux (LF)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="88"/>
-      <source>Macintosh (CR)</source>
-      <translation>Macintosh (CR)</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="88"/>
+        <source>Macintosh (CR)</source>
+        <translation>Macintosh (CR)</translation>
     </message>
     <message>
-      <location filename="../src/dialogs/PreferencesDialog.cpp" line="185"/>
-      <source>&lt;System Default&gt;</source>
-      <translation>&lt;System Default&gt;</translation>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="185"/>
+        <source>&lt;System Default&gt;</source>
+        <translation>&lt;System Default&gt;</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>QuickFindWidget</name>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="17"/>
-      <source>Frame</source>
-      <translation>Moldura</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="17"/>
+        <source>Frame</source>
+        <translation>Moldura</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="32"/>
-      <source>Find...</source>
-      <translation>Localizar...</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="32"/>
+        <source>Find...</source>
+        <translation>Localizar...</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="44"/>
-      <source>Match case</source>
-      <translation>Corresponder minúsculas/maiúsculas</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="44"/>
+        <source>Match case</source>
+        <translation>Corresponder minúsculas/maiúsculas</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="47"/>
-      <source>Aa</source>
-      <translation>Aa</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="47"/>
+        <source>Aa</source>
+        <translation>Aa</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="57"/>
-      <source>Match whole word</source>
-      <translation>Corresponder palavra inteira</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="57"/>
+        <source>Match whole word</source>
+        <translation>Corresponder palavra inteira</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="60"/>
-      <source>|A|</source>
-      <translation>|A|</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="60"/>
+        <source>|A|</source>
+        <translation>|A|</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="70"/>
-      <source>Use regular expression</source>
-      <translation>Usar expressão regular</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="70"/>
+        <source>Use regular expression</source>
+        <translation>Usar expressão regular</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="73"/>
-      <source>. *</source>
-      <translation>. *</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="73"/>
+        <source>. *</source>
+        <translation>. *</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.ui" line="76"/>
-      <source>Alt+E</source>
-      <translation>Alt+E</translation>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="76"/>
+        <source>Alt+E</source>
+        <translation>Alt+E</translation>
     </message>
     <message>
-      <location filename="../src/widgets/QuickFindWidget.cpp" line="238"/>
-      <source>%L1/%L2</source>
-      <translation>%L1/%L2</translation>
+        <location filename="../src/widgets/QuickFindWidget.cpp" line="238"/>
+        <source>%L1/%L2</source>
+        <translation>%L1/%L2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>SearchResultsDock</name>
     <message>
-      <location filename="../src/docks/SearchResultsDock.ui" line="14"/>
-      <source>Search Results</source>
-      <translation>Resultados da pesquisa</translation>
+        <location filename="../src/docks/SearchResultsDock.ui" line="14"/>
+        <source>Search Results</source>
+        <translation>Resultados da pesquisa</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.ui" line="38"/>
-      <source>Copy Results to Clipboard</source>
-      <translation>Copiar resultados para a área de transferência</translation>
+        <location filename="../src/docks/SearchResultsDock.ui" line="38"/>
+        <source>Copy Results to Clipboard</source>
+        <translation>Copiar resultados para a área de transferência</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.cpp" line="57"/>
-      <source>Collapse All</source>
-      <translation>Recolher tudo</translation>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="57"/>
+        <source>Collapse All</source>
+        <translation>Recolher tudo</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.cpp" line="58"/>
-      <source>Expand All</source>
-      <translation>Expandir tudo</translation>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="58"/>
+        <source>Expand All</source>
+        <translation>Expandir tudo</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.cpp" line="60"/>
-      <source>Delete Entry</source>
-      <translation>Eliminar entrada</translation>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="60"/>
+        <source>Delete Entry</source>
+        <translation>Eliminar entrada</translation>
     </message>
     <message>
-      <location filename="../src/docks/SearchResultsDock.cpp" line="62"/>
-      <source>Delete All</source>
-      <translation>Eliminar tudo</translation>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="62"/>
+        <source>Delete All</source>
+        <translation>Eliminar tudo</translation>
     </message>
-  </context>
+</context>
 </TS>


### PR DESCRIPTION
The `pt` lang was added since the last release... there should only be `pt_BR` and `pt_PT` lang codes Nevertheless, `pt` stands for Portuguese language, not Portuguese from Brazil