### PR TITLE
Force xcb platform on Wayland to fix tab drag indicators

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,25 @@ int main(int argc, char *argv[])
 {
     qSetMessagePattern("[%{time process}] %{if-debug}D%{endif}%{if-info}I%{endif}%{if-warning}W%{endif}%{if-critical}C%{endif}%{if-fatal}F%{endif}: %{message}");
 
+#ifdef Q_OS_LINUX
+    // Qt Advanced Docking System positions its drop-indicator overlays as
+    // top-level Qt::Tool windows using mapToGlobal() + move() to absolute
+    // coordinates. Wayland does not let clients position top-level windows,
+    // so during a tab drag the indicators appear at wrong locations. Run
+    // through XWayland where the positioning works correctly. Honor an
+    // explicit QT_QPA_PLATFORM and an opt-out escape hatch.
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")
+        && !qEnvironmentVariableIsSet("NOTEPADNEXT_FORCE_NATIVE_WAYLAND"))
+    {
+        const QByteArray sessionType = qgetenv("XDG_SESSION_TYPE");
+        const bool isWayland = (sessionType == "wayland")
+                            || qEnvironmentVariableIsSet("WAYLAND_DISPLAY");
+        if (isWayland) {
+            qputenv("QT_QPA_PLATFORM", "xcb;wayland");
+        }
+    }
+#endif
+
     // Set these since other parts of the app references these
     QApplication::setOrganizationName("NotepadNext");
     QApplication::setApplicationName("NotepadNext");


### PR DESCRIPTION
> **Disclosure:** This pull request was authored by an LLM (Claude Opus 4.7) under my direction. I have built it locally, reproduced the bug before the change, verified the fix on my Wayland session, and confirmed both escape hatches behave as documented. Maintainer review is welcome and expected; please push back on anything that doesn't match the project's conventions.

## Summary

Qt Advanced Docking System positions its drop-indicator overlays (the cross of split-direction buttons and the highlighted preview rectangles) as top-level `Qt::Tool` windows using `mapToGlobal()` + `move()` to absolute global coordinates. Wayland does not let clients position top-level windows, so during a tab drag the indicators appear at wrong locations across the screen, making the dock UX effectively unusable on Wayland.

ADS upstream has [documented this limitation](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/288) and officially recommends running through XWayland. The newer ADS releases (4.5.0) still don't fix it.

This PR sets `QT_QPA_PLATFORM=xcb;wayland` on Linux Wayland sessions in `main.cpp` before constructing `QApplication`, so the app runs through XWayland where the positioning works correctly. The semicolon-separated form is Qt 6 syntax for a fallback list: Qt tries xcb first and falls back to wayland on systems where the xcb plugin is unavailable, so it stays safe on minimal containers.

The override only kicks in when:
- `QT_QPA_PLATFORM` is not already set by the user (their explicit choice always wins), and
- The opt-out `NOTEPADNEXT_FORCE_NATIVE_WAYLAND` is not set.

The Wayland platform plugin is still bundled with the AppImage (added in #1022), so users who set `NOTEPADNEXT_FORCE_NATIVE_WAYLAND=1` still get a working app, just with the original misaligned indicators during tab drags.

## Test plan

- [x] Reproduced the misalignment on Wayland (GNOME) before the change: drop indicators rendered far outside the dock area during tab drag.
- [x] Built and ran with the change on the same Wayland session: drop indicators now align correctly with the dock area, and split-on-drop works as on X11.
- [x] Verified `NOTEPADNEXT_FORCE_NATIVE_WAYLAND=1 ./NotepadNext` reproduces the original misalignment, confirming the escape hatch works.
- [x] Verified `QT_QPA_PLATFORM=wayland ./NotepadNext` honors the explicit user setting.
- [ ] X11 sessions: no behavioral change expected (the block is gated on `XDG_SESSION_TYPE=wayland` / `WAYLAND_DISPLAY`).
- [ ] Non-Linux platforms: no behavioral change (entire block is `#ifdef Q_OS_LINUX`).