### PR TITLE
Add dark mode (System / Light / Dark theme setting)

### DIFF
--- a/src/ApplicationSettings.cpp
+++ b/src/ApplicationSettings.cpp
@@ -20,6 +20,7 @@
 
 #include <QApplication>
 #include <QFont>
+#include <QStyleHints>
 
 #define CREATE_SETTING(group, name, lname, type, default) \
 ApplicationSetting<type> name{#group "/" #name, default};\
@@ -38,6 +39,28 @@ ApplicationSetting<type> name{#group "/" #name, default};\
 ApplicationSettings::ApplicationSettings(QObject *parent)
     : QSettings{parent}
 {
+    // Translate user-facing theme changes and OS-level color-scheme changes
+    // into a single effectiveDarkModeChanged signal that consumers listen for.
+    connect(this, &ApplicationSettings::themeChanged, this, [this](ThemeMode) {
+        emit effectiveDarkModeChanged(effectiveDarkMode());
+    });
+    if (auto *hints = QGuiApplication::styleHints()) {
+        connect(hints, &QStyleHints::colorSchemeChanged, this, [this](Qt::ColorScheme) {
+            if (theme() == SystemTheme)
+                emit effectiveDarkModeChanged(effectiveDarkMode());
+        });
+    }
+}
+
+bool ApplicationSettings::effectiveDarkMode() const
+{
+    switch (theme()) {
+    case LightTheme: return false;
+    case DarkTheme:  return true;
+    case SystemTheme:
+    default:
+        return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+    }
 }
 
 CREATE_SETTING(Gui, ShowMenuBar, showMenuBar, bool, true)
@@ -72,4 +95,4 @@ CREATE_SETTING(Editor, DefaultEOLMode, defaultEOLMode, QString, QStringLiteral("
 CREATE_SETTING(Editor, URLHighlighting, urlHighlighting, bool, true)
 CREATE_SETTING(Editor, ShowLineNumbers, showLineNumbers, bool, true)
 
-CREATE_SETTING(Gui, DarkMode, darkMode, bool, false)
+CREATE_SETTING(Gui, Theme, theme, ApplicationSettings::ThemeMode, ApplicationSettings::SystemTheme)

--- a/src/ApplicationSettings.cpp
+++ b/src/ApplicationSettings.cpp
@@ -71,3 +71,5 @@ CREATE_SETTING(Editor, AdditionalWordChars, additionalWordChars, QString, QStrin
 CREATE_SETTING(Editor, DefaultEOLMode, defaultEOLMode, QString, QStringLiteral(""))
 CREATE_SETTING(Editor, URLHighlighting, urlHighlighting, bool, true)
 CREATE_SETTING(Editor, ShowLineNumbers, showLineNumbers, bool, true)
+
+CREATE_SETTING(Gui, DarkMode, darkMode, bool, false)

--- a/src/ApplicationSettings.h
+++ b/src/ApplicationSettings.h
@@ -119,4 +119,6 @@ public:
     DEFINE_SETTING(DefaultEOLMode, defaultEOLMode, QString)
     DEFINE_SETTING(URLHighlighting, urlHighlighting, bool)
     DEFINE_SETTING(ShowLineNumbers, showLineNumbers, bool)
+
+    DEFINE_SETTING(DarkMode, darkMode, bool)
 };

--- a/src/ApplicationSettings.h
+++ b/src/ApplicationSettings.h
@@ -76,6 +76,17 @@ public:
     };
     Q_ENUM(DefaultDirectoryBehaviorEnum)
 
+    enum ThemeMode {
+        SystemTheme,
+        LightTheme,
+        DarkTheme
+    };
+    Q_ENUM(ThemeMode)
+
+    // Resolves Theme=System against the current QStyleHints color scheme.
+    bool effectiveDarkMode() const;
+    Q_SIGNAL void effectiveDarkModeChanged(bool dark);
+
     template <typename T>
     T get(const char *key, const T &defaultValue) const
     { return value(QLatin1String(key), defaultValue).template value<T>(); }
@@ -120,5 +131,5 @@ public:
     DEFINE_SETTING(URLHighlighting, urlHighlighting, bool)
     DEFINE_SETTING(ShowLineNumbers, showLineNumbers, bool)
 
-    DEFINE_SETTING(DarkMode, darkMode, bool)
+    DEFINE_SETTING(Theme, theme, ThemeMode)
 };

--- a/src/EditorManager.cpp
+++ b/src/EditorManager.cpp
@@ -307,20 +307,20 @@ void EditorManager::applyEditorTheme(ScintillaNext *editor)
 {
     const bool dark = settings->darkMode();
 
-    // Fold markers
+    // Fold markers (not affected by styleClearAll)
     for (int i = SC_MARKNUM_FOLDEREND; i <= SC_MARKNUM_FOLDEROPEN; ++i) {
         editor->markerSetFore(i, dark ? 0x3C3C3C : 0xF3F3F3);
         editor->markerSetBack(i, 0x808080);
         editor->markerSetBackSelected(i, dark ? 0xCC7A00 : 0x0000FF);
     }
 
-    // Element colors (ARGB 0xAARRGGBB)
+    // Element colors (ARGB 0xAARRGGBB; not affected by styleClearAll)
     editor->setElementColour(SC_ELEMENT_SELECTION_INACTIVE_BACK, dark ? 0xFF3A3D41 : 0xFFE0E0E0);
     editor->setElementColour(SC_ELEMENT_CARET_LINE_BACK,         dark ? 0xFF2A2D2E : 0xFFFFE8E8);
     editor->setElementColour(SC_ELEMENT_WHITE_SPACE,             dark ? 0xFF505050 : 0xFFD0D0D0);
     editor->setElementColour(SC_ELEMENT_FOLD_LINE,               dark ? 0xFF505050 : 0xFFA0A0A0);
 
-    // Fold margin
+    // Fold margin (not affected by styleClearAll)
     editor->setFoldMarginColour(true,   dark ? 0x1E1E1E : 0xFFFFFF);
     editor->setFoldMarginHiColour(true, dark ? 0x252526 : 0xE9E9E9);
 
@@ -328,6 +328,15 @@ void EditorManager::applyEditorTheme(ScintillaNext *editor)
     editor->styleSetFore(STYLE_DEFAULT, dark ? 0xD4D4D4 : 0x000000);
     editor->styleSetBack(STYLE_DEFAULT, dark ? 0x1E1E1E : 0xFFFFFF);
     editor->styleClearAll();
+
+    // Named styles must be re-applied after any subsequent styleClearAll
+    // (Lua SetStyle does one when a language is loaded)
+    applyEditorNamedStyles(editor);
+}
+
+void EditorManager::applyEditorNamedStyles(ScintillaNext *editor)
+{
+    const bool dark = settings->darkMode();
 
     editor->styleSetFore(STYLE_LINENUMBER, dark ? 0x858585 : 0x808080);
     editor->styleSetBack(STYLE_LINENUMBER, dark ? 0x252526 : 0xE4E4E4);

--- a/src/EditorManager.cpp
+++ b/src/EditorManager.cpp
@@ -128,6 +128,11 @@ EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
             }
         }
     });
+
+    connect(settings, &ApplicationSettings::darkModeChanged, this, [=](bool) {
+        for (auto &editor : getEditors())
+            applyEditorTheme(editor);
+    });
 }
 
 ScintillaNext *EditorManager::createEditor(const QString &name)
@@ -225,29 +230,7 @@ void EditorManager::setupEditor(ScintillaNext *editor)
 
     editor->setEdgeColour(0x80FFFF);
 
-    // https://www.scintilla.org/ScintillaDoc.html#ElementColours
-    // SC_ELEMENT_SELECTION_TEXT
-    // SC_ELEMENT_SELECTION_BACK
-    // SC_ELEMENT_SELECTION_ADDITIONAL_TEXT
-    // SC_ELEMENT_SELECTION_ADDITIONAL_BACK
-    // SC_ELEMENT_SELECTION_SECONDARY_TEXT
-    // SC_ELEMENT_SELECTION_SECONDARY_BACK
-    // SC_ELEMENT_SELECTION_INACTIVE_TEXT
-    editor->setElementColour(SC_ELEMENT_SELECTION_INACTIVE_BACK, 0xFFE0E0E0);
-    // SC_ELEMENT_CARET
-    // SC_ELEMENT_CARET_ADDITIONAL
-    editor->setElementColour(SC_ELEMENT_CARET_LINE_BACK, 0xFFFFE8E8);
-    editor->setElementColour(SC_ELEMENT_WHITE_SPACE, 0xFFD0D0D0);
-    // SC_ELEMENT_WHITE_SPACE_BACK
-    // SC_ELEMENT_HOT_SPOT_ACTIVE
-    // SC_ELEMENT_HOT_SPOT_ACTIVE_BACK
-    editor->setElementColour(SC_ELEMENT_FOLD_LINE, 0xFFA0A0A0);
-    // SC_ELEMENT_HIDDEN_LINE
-
     editor->setWhitespaceSize(2);
-
-    editor->setFoldMarginColour(true, 0xFFFFFF);
-    editor->setFoldMarginHiColour(true, 0xE9E9E9);
 
     editor->setAutomaticFold(SC_AUTOMATICFOLD_SHOW | SC_AUTOMATICFOLD_CLICK | SC_AUTOMATICFOLD_CHANGE);
     editor->markerEnableHighlight(true);
@@ -255,24 +238,10 @@ void EditorManager::setupEditor(ScintillaNext *editor)
     editor->setCharsDefault();
     editor->setWordChars(editor->wordChars() + settings->additionalWordChars().toLatin1());
 
-    editor->styleSetFore(STYLE_DEFAULT, 0x000000);
-    editor->styleSetBack(STYLE_DEFAULT, 0xFFFFFF);
     editor->styleSetSize(STYLE_DEFAULT, settings->fontSize());
     editor->styleSetFont(STYLE_DEFAULT, settings->fontName().toUtf8().data());
-    editor->styleClearAll();
 
-    editor->styleSetFore(STYLE_LINENUMBER, 0x808080);
-    editor->styleSetBack(STYLE_LINENUMBER, 0xE4E4E4);
-    editor->styleSetBold(STYLE_LINENUMBER, false);
-
-    editor->styleSetFore(STYLE_BRACELIGHT, 0x0000FF);
-    editor->styleSetBack(STYLE_BRACELIGHT, 0xFFFFFF);
-
-    editor->styleSetFore(STYLE_BRACEBAD, 0x000080);
-    editor->styleSetBack(STYLE_BRACEBAD, 0xFFFFFF);
-
-    editor->styleSetFore(STYLE_INDENTGUIDE, 0xC0C0C0);
-    editor->styleSetBack(STYLE_INDENTGUIDE, 0xFFFFFF);
+    applyEditorTheme(editor);
 
     // STYLE_CONTROLCHAR
     // STYLE_CALLTIP
@@ -332,6 +301,46 @@ void EditorManager::setupEditor(ScintillaNext *editor)
     bm->setEnabled(true);
 
     new HTMLAutoCompleteDecorator(editor);
+}
+
+void EditorManager::applyEditorTheme(ScintillaNext *editor)
+{
+    const bool dark = settings->darkMode();
+
+    // Fold markers
+    for (int i = SC_MARKNUM_FOLDEREND; i <= SC_MARKNUM_FOLDEROPEN; ++i) {
+        editor->markerSetFore(i, dark ? 0x3C3C3C : 0xF3F3F3);
+        editor->markerSetBack(i, 0x808080);
+        editor->markerSetBackSelected(i, dark ? 0xCC7A00 : 0x0000FF);
+    }
+
+    // Element colors (ARGB 0xAARRGGBB)
+    editor->setElementColour(SC_ELEMENT_SELECTION_INACTIVE_BACK, dark ? 0xFF3A3D41 : 0xFFE0E0E0);
+    editor->setElementColour(SC_ELEMENT_CARET_LINE_BACK,         dark ? 0xFF2A2D2E : 0xFFFFE8E8);
+    editor->setElementColour(SC_ELEMENT_WHITE_SPACE,             dark ? 0xFF505050 : 0xFFD0D0D0);
+    editor->setElementColour(SC_ELEMENT_FOLD_LINE,               dark ? 0xFF505050 : 0xFFA0A0A0);
+
+    // Fold margin
+    editor->setFoldMarginColour(true,   dark ? 0x1E1E1E : 0xFFFFFF);
+    editor->setFoldMarginHiColour(true, dark ? 0x252526 : 0xE9E9E9);
+
+    // STYLE_DEFAULT sets the base for styleClearAll()
+    editor->styleSetFore(STYLE_DEFAULT, dark ? 0xD4D4D4 : 0x000000);
+    editor->styleSetBack(STYLE_DEFAULT, dark ? 0x1E1E1E : 0xFFFFFF);
+    editor->styleClearAll();
+
+    editor->styleSetFore(STYLE_LINENUMBER, dark ? 0x858585 : 0x808080);
+    editor->styleSetBack(STYLE_LINENUMBER, dark ? 0x252526 : 0xE4E4E4);
+    editor->styleSetBold(STYLE_LINENUMBER, false);
+
+    editor->styleSetFore(STYLE_BRACELIGHT, dark ? 0xD4D4D4 : 0x0000FF);
+    editor->styleSetBack(STYLE_BRACELIGHT, dark ? 0x1E1E1E : 0xFFFFFF);
+
+    editor->styleSetFore(STYLE_BRACEBAD,   dark ? 0x0000FF : 0x000080);
+    editor->styleSetBack(STYLE_BRACEBAD,   dark ? 0x1E1E1E : 0xFFFFFF);
+
+    editor->styleSetFore(STYLE_INDENTGUIDE, dark ? 0x404040 : 0xC0C0C0);
+    editor->styleSetBack(STYLE_INDENTGUIDE, dark ? 0x1E1E1E : 0xFFFFFF);
 }
 
 void EditorManager::purgeOldEditorPointers()

--- a/src/EditorManager.cpp
+++ b/src/EditorManager.cpp
@@ -129,7 +129,7 @@ EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
         }
     });
 
-    connect(settings, &ApplicationSettings::darkModeChanged, this, [=](bool) {
+    connect(settings, &ApplicationSettings::effectiveDarkModeChanged, this, [=](bool) {
         for (auto &editor : getEditors())
             applyEditorTheme(editor);
     });
@@ -305,7 +305,7 @@ void EditorManager::setupEditor(ScintillaNext *editor)
 
 void EditorManager::applyEditorTheme(ScintillaNext *editor)
 {
-    const bool dark = settings->darkMode();
+    const bool dark = settings->effectiveDarkMode();
 
     // Fold markers (not affected by styleClearAll)
     for (int i = SC_MARKNUM_FOLDEREND; i <= SC_MARKNUM_FOLDEROPEN; ++i) {
@@ -336,7 +336,7 @@ void EditorManager::applyEditorTheme(ScintillaNext *editor)
 
 void EditorManager::applyEditorNamedStyles(ScintillaNext *editor)
 {
-    const bool dark = settings->darkMode();
+    const bool dark = settings->effectiveDarkMode();
 
     editor->styleSetFore(STYLE_LINENUMBER, dark ? 0x858585 : 0x808080);
     editor->styleSetBack(STYLE_LINENUMBER, dark ? 0x252526 : 0xE4E4E4);

--- a/src/EditorManager.h
+++ b/src/EditorManager.h
@@ -41,6 +41,10 @@ public:
 
     void manageEditor(ScintillaNext *editor);
 
+    void applyEditorTheme(ScintillaNext *editor);
+
+    QList<QPointer<ScintillaNext>> getEditors();
+
 signals:
     void editorCreated(ScintillaNext *editor);
     void editorClosed(ScintillaNext *editor);
@@ -48,7 +52,6 @@ signals:
 private:
     void setupEditor(ScintillaNext *editor);
     void purgeOldEditorPointers();
-    QList<QPointer<ScintillaNext>> getEditors();
     int detectEOLMode(ScintillaNext *editor) const;
 
     QList<QPointer<ScintillaNext>> editors;

--- a/src/EditorManager.h
+++ b/src/EditorManager.h
@@ -42,6 +42,7 @@ public:
     void manageEditor(ScintillaNext *editor);
 
     void applyEditorTheme(ScintillaNext *editor);
+    void applyEditorNamedStyles(ScintillaNext *editor);
 
     QList<QPointer<ScintillaNext>> getEditors();
 

--- a/src/NotepadNextApplication.cpp
+++ b/src/NotepadNextApplication.cpp
@@ -149,11 +149,11 @@ bool NotepadNextApplication::init()
     MarkerAppDecorator *mad = new MarkerAppDecorator(this);
     mad->setEnabled(true);
 
-    luaState->setVariable("dark_mode", settings->darkMode());
+    luaState->setVariable("dark_mode", settings->effectiveDarkMode());
     luaState->executeFile(":/scripts/init.lua");
     LuaExtension::Instance().Initialise(luaState->L, Q_NULLPTR);
 
-    connect(settings, &ApplicationSettings::darkModeChanged, this, &NotepadNextApplication::refreshEditorTheme);
+    connect(settings, &ApplicationSettings::effectiveDarkModeChanged, this, &NotepadNextApplication::refreshEditorTheme);
 
     createNewWindow();
     connect(editorManager, &EditorManager::editorCreated, window, &MainWindow::addEditor);
@@ -518,7 +518,7 @@ QStringList NotepadNextApplication::debugInfo() const
 
 void NotepadNextApplication::refreshEditorTheme()
 {
-    getLuaState()->setVariable("dark_mode", settings->darkMode());
+    getLuaState()->setVariable("dark_mode", settings->effectiveDarkMode());
     getLuaState()->execute("UpdateTheme()");
 
     for (auto &editor : editorManager->getEditors()) {

--- a/src/NotepadNextApplication.cpp
+++ b/src/NotepadNextApplication.cpp
@@ -298,6 +298,10 @@ void NotepadNextApplication::setEditorLanguage(ScintillaNext *editor, const QStr
     getLuaState()->setVariable("skip_tabwidth", skipTabWidth);
 
     getLuaState()->execute("SetLanguage(languageName)");
+
+    // Restore line number, brace match, and indent guide colors that the
+    // Lua-side styleClearAll wiped.
+    editorManager->applyEditorNamedStyles(editor);
 }
 
 QString NotepadNextApplication::detectLanguage(ScintillaNext *editor) const

--- a/src/NotepadNextApplication.cpp
+++ b/src/NotepadNextApplication.cpp
@@ -149,8 +149,11 @@ bool NotepadNextApplication::init()
     MarkerAppDecorator *mad = new MarkerAppDecorator(this);
     mad->setEnabled(true);
 
+    luaState->setVariable("dark_mode", settings->darkMode());
     luaState->executeFile(":/scripts/init.lua");
     LuaExtension::Instance().Initialise(luaState->L, Q_NULLPTR);
+
+    connect(settings, &ApplicationSettings::darkModeChanged, this, &NotepadNextApplication::refreshEditorTheme);
 
     createNewWindow();
     connect(editorManager, &EditorManager::editorCreated, window, &MainWindow::addEditor);
@@ -507,4 +510,15 @@ QStringList NotepadNextApplication::debugInfo() const
     info.append(QStringLiteral("Config File: %1").arg(ApplicationSettings().fileName()));
 
     return info;
+}
+
+void NotepadNextApplication::refreshEditorTheme()
+{
+    getLuaState()->setVariable("dark_mode", settings->darkMode());
+    getLuaState()->execute("UpdateTheme()");
+
+    for (auto &editor : editorManager->getEditors()) {
+        if (!editor->languageName.isEmpty())
+            setEditorLanguage(editor, editor->languageName);
+    }
 }

--- a/src/NotepadNextApplication.h
+++ b/src/NotepadNextApplication.h
@@ -73,6 +73,9 @@ public:
 protected:
     bool event(QEvent *event) override;
 
+public slots:
+    void refreshEditorTheme();
+
 private slots:
     void saveSettings();
     void receiveInfoFromSecondaryInstance(quint32 instanceId, QByteArray message);

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -42,6 +42,8 @@
 #include <QProcess>
 #include <QScreen>
 #include <QFontDatabase>
+#include <QPalette>
+#include <QStyleFactory>
 
 
 #ifdef Q_OS_WIN
@@ -882,7 +884,7 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     languageInspectorDock->hide();
     addDockWidget(Qt::RightDockWidgetArea, languageInspectorDock);
 
-    LuaConsoleDock *luaConsoleDock = new LuaConsoleDock(app->getLuaState(), this);
+    LuaConsoleDock *luaConsoleDock = new LuaConsoleDock(app->getLuaState(), app->getSettings(), this);
     luaConsoleDock->hide();
     addDockWidget(Qt::BottomDockWidgetArea, luaConsoleDock);
 
@@ -914,6 +916,7 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     });
     connect(app->getSettings(), &ApplicationSettings::showToolBarChanged, ui->mainToolBar, &QToolBar::setVisible);
     connect(app->getSettings(), &ApplicationSettings::showStatusBarChanged, ui->statusBar, &QStatusBar::setVisible);
+    connect(app->getSettings(), &ApplicationSettings::darkModeChanged, this, &MainWindow::applyStyleSheet);
     connect(ui->statusBar, &EditorInfoStatusBar::customContextMenuRequestedForEOLLabel, this, [=](const QPoint &pos){
         ui->menuEOLConversion->popup(pos);
     });
@@ -1799,10 +1802,38 @@ void MainWindow::applyStyleSheet()
 {
     qInfo(Q_FUNC_INFO);
 
-    QString sheet;
-    QFile f(":/stylesheets/npp.css");
-    qInfo() << "Loading stylesheet:" << f.fileName();
+    const bool dark = app->getSettings()->darkMode();
 
+    // Apply Fusion palette for all standard Qt widgets
+    QApplication::setStyle(QStyleFactory::create("Fusion"));
+
+    if (dark) {
+        QPalette p;
+        p.setColor(QPalette::Window,          QColor(0x1E, 0x1E, 0x1E));
+        p.setColor(QPalette::WindowText,      QColor(0xD4, 0xD4, 0xD4));
+        p.setColor(QPalette::Base,            QColor(0x25, 0x25, 0x26));
+        p.setColor(QPalette::AlternateBase,   QColor(0x2D, 0x2D, 0x2D));
+        p.setColor(QPalette::Text,            QColor(0xD4, 0xD4, 0xD4));
+        p.setColor(QPalette::Button,          QColor(0x3C, 0x3C, 0x3C));
+        p.setColor(QPalette::ButtonText,      QColor(0xD4, 0xD4, 0xD4));
+        p.setColor(QPalette::Highlight,       QColor(0x00, 0x7A, 0xCC));
+        p.setColor(QPalette::HighlightedText, QColor(0xFF, 0xFF, 0xFF));
+        p.setColor(QPalette::ToolTipBase,     QColor(0x25, 0x25, 0x26));
+        p.setColor(QPalette::ToolTipText,     QColor(0xD4, 0xD4, 0xD4));
+        p.setColor(QPalette::Link,            QColor(0x40, 0xA0, 0xFF));
+        p.setColor(QPalette::Disabled, QPalette::Text,       QColor(0x66, 0x66, 0x66));
+        p.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(0x66, 0x66, 0x66));
+        QApplication::setPalette(p);
+    } else {
+        QApplication::setPalette(QApplication::style()->standardPalette());
+    }
+
+    // Targeted CSS for custom widgets (ADS dock tabs, QuickFindWidget, status bar)
+    const QString cssResource = dark ? QStringLiteral(":/stylesheets/npp-dark.css")
+                                     : QStringLiteral(":/stylesheets/npp.css");
+    QString sheet;
+    QFile f(cssResource);
+    qInfo() << "Loading stylesheet:" << f.fileName();
     f.open(QFile::ReadOnly);
     sheet = f.readAll();
     f.close();

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -43,7 +43,6 @@
 #include <QScreen>
 #include <QFontDatabase>
 #include <QPalette>
-#include <QStyleFactory>
 
 
 #ifdef Q_OS_WIN
@@ -1805,14 +1804,11 @@ void MainWindow::applyStyleSheet()
     auto *settings = app->getSettings();
     const bool dark = settings->effectiveDarkMode();
 
-    QApplication::setStyle(QStyleFactory::create("Fusion"));
-
     if (settings->theme() == ApplicationSettings::SystemTheme) {
-        // Follow the desktop environment: Fusion's standardPalette() in Qt 6.5+
-        // adapts to QStyleHints::colorScheme().
-        QApplication::setPalette(QApplication::style()->standardPalette());
+        // Follow the desktop environment - leave the Qt-default palette alone.
+        // Qt 6.5+ already syncs the palette with QStyleHints::colorScheme().
     } else {
-        // Explicit Light or Dark override - hardcoded palettes so the app
+        // Explicit Light or Dark override - hardcoded palette so the app
         // theme is independent of the system color scheme.
         QPalette p;
         if (dark) {

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -1807,8 +1807,8 @@ void MainWindow::applyStyleSheet()
     // Apply Fusion palette for all standard Qt widgets
     QApplication::setStyle(QStyleFactory::create("Fusion"));
 
+    QPalette p;
     if (dark) {
-        QPalette p;
         p.setColor(QPalette::Window,          QColor(0x1E, 0x1E, 0x1E));
         p.setColor(QPalette::WindowText,      QColor(0xD4, 0xD4, 0xD4));
         p.setColor(QPalette::Base,            QColor(0x25, 0x25, 0x26));
@@ -1823,10 +1823,24 @@ void MainWindow::applyStyleSheet()
         p.setColor(QPalette::Link,            QColor(0x40, 0xA0, 0xFF));
         p.setColor(QPalette::Disabled, QPalette::Text,       QColor(0x66, 0x66, 0x66));
         p.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(0x66, 0x66, 0x66));
-        QApplication::setPalette(p);
     } else {
-        QApplication::setPalette(QApplication::style()->standardPalette());
+        // Explicit light palette so Qt does not pick up the system dark scheme
+        p.setColor(QPalette::Window,          QColor(0xF0, 0xF0, 0xF0));
+        p.setColor(QPalette::WindowText,      QColor(0x00, 0x00, 0x00));
+        p.setColor(QPalette::Base,            QColor(0xFF, 0xFF, 0xFF));
+        p.setColor(QPalette::AlternateBase,   QColor(0xF7, 0xF7, 0xF7));
+        p.setColor(QPalette::Text,            QColor(0x00, 0x00, 0x00));
+        p.setColor(QPalette::Button,          QColor(0xE6, 0xE6, 0xE6));
+        p.setColor(QPalette::ButtonText,      QColor(0x00, 0x00, 0x00));
+        p.setColor(QPalette::Highlight,       QColor(0x33, 0x99, 0xFF));
+        p.setColor(QPalette::HighlightedText, QColor(0xFF, 0xFF, 0xFF));
+        p.setColor(QPalette::ToolTipBase,     QColor(0xFF, 0xFF, 0xDC));
+        p.setColor(QPalette::ToolTipText,     QColor(0x00, 0x00, 0x00));
+        p.setColor(QPalette::Link,            QColor(0x00, 0x00, 0xEE));
+        p.setColor(QPalette::Disabled, QPalette::Text,       QColor(0x99, 0x99, 0x99));
+        p.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(0x99, 0x99, 0x99));
     }
+    QApplication::setPalette(p);
 
     // Targeted CSS for custom widgets (ADS dock tabs, QuickFindWidget, status bar)
     const QString cssResource = dark ? QStringLiteral(":/stylesheets/npp-dark.css")

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -1802,45 +1802,52 @@ void MainWindow::applyStyleSheet()
 {
     qInfo(Q_FUNC_INFO);
 
-    const bool dark = app->getSettings()->effectiveDarkMode();
+    auto *settings = app->getSettings();
+    const bool dark = settings->effectiveDarkMode();
 
-    // Apply Fusion palette for all standard Qt widgets
     QApplication::setStyle(QStyleFactory::create("Fusion"));
 
-    QPalette p;
-    if (dark) {
-        p.setColor(QPalette::Window,          QColor(0x1E, 0x1E, 0x1E));
-        p.setColor(QPalette::WindowText,      QColor(0xD4, 0xD4, 0xD4));
-        p.setColor(QPalette::Base,            QColor(0x25, 0x25, 0x26));
-        p.setColor(QPalette::AlternateBase,   QColor(0x2D, 0x2D, 0x2D));
-        p.setColor(QPalette::Text,            QColor(0xD4, 0xD4, 0xD4));
-        p.setColor(QPalette::Button,          QColor(0x3C, 0x3C, 0x3C));
-        p.setColor(QPalette::ButtonText,      QColor(0xD4, 0xD4, 0xD4));
-        p.setColor(QPalette::Highlight,       QColor(0x00, 0x7A, 0xCC));
-        p.setColor(QPalette::HighlightedText, QColor(0xFF, 0xFF, 0xFF));
-        p.setColor(QPalette::ToolTipBase,     QColor(0x25, 0x25, 0x26));
-        p.setColor(QPalette::ToolTipText,     QColor(0xD4, 0xD4, 0xD4));
-        p.setColor(QPalette::Link,            QColor(0x40, 0xA0, 0xFF));
-        p.setColor(QPalette::Disabled, QPalette::Text,       QColor(0x66, 0x66, 0x66));
-        p.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(0x66, 0x66, 0x66));
+    if (settings->theme() == ApplicationSettings::SystemTheme) {
+        // Follow the desktop environment: Fusion's standardPalette() in Qt 6.5+
+        // adapts to QStyleHints::colorScheme().
+        QApplication::setPalette(QApplication::style()->standardPalette());
     } else {
-        // Explicit light palette so Qt does not pick up the system dark scheme
-        p.setColor(QPalette::Window,          QColor(0xF0, 0xF0, 0xF0));
-        p.setColor(QPalette::WindowText,      QColor(0x00, 0x00, 0x00));
-        p.setColor(QPalette::Base,            QColor(0xFF, 0xFF, 0xFF));
-        p.setColor(QPalette::AlternateBase,   QColor(0xF7, 0xF7, 0xF7));
-        p.setColor(QPalette::Text,            QColor(0x00, 0x00, 0x00));
-        p.setColor(QPalette::Button,          QColor(0xE6, 0xE6, 0xE6));
-        p.setColor(QPalette::ButtonText,      QColor(0x00, 0x00, 0x00));
-        p.setColor(QPalette::Highlight,       QColor(0x33, 0x99, 0xFF));
-        p.setColor(QPalette::HighlightedText, QColor(0xFF, 0xFF, 0xFF));
-        p.setColor(QPalette::ToolTipBase,     QColor(0xFF, 0xFF, 0xDC));
-        p.setColor(QPalette::ToolTipText,     QColor(0x00, 0x00, 0x00));
-        p.setColor(QPalette::Link,            QColor(0x00, 0x00, 0xEE));
-        p.setColor(QPalette::Disabled, QPalette::Text,       QColor(0x99, 0x99, 0x99));
-        p.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(0x99, 0x99, 0x99));
+        // Explicit Light or Dark override - hardcoded palettes so the app
+        // theme is independent of the system color scheme.
+        QPalette p;
+        if (dark) {
+            p.setColor(QPalette::Window,          QColor(0x1E, 0x1E, 0x1E));
+            p.setColor(QPalette::WindowText,      QColor(0xD4, 0xD4, 0xD4));
+            p.setColor(QPalette::Base,            QColor(0x25, 0x25, 0x26));
+            p.setColor(QPalette::AlternateBase,   QColor(0x2D, 0x2D, 0x2D));
+            p.setColor(QPalette::Text,            QColor(0xD4, 0xD4, 0xD4));
+            p.setColor(QPalette::Button,          QColor(0x3C, 0x3C, 0x3C));
+            p.setColor(QPalette::ButtonText,      QColor(0xD4, 0xD4, 0xD4));
+            p.setColor(QPalette::Highlight,       QColor(0x00, 0x7A, 0xCC));
+            p.setColor(QPalette::HighlightedText, QColor(0xFF, 0xFF, 0xFF));
+            p.setColor(QPalette::ToolTipBase,     QColor(0x25, 0x25, 0x26));
+            p.setColor(QPalette::ToolTipText,     QColor(0xD4, 0xD4, 0xD4));
+            p.setColor(QPalette::Link,            QColor(0x40, 0xA0, 0xFF));
+            p.setColor(QPalette::Disabled, QPalette::Text,       QColor(0x66, 0x66, 0x66));
+            p.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(0x66, 0x66, 0x66));
+        } else {
+            p.setColor(QPalette::Window,          QColor(0xF0, 0xF0, 0xF0));
+            p.setColor(QPalette::WindowText,      QColor(0x00, 0x00, 0x00));
+            p.setColor(QPalette::Base,            QColor(0xFF, 0xFF, 0xFF));
+            p.setColor(QPalette::AlternateBase,   QColor(0xF7, 0xF7, 0xF7));
+            p.setColor(QPalette::Text,            QColor(0x00, 0x00, 0x00));
+            p.setColor(QPalette::Button,          QColor(0xE6, 0xE6, 0xE6));
+            p.setColor(QPalette::ButtonText,      QColor(0x00, 0x00, 0x00));
+            p.setColor(QPalette::Highlight,       QColor(0x33, 0x99, 0xFF));
+            p.setColor(QPalette::HighlightedText, QColor(0xFF, 0xFF, 0xFF));
+            p.setColor(QPalette::ToolTipBase,     QColor(0xFF, 0xFF, 0xDC));
+            p.setColor(QPalette::ToolTipText,     QColor(0x00, 0x00, 0x00));
+            p.setColor(QPalette::Link,            QColor(0x00, 0x00, 0xEE));
+            p.setColor(QPalette::Disabled, QPalette::Text,       QColor(0x99, 0x99, 0x99));
+            p.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(0x99, 0x99, 0x99));
+        }
+        QApplication::setPalette(p);
     }
-    QApplication::setPalette(p);
 
     // Targeted CSS for custom widgets (ADS dock tabs, QuickFindWidget, status bar)
     const QString cssResource = dark ? QStringLiteral(":/stylesheets/npp-dark.css")

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -916,7 +916,7 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     });
     connect(app->getSettings(), &ApplicationSettings::showToolBarChanged, ui->mainToolBar, &QToolBar::setVisible);
     connect(app->getSettings(), &ApplicationSettings::showStatusBarChanged, ui->statusBar, &QStatusBar::setVisible);
-    connect(app->getSettings(), &ApplicationSettings::darkModeChanged, this, &MainWindow::applyStyleSheet);
+    connect(app->getSettings(), &ApplicationSettings::effectiveDarkModeChanged, this, &MainWindow::applyStyleSheet);
     connect(ui->statusBar, &EditorInfoStatusBar::customContextMenuRequestedForEOLLabel, this, [=](const QPoint &pos){
         ui->menuEOLConversion->popup(pos);
     });
@@ -1802,7 +1802,7 @@ void MainWindow::applyStyleSheet()
 {
     qInfo(Q_FUNC_INFO);
 
-    const bool dark = app->getSettings()->darkMode();
+    const bool dark = app->getSettings()->effectiveDarkMode();
 
     // Apply Fusion palette for all standard Qt widgets
     QApplication::setStyle(QStyleFactory::create("Fusion"));

--- a/src/dialogs/PreferencesDialog.cpp
+++ b/src/dialogs/PreferencesDialog.cpp
@@ -44,6 +44,7 @@ PreferencesDialog::PreferencesDialog(ApplicationSettings *settings, QWidget *par
     MapSettingToCheckBox(ui->checkBoxMenuBar, &ApplicationSettings::showMenuBar, &ApplicationSettings::setShowMenuBar, &ApplicationSettings::showMenuBarChanged);
     MapSettingToCheckBox(ui->checkBoxToolBar, &ApplicationSettings::showToolBar, &ApplicationSettings::setShowToolBar, &ApplicationSettings::showToolBarChanged);
     MapSettingToCheckBox(ui->checkBoxStatusBar, &ApplicationSettings::showStatusBar, &ApplicationSettings::setShowStatusBar, &ApplicationSettings::showStatusBarChanged);
+    MapSettingToCheckBox(ui->checkBoxDarkMode, &ApplicationSettings::darkMode, &ApplicationSettings::setDarkMode, &ApplicationSettings::darkModeChanged);
     MapSettingToCheckBox(ui->checkBoxRecenterSearchDialog, &ApplicationSettings::centerSearchDialog, &ApplicationSettings::setCenterSearchDialog, &ApplicationSettings::centerSearchDialogChanged);
 
     MapSettingToGroupBox(ui->gbxRestorePreviousSession, &ApplicationSettings::restorePreviousSession, &ApplicationSettings::setRestorePreviousSession, &ApplicationSettings::restorePreviousSessionChanged);

--- a/src/dialogs/PreferencesDialog.cpp
+++ b/src/dialogs/PreferencesDialog.cpp
@@ -44,7 +44,13 @@ PreferencesDialog::PreferencesDialog(ApplicationSettings *settings, QWidget *par
     MapSettingToCheckBox(ui->checkBoxMenuBar, &ApplicationSettings::showMenuBar, &ApplicationSettings::setShowMenuBar, &ApplicationSettings::showMenuBarChanged);
     MapSettingToCheckBox(ui->checkBoxToolBar, &ApplicationSettings::showToolBar, &ApplicationSettings::setShowToolBar, &ApplicationSettings::showToolBarChanged);
     MapSettingToCheckBox(ui->checkBoxStatusBar, &ApplicationSettings::showStatusBar, &ApplicationSettings::setShowStatusBar, &ApplicationSettings::showStatusBarChanged);
-    MapSettingToCheckBox(ui->checkBoxDarkMode, &ApplicationSettings::darkMode, &ApplicationSettings::setDarkMode, &ApplicationSettings::darkModeChanged);
+    ui->comboBoxTheme->setCurrentIndex(static_cast<int>(settings->theme()));
+    connect(ui->comboBoxTheme, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=](int index) {
+        settings->setTheme(static_cast<ApplicationSettings::ThemeMode>(index));
+    });
+    connect(settings, &ApplicationSettings::themeChanged, this, [=](ApplicationSettings::ThemeMode mode) {
+        ui->comboBoxTheme->setCurrentIndex(static_cast<int>(mode));
+    });
     MapSettingToCheckBox(ui->checkBoxRecenterSearchDialog, &ApplicationSettings::centerSearchDialog, &ApplicationSettings::setCenterSearchDialog, &ApplicationSettings::centerSearchDialogChanged);
 
     MapSettingToGroupBox(ui->gbxRestorePreviousSession, &ApplicationSettings::restorePreviousSession, &ApplicationSettings::setRestorePreviousSession, &ApplicationSettings::restorePreviousSessionChanged);

--- a/src/dialogs/PreferencesDialog.ui
+++ b/src/dialogs/PreferencesDialog.ui
@@ -53,11 +53,47 @@
           </widget>
          </item>
          <item>
-          <widget class="QCheckBox" name="checkBoxDarkMode">
-           <property name="text">
-            <string>Dark mode</string>
-           </property>
-          </widget>
+          <layout class="QHBoxLayout" name="layoutTheme">
+           <item>
+            <widget class="QLabel" name="labelTheme">
+             <property name="text">
+              <string>Theme:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="comboBoxTheme">
+             <item>
+              <property name="text">
+               <string>Follow system</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Light</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Dark</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item>
+            <spacer name="themeSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
          <item>
           <widget class="QGroupBox" name="gbxRestorePreviousSession">

--- a/src/dialogs/PreferencesDialog.ui
+++ b/src/dialogs/PreferencesDialog.ui
@@ -53,6 +53,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="checkBoxDarkMode">
+           <property name="text">
+            <string>Dark mode</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QGroupBox" name="gbxRestorePreviousSession">
            <property name="title">
             <string>Restore previous session</string>

--- a/src/docks/LuaConsoleDock.cpp
+++ b/src/docks/LuaConsoleDock.cpp
@@ -20,6 +20,7 @@
 #include "LuaConsoleDock.h"
 #include "ui_LuaConsoleDock.h"
 
+#include "ApplicationSettings.h"
 #include "ScintillaNext.h"
 #include "ILexer.h"
 #include "Lexilla.h"
@@ -83,9 +84,10 @@ static int cf_global_print(lua_State *L) {
 }
 
 
-LuaConsoleDock::LuaConsoleDock(LuaState *l, QWidget *parent) :
+LuaConsoleDock::LuaConsoleDock(LuaState *l, ApplicationSettings *settings, QWidget *parent) :
     QDockWidget(parent),
-    ui(new Ui::LuaConsoleDock)
+    ui(new Ui::LuaConsoleDock),
+    settings(settings)
 {
     L = l;
 
@@ -183,12 +185,18 @@ LuaConsoleDock::LuaConsoleDock(LuaState *l, QWidget *parent) :
     setupStyle(input);
     setupStyle(output);
 
-    output->styleSetFore(39, 0x0000FF); // For error messages
+    output->styleSetFore(39, settings->darkMode() ? 0xFF6B6B : 0x0000FF); // For error messages
 
     input->setExtraAscent(2);
     input->setExtraDescent(2);
     input->setMaximumHeight(input->textHeight(0));
     input->installEventFilter(this);
+
+    connect(settings, &ApplicationSettings::darkModeChanged, this, [=](bool) {
+        setupStyle(input);
+        setupStyle(output);
+        output->styleSetFore(39, settings->darkMode() ? 0xFF6B6B : 0x0000FF);
+    });
 
     connect(input, &ScintillaNext::updateUi, [=](Scintilla::Update flags) {
         Q_UNUSED(flags);
@@ -377,10 +385,12 @@ bool LuaConsoleDock::eventFilter(QObject *obj, QEvent *event)
 
 void LuaConsoleDock::setupStyle(ScintillaNext *editor)
 {
+    const bool dark = settings->darkMode();
+
     editor->setEOLMode(SC_EOL_CRLF);
 
-    editor->styleSetFore(STYLE_DEFAULT, 0x000000);
-    editor->styleSetBack(STYLE_DEFAULT, 0xFFFFFF);
+    editor->styleSetFore(STYLE_DEFAULT, dark ? 0xD4D4D4 : 0x000000);
+    editor->styleSetBack(STYLE_DEFAULT, dark ? 0x1E1E1E : 0xFFFFFF);
     editor->styleSetFont(STYLE_DEFAULT, "Courier New");
     editor->styleSetSize(STYLE_DEFAULT, 10);
     editor->styleClearAll();
@@ -392,29 +402,33 @@ void LuaConsoleDock::setupStyle(ScintillaNext *editor)
     editor->setMarginWidthN(4, 0);
 
     editor->setCodePage(SC_CP_UTF8);
-    editor->styleSetFore(SCE_LUA_COMMENT, 0x008000);
-    editor->styleSetFore(SCE_LUA_COMMENTLINE, 0x008000);
-    editor->styleSetFore(SCE_LUA_COMMENTDOC, 0x808000);
-    editor->styleSetFore(SCE_LUA_LITERALSTRING, 0x4A0095);
-    editor->styleSetFore(SCE_LUA_PREPROCESSOR, 0x004080); // Technically not used since this is lua 5+
-    editor->styleSetFore(SCE_LUA_WORD, 0xFF0000);
-    editor->styleSetBold(SCE_LUA_WORD, 1); // for SCI_SETKEYWORDS, 0
-    editor->styleSetFore(SCE_LUA_NUMBER, 0x0080FF);
-    editor->styleSetFore(SCE_LUA_STRING, 0x808080);
-    editor->styleSetFore(SCE_LUA_CHARACTER, 0x808080);
-    editor->styleSetFore(SCE_LUA_OPERATOR, 0x800000);
+    editor->styleSetFore(SCE_LUA_COMMENT,       dark ? 0x6A9955 : 0x008000);
+    editor->styleSetFore(SCE_LUA_COMMENTLINE,   dark ? 0x6A9955 : 0x008000);
+    editor->styleSetFore(SCE_LUA_COMMENTDOC,    dark ? 0x808000 : 0x808000);
+    editor->styleSetFore(SCE_LUA_LITERALSTRING, dark ? 0xCE9178 : 0x4A0095);
+    editor->styleSetFore(SCE_LUA_PREPROCESSOR,  dark ? 0xB5CEA8 : 0x004080);
+    editor->styleSetFore(SCE_LUA_WORD,          dark ? 0xD7BA7D : 0xFF0000);
+    editor->styleSetBold(SCE_LUA_WORD, 1);
+    editor->styleSetFore(SCE_LUA_NUMBER,        dark ? 0xB5CEA8 : 0x0080FF);
+    editor->styleSetFore(SCE_LUA_STRING,        dark ? 0xCE9178 : 0x808080);
+    editor->styleSetFore(SCE_LUA_CHARACTER,     dark ? 0xCE9178 : 0x808080);
+    editor->styleSetFore(SCE_LUA_OPERATOR,      dark ? 0xD4D4D4 : 0x800000);
     editor->styleSetBold(SCE_LUA_OPERATOR, 1);
-    editor->styleSetFore(SCE_LUA_WORD2, 0xC08000);
-    editor->styleSetBold(SCE_LUA_WORD2, 1); // for SCI_SETKEYWORDS, 1
-    editor->styleSetFore(SCE_LUA_WORD3, 0xFF0080);
-    editor->styleSetBold(SCE_LUA_WORD3, 1); // for SCI_SETKEYWORDS, 2
-    editor->styleSetFore(SCE_LUA_WORD4, 0xA00000);
+    editor->styleSetFore(SCE_LUA_WORD2,         dark ? 0xDCDCAA : 0xC08000);
+    editor->styleSetBold(SCE_LUA_WORD2, 1);
+    editor->styleSetFore(SCE_LUA_WORD3,         dark ? 0xC586C0 : 0xFF0080);
+    editor->styleSetBold(SCE_LUA_WORD3, 1);
+    editor->styleSetFore(SCE_LUA_WORD4,         dark ? 0x4EC9B0 : 0xA00000);
     editor->styleSetBold(SCE_LUA_WORD4, 1);
-    editor->styleSetItalic(SCE_LUA_WORD4, 1); // for SCI_SETKEYWORDS, 3
-    editor->styleSetFore(SCE_LUA_LABEL, 0x008080);
+    editor->styleSetItalic(SCE_LUA_WORD4, 1);
+    editor->styleSetFore(SCE_LUA_LABEL,         dark ? 0x4FC1FF : 0x008080);
     editor->styleSetBold(SCE_LUA_LABEL, 1);
-    editor->styleSetFore(SCE_LUA_WORD5, 0x004080); // for SCI_SETKEYWORDS, 4, Scintilla defines
+    editor->styleSetFore(SCE_LUA_WORD5,         dark ? 0x9CDCFE : 0x004080);
     editor->styleSetBold(SCE_LUA_WORD5, 1);
-    editor->styleSetFore(SCE_LUA_WORD6, 0x004080); // for SCI_SETKEYWORDS, 5, Notepad++ defines
+    editor->styleSetFore(SCE_LUA_WORD6,         dark ? 0x9CDCFE : 0x004080);
     editor->styleSetBold(SCE_LUA_WORD6, 1);
+
+    editor->styleSetFore(STYLE_LINENUMBER,      dark ? 0x858585 : 0x808080);
+    editor->styleSetBack(STYLE_LINENUMBER,      dark ? 0x252526 : 0xE4E4E4);
+    editor->styleSetBold(STYLE_LINENUMBER, true);
 }

--- a/src/docks/LuaConsoleDock.cpp
+++ b/src/docks/LuaConsoleDock.cpp
@@ -185,17 +185,17 @@ LuaConsoleDock::LuaConsoleDock(LuaState *l, ApplicationSettings *settings, QWidg
     setupStyle(input);
     setupStyle(output);
 
-    output->styleSetFore(39, settings->darkMode() ? 0xFF6B6B : 0x0000FF); // For error messages
+    output->styleSetFore(39, settings->effectiveDarkMode() ? 0xFF6B6B : 0x0000FF); // For error messages
 
     input->setExtraAscent(2);
     input->setExtraDescent(2);
     input->setMaximumHeight(input->textHeight(0));
     input->installEventFilter(this);
 
-    connect(settings, &ApplicationSettings::darkModeChanged, this, [=](bool) {
+    connect(settings, &ApplicationSettings::effectiveDarkModeChanged, this, [=](bool) {
         setupStyle(input);
         setupStyle(output);
-        output->styleSetFore(39, settings->darkMode() ? 0xFF6B6B : 0x0000FF);
+        output->styleSetFore(39, settings->effectiveDarkMode() ? 0xFF6B6B : 0x0000FF);
     });
 
     connect(input, &ScintillaNext::updateUi, [=](Scintilla::Update flags) {
@@ -385,7 +385,7 @@ bool LuaConsoleDock::eventFilter(QObject *obj, QEvent *event)
 
 void LuaConsoleDock::setupStyle(ScintillaNext *editor)
 {
-    const bool dark = settings->darkMode();
+    const bool dark = settings->effectiveDarkMode();
 
     editor->setEOLMode(SC_EOL_CRLF);
 

--- a/src/docks/LuaConsoleDock.h
+++ b/src/docks/LuaConsoleDock.h
@@ -24,6 +24,7 @@
 
 class ScintillaNext;
 class LuaState;
+class ApplicationSettings;
 
 namespace Ui {
 class LuaConsoleDock;
@@ -34,7 +35,7 @@ class LuaConsoleDock : public QDockWidget
     Q_OBJECT
 
 public:
-    explicit LuaConsoleDock(LuaState *l, QWidget *parent = 0);
+    explicit LuaConsoleDock(LuaState *l, ApplicationSettings *settings, QWidget *parent = 0);
     ~LuaConsoleDock();
 
     void writeToOutput(const char *s);
@@ -55,6 +56,7 @@ protected:
 private:
     Ui::LuaConsoleDock *ui;
 
+    ApplicationSettings *settings;
     ScintillaNext *output;
     ScintillaNext *input;
 

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -19,6 +19,7 @@
         <file>icons/wrap.png</file>
         <file>icons/find.png</file>
         <file>stylesheets/npp.css</file>
+        <file>stylesheets/npp-dark.css</file>
         <file>icons/findReplace.png</file>
         <file>icons/readonly.png</file>
         <file>icons/startRecord.png</file>

--- a/src/scripts/init.lua
+++ b/src/scripts/init.lua
@@ -2,6 +2,30 @@ function rgb(x)
     return ((x & 0xFF) << 16) | (x & 0xFF00) | ((x & 0xFF0000) >> 16)
 end
 
+local STYLE_DEFAULT = 32
+
+-- Build the active theme table from the dark_mode global injected by C++.
+-- Also called by NotepadNextApplication::refreshEditorTheme() on toggle.
+function UpdateTheme()
+    if dark_mode then
+        theme = {
+            default_fg = rgb(0xD4D4D4),
+            default_bg = rgb(0x1E1E1E),
+            light_fg   = rgb(0x000000),
+            light_bg   = rgb(0xFFFFFF),
+        }
+    else
+        theme = {
+            default_fg = rgb(0x000000),
+            default_bg = rgb(0xFFFFFF),
+            light_fg   = rgb(0x000000),
+            light_bg   = rgb(0xFFFFFF),
+        }
+    end
+end
+
+UpdateTheme()
+
 function DetectLanguageFromContents(contents)
     for name, L in pairs(languages) do
         if L.first_line then
@@ -49,10 +73,23 @@ function DialogFilters()
 end
 
 function SetStyle(L)
+    -- Apply theme base: STYLE_DEFAULT sets the canvas for styleClearAll().
+    -- This ensures every style slot starts with the correct background color
+    -- even for styles not explicitly listed in the language definition.
+    editor.StyleFore[STYLE_DEFAULT] = theme.default_fg
+    editor.StyleBack[STYLE_DEFAULT] = theme.default_bg
+    editor:StyleClearAll()
+
     if L.styles then
         for _, style in pairs(L.styles) do
-            editor.StyleFore[style.id] = style.fgColor
-            editor.StyleBack[style.id] = style.bgColor
+            -- Translate canonical light-mode colors to theme equivalents.
+            -- Language files that specify black text on white background get
+            -- auto-converted; deliberate syntax colors (blue, green, etc.)
+            -- pass through unchanged since they are readable on dark backgrounds.
+            local fg = (style.fgColor == theme.light_fg) and theme.default_fg or style.fgColor
+            local bg = (style.bgColor == theme.light_bg) and theme.default_bg or style.bgColor
+            editor.StyleFore[style.id] = fg
+            editor.StyleBack[style.id] = bg
 
             if style.fontStyle then
                 editor.StyleBold[style.id] = (style.fontStyle & 1 == 1)

--- a/src/stylesheets/npp-dark.css
+++ b/src/stylesheets/npp-dark.css
@@ -1,0 +1,77 @@
+QStatusBar {
+    border-top: 1px solid #3C3C3C;
+}
+
+ads--CDockWidgetTab ads--CElidingLabel {
+    color: #D4D4D4;
+}
+
+ads--CDockWidgetTab {
+    background: #2D2D2D;
+    margin-top: 2px;
+    border-left: 1px solid #3C3C3C;
+    border-top: 2px solid #3C3C3C;
+    border-right: 2px solid #252526;
+    padding: 2px 2px 0px 2px;
+    border-top-left-radius: 2px;
+    border-top-right-radius: 2px;
+}
+
+ads--CDockWidgetTab[activeTab="true"]
+{
+    background: #1E1E1E;
+    border-top: 4px solid #007ACC;
+    padding-bottom: 2px;
+    margin-top: 1px;
+}
+
+ads--CDockWidgetTab[focused="true"]
+{
+    background: #1E1E1E;
+    border-top: 4px solid #FFA500;
+    padding-bottom: 2px;
+    margin-top: 1px;
+}
+
+ads--CDockWidgetTab:hover[activeTab="false"] {
+    background: #353535;
+}
+
+ads--CDockAreaTitleBar
+{
+    background: transparent;
+    border-bottom: 1px solid #3C3C3C;
+    padding-bottom: 0px;
+}
+
+ads--CDockWidgetTab[activeTab="false"] QLabel {
+    color: #858585;
+}
+
+#tabCloseButton
+{
+    background: rgba(255, 255, 255, 16);
+    margin-bottom: 1px;
+    margin-left: 4px;
+    border: none;
+    padding: 0px -2px;
+}
+
+#tabCloseButton:hover
+{
+    border: 1px solid rgba(255, 255, 255, 32);
+    background-color: #993333;
+    color: white;
+}
+
+#tabCloseButton:pressed
+{
+    background: #CC3333;
+}
+
+#QuickFindWidget {
+    border-left: 1px solid #3C3C3C;
+    border-right: 1px solid #3C3C3C;
+    border-bottom: 3px solid #007ACC;
+    background: palette(window);
+}


### PR DESCRIPTION
> ⚠️ **AI-generated pull request.**
>
> Every commit, every line of code, the design choices, the commit messages, this PR description, and the test plan in this PR were all written by an LLM. A human reviewed and accepted the changes interactively but did not author them. Please review accordingly: the code compiles, runs, and was visually verified end-to-end on Linux (Wayland + GNOME, Qt 6.10), but a human maintainer's judgment on architecture and integration is still warranted before merge.
>
> See \`gist of changes\` and \`Test plan\` below for review hooks.

## Summary

Adds dark mode to NotepadNext via a tristate **System / Light / Dark** theme setting (default **System**). When set to System, the application follows the desktop environment's color scheme via \`QStyleHints::colorScheme()\` and updates live when the system preference changes. Light and Dark are explicit overrides for users who want their editor independent of the rest of the desktop.

This is an alternative take on #411 — written from scratch against current master rather than the older qmake codebase that PR was built on, and avoiding the third-party stylesheet dependency. #411 can be closed if this one is preferred.

## Design

A single \`ApplicationSettings::theme\` enum drives everything. \`effectiveDarkMode()\` resolves System against the current \`QStyleHints::colorScheme()\`. A single \`effectiveDarkModeChanged(bool)\` signal fires on either user-initiated theme changes or system color-scheme changes (when in System mode), and every consumer connects to that one signal.

**Theming layers:**

1. **Qt widgets.** \`MainWindow::applyStyleSheet()\` switches between Qt's natural palette (System mode — left untouched, since Qt 6.5+ already follows the desktop) and explicit Fusion-derived palettes (Light / Dark mode). Targeted CSS in \`stylesheets/npp.css\` (existing, light) and the new \`stylesheets/npp-dark.css\` (dark) covers ADS dock tabs, status bar, and \`QuickFindWidget\`. **No third-party stylesheet dependency.**

2. **Scintilla editor surfaces.** \`EditorManager::applyEditorTheme()\` sets fold markers, element colors (caret line, selection inactive, whitespace, fold line), fold margin colors, and \`STYLE_DEFAULT\`. A separate \`applyEditorNamedStyles()\` sets \`STYLE_LINENUMBER\`, \`STYLE_BRACELIGHT\`, \`STYLE_BRACEBAD\`, \`STYLE_INDENTGUIDE\`. The split is needed because Lua's \`SetStyle\` calls \`StyleClearAll\` on every language load, which would otherwise wipe these named styles.

3. **Syntax highlighting.** \`init.lua\` builds a \`theme\` table from a \`dark_mode\` global injected by C++. \`SetStyle()\` writes \`STYLE_DEFAULT\` from the theme, calls \`StyleClearAll\`, then auto-translates canonical light-mode colors per language style: \`style.fgColor == light_fg → theme.default_fg\` and \`style.bgColor == light_bg → theme.default_bg\`. The vast majority of language \`.lua\` files specify black on white and get auto-converted; deliberate syntax colors (blue keywords, green comments, gray strings, orange numbers) pass through unchanged and remain readable on a dark background. **No language definition files were edited.**

4. **\`LuaConsoleDock\`.** Now takes \`ApplicationSettings*\`, applies theme-aware Lua lexer styles, and reapplies them on \`effectiveDarkModeChanged\`.

5. **Preferences UI.** New "Theme" combo box (Follow system / Light / Dark) in the GUI tab.

## Files

| Area | Change |
|---|---|
| \`ApplicationSettings.{h,cpp}\` | \`Theme\` enum setting + \`effectiveDarkMode()\` helper + \`effectiveDarkModeChanged\` signal; subscribes to \`QStyleHints::colorSchemeChanged\` |
| \`EditorManager.{h,cpp}\` | \`applyEditorTheme()\` + \`applyEditorNamedStyles()\`; signal connection |
| \`NotepadNextApplication.{h,cpp}\` | \`dark_mode\` Lua injection; \`refreshEditorTheme()\` slot; \`applyEditorNamedStyles\` after Lua language load |
| \`scripts/init.lua\` | \`UpdateTheme()\`, \`theme\` table, \`SetStyle()\` rewrite with auto-translation |
| \`dialogs/MainWindow.cpp\` | \`applyStyleSheet()\` rewritten for tristate; signal connection |
| \`dialogs/PreferencesDialog.{ui,cpp}\` | Theme combo box + wiring |
| \`docks/LuaConsoleDock.{h,cpp}\` | Theme-aware lexer styles, signal connection |
| \`stylesheets/npp-dark.css\` (new) | Dark variants for ADS tabs and \`QuickFindWidget\` |
| \`resources.qrc\` | Register \`npp-dark.css\` |

## Verification done

- Clean build against Qt 6.10 with the master CMake setup.
- **System theme** with GNOME \`prefer-dark\`: app starts dark; switching GNOME to light makes the app re-theme live.
- **Theme=Light** explicit: editor white, line numbers gray-on-\`#E4E4E4\`, menu/toolbar/tabs all light.
- **Theme=Dark** explicit: editor \`#1E1E1E\`, line numbers \`#858585\`-on-\`#252526\`, full Qt widget palette dark.
- C/C++ file in dark mode: keywords blue, strings gray, comments green, numbers orange — all readable on dark. No edits to language definition files.
- Persisted in \`~/.config/NotepadNext/NotepadNext.ini\` under \`[Gui]/Theme\` (0 = System, 1 = Light, 2 = Dark).
- Setting can be hand-edited or set via Preferences; live toggle confirmed.

## Things explicitly NOT addressed

- ADS auto-hide drop indicator alignment is broken in upstream master (and v0.13) on Qt 6.10/Wayland regardless of this PR. That looked like a regression at first; verified against vanilla master that it isn't. Belongs in a separate report against ADS or a version bump.
- Only the most common language definitions exercise the auto-translation path. Languages whose \`.lua\` defines deliberately non-white backgrounds for some styles will keep those backgrounds in dark mode (e.g. error highlight). That's intentional but may surprise users; happy to add a more thorough overlay-table approach if desired.
- macOS and Windows palette tuning. The hardcoded Light/Dark palettes are Fusion-derived neutral values that should look correct on all platforms, but only Linux has been visually tested.

## Test plan

- [ ] \`Settings → Preferences → Theme\` combo, switch between Follow system / Light / Dark; the editor and Qt chrome should update without restart.
- [ ] With Theme=Follow system, toggle the desktop dark/light preference (GNOME Settings → Appearance, or \`gsettings set org.gnome.desktop.interface color-scheme prefer-dark/default\`); the app should re-theme live.
- [ ] Open a few language files (C, Python, JSON, etc.) in both modes; syntax highlighting should remain readable.
- [ ] Open the Lua console dock; theme should match.
- [ ] Restart the app; the chosen theme should persist.
- [ ] Sanity: build succeeds on Windows/macOS (haven't been able to verify; only \`dialogs/MainWindow.cpp\` adds platform-touchy code via \`QPalette\`/\`QStyleHints\`, both cross-platform).