### PR TITLE
Fix file rename: pre-fill dialog and actually delete old file

### DIFF
--- a/src/ScintillaNext.cpp
+++ b/src/ScintillaNext.cpp
@@ -456,7 +456,7 @@ bool ScintillaNext::rename(const QString &newFilePath)
     emit aboutToSave();
 
     // Write out the buffer to the new path
-    if (saveCopyAs(newFilePath)) {
+    if (saveCopyAs(newFilePath) == QFileDevice::NoError) {
         // Remove the old file
         const QString oldPath = fileInfo.canonicalFilePath();
         QFile::remove(oldPath);

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -1479,7 +1479,7 @@ void MainWindow::renameFile()
     if (editor->isFile()) {
         const QString filter = app->getFileDialogFilter();
         QString selectedFilter = app->getFileDialogFilterForLanguage(editor->languageName);
-        QString fileName = FileDialogHelpers::getSaveFileName(this, tr("Rename"), defaultDirectoryManager->getDefaultDirectory(), filter, &selectedFilter);
+        QString fileName = FileDialogHelpers::getSaveFileName(this, tr("Rename"), editor->getFilePath(), filter, &selectedFilter);
 
         if (fileName.isEmpty()) {
             return;


### PR DESCRIPTION
Fixes #1034

### Problem

Two bugs caused the rename feature (right-click tab → Rename) to misbehave:

1. **Dialog opened with no pre-filled name.** `MainWindow::renameFile()` passed only the default directory to `FileDialogHelpers::getSaveFileName`. `QFileDialog` only pre-fills the filename field when given a full file path, so the field was always empty.

2. **Old file was never deleted.** `ScintillaNext::rename()` checked `if (saveCopyAs(newFilePath))` to decide whether to remove the original. `saveCopyAs` returns `QFileDevice::FileError`, where `NoError == 0` (falsy). The condition was inverted — it entered the block only on *error*, so on success the `QFile::remove` was skipped and the old file was left on disk.

The combination made it appear as if the file was "renamed" in the tab but the original remained untouched and a second copy appeared at the destination.

Video of the manual test below :

[Screencast from 2026-05-02 00-56-33.webm](https://github.com/user-attachments/assets/c8ae800a-e758-4640-b0a6-1967ac13627c)

### Changes

**`src/dialogs/MainWindow.cpp`**

Pass `editor->getFilePath()` (the current file's full path) to `getSaveFileName` instead of the default directory. `QFileDialog` now navigates to the file's directory and pre-fills its name.

**`src/ScintillaNext.cpp`**

Change the save-success check from `if (saveCopyAs(newFilePath))` to `if (saveCopyAs(newFilePath) == QFileDevice::NoError)`. The old file is now correctly removed after a successful copy.

