### PR TITLE
Add Gemini markdown formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ __cmake_systeminformation
 
 /build
 /build*
+/build-*/
+/build-mingw/
 /icon/*.png
 /icon/ImageMagick
 
@@ -65,6 +67,11 @@ __cmake_systeminformation
 ._*
 
 .cpm-cache/
+aqtinstall.log
+
+# Local AI/research archives
+issue_reports/
+project_context/
 
 # ninja
 .ninja_deps

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,9 @@ qt_add_executable(NotepadNext
 	FileDialogHelpers.h
 	Finder.h
 	FocusWatcher.h
+	GeminiClient.h
+	GeminiCredentialStore.h
+	GeminiSettingsPopup.h
 	HtmlConverter.h
 	IFaceTable.h
 	IFaceTableMixer.h
@@ -64,6 +67,9 @@ qt_add_executable(NotepadNext
 	EditorPrintPreviewRenderer.cpp
 	FileDialogHelpers.cpp
 	Finder.cpp
+	GeminiClient.cpp
+	GeminiCredentialStore.cpp
+	GeminiSettingsPopup.cpp
 	HtmlConverter.cpp
 	IFaceTable.cpp
 	IFaceTableMixer.cpp
@@ -239,6 +245,15 @@ target_link_libraries(NotepadNext
         scintilla
         uchardet
 )
+
+if(WIN32)
+    target_link_libraries(NotepadNext PRIVATE Crypt32)
+elseif(APPLE)
+    target_link_libraries(NotepadNext PRIVATE "-framework Security")
+elseif(UNIX)
+    find_package(Qt6 REQUIRED COMPONENTS DBus)
+    target_link_libraries(NotepadNext PRIVATE Qt6::DBus)
+endif()
 
 target_compile_definitions(NotepadNext
     PRIVATE

--- a/src/GeminiClient.cpp
+++ b/src/GeminiClient.cpp
@@ -1,0 +1,148 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "GeminiClient.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+
+namespace {
+
+QString normalizeModelName(QString model)
+{
+    model = model.trimmed();
+    if (model.startsWith(QLatin1String("models/"))) {
+        model.remove(0, 7);
+    }
+    return model;
+}
+
+QJsonObject textPart(const QString &text)
+{
+    QJsonObject part;
+    part.insert(QStringLiteral("text"), text);
+    return part;
+}
+
+QString parseGeminiMarkdown(const QJsonDocument &document)
+{
+    const QJsonArray candidates = document.object().value(QStringLiteral("candidates")).toArray();
+    for (const QJsonValue &candidateValue : candidates) {
+        const QJsonObject candidate = candidateValue.toObject();
+        const QJsonObject content = candidate.value(QStringLiteral("content")).toObject();
+        const QJsonArray parts = content.value(QStringLiteral("parts")).toArray();
+
+        QString markdown;
+        for (const QJsonValue &partValue : parts) {
+            markdown += partValue.toObject().value(QStringLiteral("text")).toString();
+        }
+
+        if (!markdown.trimmed().isEmpty()) {
+            return markdown;
+        }
+    }
+
+    return QString();
+}
+
+QString parseGeminiError(const QJsonDocument &document)
+{
+    const QJsonObject error = document.object().value(QStringLiteral("error")).toObject();
+    return error.value(QStringLiteral("message")).toString();
+}
+
+}
+
+GeminiClient::GeminiClient(QObject *parent)
+    : QObject(parent)
+    , networkAccessManager(new QNetworkAccessManager(this))
+{
+}
+
+void GeminiClient::formatMarkdown(const QString &text, const QString &model, const QString &apiKey)
+{
+    const QString normalizedModel = normalizeModelName(model);
+    if (normalizedModel.isEmpty()) {
+        emit formatFailed(tr("Gemini model name is empty."));
+        return;
+    }
+
+    const QUrl url(QStringLiteral("https://generativelanguage.googleapis.com/v1beta/models/%1:generateContent").arg(normalizedModel));
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
+    request.setRawHeader("x-goog-api-key", apiKey.toUtf8());
+
+    QJsonObject systemInstruction;
+    systemInstruction.insert(QStringLiteral("parts"), QJsonArray{
+        textPart(QStringLiteral("Return only Markdown. Do not wrap the response in a code fence and do not add explanations. Preserve facts, language, URLs, quotes, and code blocks. Structure the text with headings, lists, tables, quotes, links, and other Markdown syntax only when it fits the content."))
+    });
+
+    QJsonObject content;
+    content.insert(QStringLiteral("role"), QStringLiteral("user"));
+    content.insert(QStringLiteral("parts"), QJsonArray{
+        textPart(QStringLiteral("Format this text as clean Markdown:\n\n%1").arg(text))
+    });
+
+    QJsonObject body;
+    body.insert(QStringLiteral("systemInstruction"), systemInstruction);
+    body.insert(QStringLiteral("contents"), QJsonArray{content});
+
+    QNetworkReply *reply = networkAccessManager->post(request, QJsonDocument(body).toJson(QJsonDocument::Compact));
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        handleReply(reply);
+    });
+}
+
+void GeminiClient::handleReply(QNetworkReply *reply)
+{
+    reply->deleteLater();
+
+    const QByteArray responseBytes = reply->readAll();
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(responseBytes, &parseError);
+
+    if (reply->error() != QNetworkReply::NoError) {
+        QString errorMessage;
+        if (parseError.error == QJsonParseError::NoError) {
+            errorMessage = parseGeminiError(document);
+        }
+        if (errorMessage.isEmpty()) {
+            errorMessage = reply->errorString();
+        }
+        emit formatFailed(errorMessage);
+        return;
+    }
+
+    if (parseError.error != QJsonParseError::NoError) {
+        emit formatFailed(tr("Gemini returned an invalid JSON response."));
+        return;
+    }
+
+    const QString markdown = parseGeminiMarkdown(document);
+    if (markdown.trimmed().isEmpty()) {
+        emit formatFailed(tr("Gemini returned an empty Markdown response."));
+        return;
+    }
+
+    emit formatSucceeded(markdown);
+}

--- a/src/GeminiClient.h
+++ b/src/GeminiClient.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+
+class GeminiClient : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit GeminiClient(QObject *parent = nullptr);
+
+    void formatMarkdown(const QString &text, const QString &model, const QString &apiKey);
+
+signals:
+    void formatSucceeded(const QString &markdown);
+    void formatFailed(const QString &errorMessage);
+
+private:
+    QNetworkAccessManager *networkAccessManager;
+
+    void handleReply(QNetworkReply *reply);
+};

--- a/src/GeminiCredentialStore.cpp
+++ b/src/GeminiCredentialStore.cpp
@@ -1,0 +1,525 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "GeminiCredentialStore.h"
+
+#include "ApplicationSettings.h"
+
+#include <QApplication>
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QMetaType>
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#include <dpapi.h>
+#endif
+
+#ifdef Q_OS_MACOS
+#include <Security/Security.h>
+#endif
+
+#ifdef Q_OS_LINUX
+#include <QDBusArgument>
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusMetaType>
+#include <QDBusObjectPath>
+#include <QDBusPendingReply>
+#include <QDBusReply>
+#include <QDBusUnixFileDescriptor>
+#include <QDBusVariant>
+#include <QMap>
+#include <QVariantMap>
+#endif
+
+#ifdef Q_OS_LINUX
+namespace GeminiInternal {
+struct SecretValue
+{
+    QDBusObjectPath session;
+    QByteArray parameters;
+    QByteArray value;
+    QString contentType;
+};
+
+using SecretAttributes = QMap<QString, QString>;
+using SecretMap = QMap<QDBusObjectPath, SecretValue>;
+}
+
+Q_DECLARE_METATYPE(GeminiInternal::SecretValue)
+Q_DECLARE_METATYPE(GeminiInternal::SecretAttributes)
+Q_DECLARE_METATYPE(GeminiInternal::SecretMap)
+#endif
+
+namespace GeminiInternal {
+
+const char GeminiApiKeySetting[] = "Gemini/ApiKeyProtected";
+const char GeminiServiceName[] = "NotepadNext Gemini";
+const char GeminiAccountName[] = "Gemini API Key";
+
+#ifdef Q_OS_WIN
+std::optional<QByteArray> protectData(const QByteArray &data, QString *errorMessage)
+{
+    DATA_BLOB input;
+    input.pbData = reinterpret_cast<BYTE *>(const_cast<char *>(data.constData()));
+    input.cbData = static_cast<DWORD>(data.size());
+
+    DATA_BLOB output;
+    if (!CryptProtectData(&input, L"NotepadNext Gemini API Key", nullptr, nullptr, nullptr, 0, &output)) {
+        if (errorMessage) {
+            *errorMessage = QApplication::translate("GeminiCredentialStore", "Could not protect the Gemini API key with Windows Data Protection API.");
+        }
+        return std::nullopt;
+    }
+
+    QByteArray protectedData(reinterpret_cast<char *>(output.pbData), static_cast<int>(output.cbData));
+    LocalFree(output.pbData);
+    return protectedData;
+}
+
+std::optional<QByteArray> unprotectData(const QByteArray &data, QString *errorMessage)
+{
+    DATA_BLOB input;
+    input.pbData = reinterpret_cast<BYTE *>(const_cast<char *>(data.constData()));
+    input.cbData = static_cast<DWORD>(data.size());
+
+    DATA_BLOB output;
+    if (!CryptUnprotectData(&input, nullptr, nullptr, nullptr, nullptr, 0, &output)) {
+        if (errorMessage) {
+            *errorMessage = QApplication::translate("GeminiCredentialStore", "Could not read the Gemini API key from Windows Data Protection API.");
+        }
+        return std::nullopt;
+    }
+
+    QByteArray unprotectedData(reinterpret_cast<char *>(output.pbData), static_cast<int>(output.cbData));
+    LocalFree(output.pbData);
+    return unprotectedData;
+}
+#endif
+
+#ifdef Q_OS_MACOS
+QByteArray toUtf8(const QString &text)
+{
+    return text.toUtf8();
+}
+
+CFDataRef makeCFData(const QByteArray &bytes)
+{
+    return CFDataCreate(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(bytes.constData()), bytes.size());
+}
+
+CFStringRef makeCFString(const QString &text)
+{
+    const QByteArray utf8 = toUtf8(text);
+    return CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(utf8.constData()), utf8.size(), kCFStringEncodingUTF8, false);
+}
+
+CFMutableDictionaryRef makeBaseQuery()
+{
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFStringRef service = makeCFString(QString::fromLatin1(GeminiServiceName));
+    CFStringRef account = makeCFString(QString::fromLatin1(GeminiAccountName));
+
+    CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+    CFDictionarySetValue(query, kSecAttrService, service);
+    CFDictionarySetValue(query, kSecAttrAccount, account);
+
+    CFRelease(service);
+    CFRelease(account);
+    return query;
+}
+#endif
+
+#ifdef Q_OS_LINUX
+QDBusArgument &operator<<(QDBusArgument &argument, const SecretValue &secret)
+{
+    argument.beginStructure();
+    argument << secret.session << secret.parameters << secret.value << secret.contentType;
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, SecretValue &secret)
+{
+    argument.beginStructure();
+    argument >> secret.session >> secret.parameters >> secret.value >> secret.contentType;
+    argument.endStructure();
+    return argument;
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument, const SecretAttributes &attributes)
+{
+    argument.beginMap(QMetaType::fromType<QString>(), QMetaType::fromType<QString>());
+    for (auto it = attributes.cbegin(); it != attributes.cend(); ++it) {
+        argument.beginMapEntry();
+        argument << it.key() << it.value();
+        argument.endMapEntry();
+    }
+    argument.endMap();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, SecretAttributes &attributes)
+{
+    argument.beginMap();
+    attributes.clear();
+    while (!argument.atEnd()) {
+        QString key;
+        QString value;
+        argument.beginMapEntry();
+        argument >> key >> value;
+        argument.endMapEntry();
+        attributes.insert(key, value);
+    }
+    argument.endMap();
+    return argument;
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument, const SecretMap &secrets)
+{
+    argument.beginMap(QMetaType::fromType<QDBusObjectPath>(), QMetaType::fromType<SecretValue>());
+    for (auto it = secrets.cbegin(); it != secrets.cend(); ++it) {
+        argument.beginMapEntry();
+        argument << it.key() << it.value();
+        argument.endMapEntry();
+    }
+    argument.endMap();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, SecretMap &secrets)
+{
+    argument.beginMap();
+    secrets.clear();
+    while (!argument.atEnd()) {
+        QDBusObjectPath itemPath;
+        SecretValue secret;
+        argument.beginMapEntry();
+        argument >> itemPath >> secret;
+        argument.endMapEntry();
+        secrets.insert(itemPath, secret);
+    }
+    argument.endMap();
+    return argument;
+}
+
+void registerSecretTypes()
+{
+    static bool registered = false;
+    if (registered) {
+        return;
+    }
+
+    qDBusRegisterMetaType<SecretValue>();
+    qDBusRegisterMetaType<SecretAttributes>();
+    qDBusRegisterMetaType<SecretMap>();
+    registered = true;
+}
+
+SecretAttributes geminiAttributes()
+{
+    return {
+        {QStringLiteral("application"), QCoreApplication::applicationName()},
+        {QStringLiteral("service"), QStringLiteral("gemini")},
+    };
+}
+
+QDBusInterface secretServiceInterface()
+{
+    return QDBusInterface(QStringLiteral("org.freedesktop.secrets"),
+                          QStringLiteral("/org/freedesktop/secrets"),
+                          QStringLiteral("org.freedesktop.Secret.Service"),
+                          QDBusConnection::sessionBus());
+}
+
+QDBusInterface secretCollectionInterface()
+{
+    return QDBusInterface(QStringLiteral("org.freedesktop.secrets"),
+                          QStringLiteral("/org/freedesktop/secrets/collection/default"),
+                          QStringLiteral("org.freedesktop.Secret.Collection"),
+                          QDBusConnection::sessionBus());
+}
+
+std::optional<QDBusObjectPath> openSecretSession(QString *errorMessage)
+{
+    registerSecretTypes();
+
+    QDBusInterface service = secretServiceInterface();
+    if (!service.isValid()) {
+        if (errorMessage) {
+            *errorMessage = QApplication::translate("GeminiCredentialStore", "Secret Service is not available on this Linux desktop session.");
+        }
+        return std::nullopt;
+    }
+
+    QDBusMessage reply = service.call(QStringLiteral("OpenSession"), QStringLiteral("plain"), QVariant::fromValue(QDBusVariant(QString())));
+    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().size() < 2) {
+        if (errorMessage) {
+            *errorMessage = QApplication::translate("GeminiCredentialStore", "Could not open a Secret Service session.");
+        }
+        return std::nullopt;
+    }
+
+    return reply.arguments().at(1).value<QDBusObjectPath>();
+}
+
+QList<QDBusObjectPath> searchGeminiItems(QString *errorMessage)
+{
+    registerSecretTypes();
+
+    QDBusInterface service = secretServiceInterface();
+    QDBusMessage reply = service.call(QStringLiteral("SearchItems"), QVariant::fromValue(geminiAttributes()));
+    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().size() < 2) {
+        if (errorMessage) {
+            *errorMessage = QApplication::translate("GeminiCredentialStore", "Could not search Secret Service for the Gemini API key.");
+        }
+        return {};
+    }
+
+    QList<QDBusObjectPath> items;
+    const auto unlocked = qdbus_cast<QList<QDBusObjectPath>>(reply.arguments().at(0));
+    const auto locked = qdbus_cast<QList<QDBusObjectPath>>(reply.arguments().at(1));
+    items.append(unlocked);
+    items.append(locked);
+    return items;
+}
+#endif
+
+}
+
+using namespace GeminiInternal;
+
+GeminiCredentialStore::GeminiCredentialStore(ApplicationSettings *settings, QObject *parent)
+    : QObject(parent)
+    , settings(settings)
+{
+}
+
+bool GeminiCredentialStore::hasApiKey(QString *errorMessage) const
+{
+#ifdef Q_OS_LINUX
+    return !searchGeminiItems(errorMessage).isEmpty();
+#elif defined(Q_OS_MACOS)
+    CFMutableDictionaryRef query = makeBaseQuery();
+    CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
+
+    const OSStatus status = SecItemCopyMatching(query, nullptr);
+    CFRelease(query);
+
+    if (status == errSecSuccess) {
+        return true;
+    }
+    if (status != errSecItemNotFound && errorMessage) {
+        *errorMessage = tr("Could not query the macOS Keychain for the Gemini API key.");
+    }
+    return false;
+#elif defined(Q_OS_WIN)
+    Q_UNUSED(errorMessage)
+    return settings->contains(QLatin1String(GeminiApiKeySetting));
+#else
+    if (errorMessage) {
+        *errorMessage = tr("Secure credential storage is not supported on this platform.");
+    }
+    return false;
+#endif
+}
+
+std::optional<QString> GeminiCredentialStore::loadApiKey(QString *errorMessage) const
+{
+#ifdef Q_OS_WIN
+    const QByteArray protectedData = QByteArray::fromBase64(settings->value(QLatin1String(GeminiApiKeySetting)).toByteArray());
+    if (protectedData.isEmpty()) {
+        return std::nullopt;
+    }
+
+    const auto data = unprotectData(protectedData, errorMessage);
+    if (!data) {
+        return std::nullopt;
+    }
+
+    return QString::fromUtf8(*data);
+#elif defined(Q_OS_MACOS)
+    CFMutableDictionaryRef query = makeBaseQuery();
+    CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
+    CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
+
+    CFTypeRef result = nullptr;
+    const OSStatus status = SecItemCopyMatching(query, &result);
+    CFRelease(query);
+
+    if (status == errSecItemNotFound) {
+        return std::nullopt;
+    }
+    if (status != errSecSuccess || !result) {
+        if (errorMessage) {
+            *errorMessage = tr("Could not read the Gemini API key from the macOS Keychain.");
+        }
+        return std::nullopt;
+    }
+
+    CFDataRef data = static_cast<CFDataRef>(result);
+    const QByteArray apiKey(reinterpret_cast<const char *>(CFDataGetBytePtr(data)), CFDataGetLength(data));
+    CFRelease(result);
+    return QString::fromUtf8(apiKey);
+#elif defined(Q_OS_LINUX)
+    const auto session = openSecretSession(errorMessage);
+    if (!session) {
+        return std::nullopt;
+    }
+
+    const QList<QDBusObjectPath> items = searchGeminiItems(errorMessage);
+    if (items.isEmpty()) {
+        return std::nullopt;
+    }
+
+    QDBusInterface service = secretServiceInterface();
+    QDBusMessage reply = service.call(QStringLiteral("GetSecrets"), QVariant::fromValue(items), QVariant::fromValue(*session));
+    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().isEmpty()) {
+        if (errorMessage) {
+            *errorMessage = tr("Could not read the Gemini API key from Secret Service.");
+        }
+        return std::nullopt;
+    }
+
+    const SecretMap secrets = qdbus_cast<SecretMap>(reply.arguments().constFirst());
+    if (secrets.isEmpty()) {
+        return std::nullopt;
+    }
+
+    return QString::fromUtf8(secrets.cbegin()->value);
+#else
+    if (errorMessage) {
+        *errorMessage = tr("Secure credential storage is not supported on this platform.");
+    }
+    return std::nullopt;
+#endif
+}
+
+bool GeminiCredentialStore::saveApiKey(const QString &apiKey, QString *errorMessage)
+{
+    const QByteArray apiKeyBytes = apiKey.toUtf8();
+
+#ifdef Q_OS_WIN
+    const auto protectedData = protectData(apiKeyBytes, errorMessage);
+    if (!protectedData) {
+        return false;
+    }
+
+    settings->setValue(QLatin1String(GeminiApiKeySetting), protectedData->toBase64());
+    return true;
+#elif defined(Q_OS_MACOS)
+    CFMutableDictionaryRef query = makeBaseQuery();
+    CFDataRef data = makeCFData(apiKeyBytes);
+
+    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFDictionarySetValue(attributes, kSecValueData, data);
+
+    OSStatus status = SecItemUpdate(query, attributes);
+    if (status == errSecItemNotFound) {
+        CFDictionarySetValue(query, kSecValueData, data);
+        status = SecItemAdd(query, nullptr);
+    }
+
+    CFRelease(attributes);
+    CFRelease(data);
+    CFRelease(query);
+
+    if (status != errSecSuccess) {
+        if (errorMessage) {
+            *errorMessage = tr("Could not save the Gemini API key in the macOS Keychain.");
+        }
+        return false;
+    }
+    return true;
+#elif defined(Q_OS_LINUX)
+    const auto session = openSecretSession(errorMessage);
+    if (!session) {
+        return false;
+    }
+
+    QVariantMap properties;
+    properties.insert(QStringLiteral("org.freedesktop.Secret.Item.Label"), QStringLiteral("NotepadNext Gemini API Key"));
+    properties.insert(QStringLiteral("org.freedesktop.Secret.Item.Attributes"), QVariant::fromValue(geminiAttributes()));
+
+    SecretValue secret{*session, QByteArray(), apiKeyBytes, QStringLiteral("text/plain")};
+
+    QDBusInterface collection = secretCollectionInterface();
+    QDBusMessage reply = collection.call(QStringLiteral("CreateItem"),
+                                         properties,
+                                         QVariant::fromValue(secret),
+                                         true);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        if (errorMessage) {
+            *errorMessage = tr("Could not save the Gemini API key in Secret Service.");
+        }
+        return false;
+    }
+
+    return true;
+#else
+    if (errorMessage) {
+        *errorMessage = tr("Secure credential storage is not supported on this platform.");
+    }
+    return false;
+#endif
+}
+
+bool GeminiCredentialStore::deleteApiKey(QString *errorMessage)
+{
+#ifdef Q_OS_WIN
+    Q_UNUSED(errorMessage)
+    settings->remove(QLatin1String(GeminiApiKeySetting));
+    return true;
+#elif defined(Q_OS_MACOS)
+    CFMutableDictionaryRef query = makeBaseQuery();
+    const OSStatus status = SecItemDelete(query);
+    CFRelease(query);
+
+    if (status == errSecSuccess || status == errSecItemNotFound) {
+        return true;
+    }
+
+    if (errorMessage) {
+        *errorMessage = tr("Could not delete the Gemini API key from the macOS Keychain.");
+    }
+    return false;
+#elif defined(Q_OS_LINUX)
+    const QList<QDBusObjectPath> items = searchGeminiItems(errorMessage);
+    for (const QDBusObjectPath &item : items) {
+        QDBusInterface itemInterface(QStringLiteral("org.freedesktop.secrets"),
+                                     item.path(),
+                                     QStringLiteral("org.freedesktop.Secret.Item"),
+                                     QDBusConnection::sessionBus());
+        QDBusMessage reply = itemInterface.call(QStringLiteral("Delete"));
+        if (reply.type() == QDBusMessage::ErrorMessage) {
+            if (errorMessage) {
+                *errorMessage = tr("Could not delete the Gemini API key from Secret Service.");
+            }
+            return false;
+        }
+    }
+
+    return true;
+#else
+    if (errorMessage) {
+        *errorMessage = tr("Secure credential storage is not supported on this platform.");
+    }
+    return false;
+#endif
+}

--- a/src/GeminiCredentialStore.h
+++ b/src/GeminiCredentialStore.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <QObject>
+#include <QString>
+
+class ApplicationSettings;
+
+class GeminiCredentialStore : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit GeminiCredentialStore(ApplicationSettings *settings, QObject *parent = nullptr);
+
+    bool hasApiKey(QString *errorMessage = nullptr) const;
+    std::optional<QString> loadApiKey(QString *errorMessage = nullptr) const;
+    bool saveApiKey(const QString &apiKey, QString *errorMessage = nullptr);
+    bool deleteApiKey(QString *errorMessage = nullptr);
+
+private:
+    ApplicationSettings *settings;
+};

--- a/src/GeminiSettingsPopup.cpp
+++ b/src/GeminiSettingsPopup.cpp
@@ -1,0 +1,157 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "GeminiSettingsPopup.h"
+
+#include "ApplicationSettings.h"
+#include "GeminiCredentialStore.h"
+
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QShowEvent>
+#include <QVBoxLayout>
+
+namespace {
+
+const char GeminiModelSetting[] = "Gemini/Model";
+const char DefaultGeminiModel[] = "gemini-3.1-flash-lite";
+
+}
+
+GeminiSettingsPopup::GeminiSettingsPopup(ApplicationSettings *settings, GeminiCredentialStore *credentialStore, QWidget *parent)
+    : QWidget(parent, Qt::Popup)
+    , settings(settings)
+    , credentialStore(credentialStore)
+    , statusLabel(new QLabel(this))
+    , apiKeyEdit(new QLineEdit(this))
+    , modelEdit(new QLineEdit(this))
+{
+    apiKeyEdit->setEchoMode(QLineEdit::Password);
+    apiKeyEdit->setPlaceholderText(tr("Enter a new API key"));
+
+    modelEdit->setText(modelName());
+
+    auto *formLayout = new QFormLayout;
+    formLayout->addRow(tr("API key:"), apiKeyEdit);
+    formLayout->addRow(tr("Model:"), modelEdit);
+
+    auto *saveButton = new QPushButton(tr("Save"), this);
+    auto *deleteButton = new QPushButton(tr("Delete"), this);
+
+    auto *buttonLayout = new QHBoxLayout;
+    buttonLayout->addStretch();
+    buttonLayout->addWidget(deleteButton);
+    buttonLayout->addWidget(saveButton);
+
+    auto *layout = new QVBoxLayout(this);
+    layout->addWidget(statusLabel);
+    layout->addLayout(formLayout);
+    layout->addLayout(buttonLayout);
+
+    connect(saveButton, &QPushButton::clicked, this, &GeminiSettingsPopup::save);
+    connect(deleteButton, &QPushButton::clicked, this, &GeminiSettingsPopup::remove);
+    connect(modelEdit, &QLineEdit::editingFinished, this, [this]() {
+        const QString model = modelEdit->text().trimmed();
+        if (!model.isEmpty()) {
+            this->settings->setValue(QLatin1String(GeminiModelSetting), model);
+            emit modelChanged(model);
+        }
+    });
+
+    refreshStatus();
+}
+
+QString GeminiSettingsPopup::modelName() const
+{
+    return settings->value(QLatin1String(GeminiModelSetting), QString::fromLatin1(DefaultGeminiModel)).toString();
+}
+
+void GeminiSettingsPopup::refreshStatus()
+{
+    QString errorMessage;
+    const bool hasKey = credentialStore->hasApiKey(&errorMessage);
+
+    if (!errorMessage.isEmpty()) {
+        statusLabel->setText(errorMessage);
+    }
+    else if (hasKey) {
+        statusLabel->setText(tr("Gemini API key is saved."));
+    }
+    else {
+        statusLabel->setText(tr("No Gemini API key is saved."));
+    }
+}
+
+void GeminiSettingsPopup::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+
+    apiKeyEdit->clear();
+    modelEdit->setText(modelName());
+    refreshStatus();
+}
+
+void GeminiSettingsPopup::save()
+{
+    const QString apiKey = apiKeyEdit->text().trimmed();
+    const QString model = modelEdit->text().trimmed();
+
+    if (!model.isEmpty()) {
+        settings->setValue(QLatin1String(GeminiModelSetting), model);
+        emit modelChanged(model);
+    }
+
+    if (apiKey.isEmpty()) {
+        refreshStatus();
+        hide();
+        return;
+    }
+
+    QString errorMessage;
+    if (!credentialStore->saveApiKey(apiKey, &errorMessage)) {
+        showError(errorMessage);
+        return;
+    }
+
+    apiKeyEdit->clear();
+    refreshStatus();
+    emit credentialsChanged();
+    hide();
+}
+
+void GeminiSettingsPopup::remove()
+{
+    QString errorMessage;
+    if (!credentialStore->deleteApiKey(&errorMessage)) {
+        showError(errorMessage);
+        return;
+    }
+
+    apiKeyEdit->clear();
+    refreshStatus();
+    emit credentialsChanged();
+}
+
+void GeminiSettingsPopup::showError(const QString &message)
+{
+    QMessageBox::warning(this, tr("Gemini API"), message.isEmpty() ? tr("The Gemini API key could not be saved.") : message);
+}

--- a/src/GeminiSettingsPopup.h
+++ b/src/GeminiSettingsPopup.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QWidget>
+
+class ApplicationSettings;
+class GeminiCredentialStore;
+class QLabel;
+class QLineEdit;
+
+class GeminiSettingsPopup : public QWidget
+{
+    Q_OBJECT
+
+public:
+    GeminiSettingsPopup(ApplicationSettings *settings, GeminiCredentialStore *credentialStore, QWidget *parent = nullptr);
+
+    QString modelName() const;
+    void refreshStatus();
+
+signals:
+    void modelChanged(const QString &model);
+    void credentialsChanged();
+
+protected:
+    void showEvent(QShowEvent *event) override;
+
+private:
+    ApplicationSettings *settings;
+    GeminiCredentialStore *credentialStore;
+
+    QLabel *statusLabel;
+    QLineEdit *apiKeyEdit;
+    QLineEdit *modelEdit;
+
+    void save();
+    void remove();
+    void showError(const QString &message);
+};

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -27,6 +27,7 @@
 #include "UndoAction.h"
 #include "ui_MainWindow.h"
 
+#include <algorithm>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QStringList>
@@ -68,6 +69,9 @@
 #include "FileListDock.h"
 
 #include "FindReplaceDialog.h"
+#include "GeminiClient.h"
+#include "GeminiCredentialStore.h"
+#include "GeminiSettingsPopup.h"
 #include "MacroRunDialog.h"
 #include "MacroSaveDialog.h"
 #include "PreferencesDialog.h"
@@ -107,8 +111,13 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     qInfo("setupUi Completed");
 
     defaultDirectoryManager = new DefaultDirectoryManager(this, app->getSettings(), this);
+    geminiCredentialStore = new GeminiCredentialStore(app->getSettings(), this);
+    geminiClient = new GeminiClient(this);
+    geminiSettingsPopup = new GeminiSettingsPopup(app->getSettings(), geminiCredentialStore, this);
 
     connect(this, &MainWindow::aboutToClose, this, &MainWindow::saveSettings);
+    connect(geminiClient, &GeminiClient::formatSucceeded, this, &MainWindow::applyGeminiFormattedMarkdown);
+    connect(geminiClient, &GeminiClient::formatFailed, this, &MainWindow::handleGeminiFormatError);
 
     // Create and set up the connections to the docked editor
     dockedEditor = new DockedEditor(this);
@@ -142,6 +151,8 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     connect(ui->actionSaveCopyAs, &QAction::triggered, this, &MainWindow::saveCopyAsDialog);
     connect(ui->actionSaveAll, &QAction::triggered, this, &MainWindow::saveAll);
     connect(ui->actionRename, &QAction::triggered, this, &MainWindow::renameFile);
+    connect(ui->actionFormatWithGemini, &QAction::triggered, this, &MainWindow::formatCurrentDocumentWithGemini);
+    connect(ui->actionGeminiApiSettings, &QAction::triggered, this, &MainWindow::showGeminiSettingsPopup);
 
     connect(ui->actionExportHtml, &QAction::triggered, this, [=]() {
         HtmlConverter html(currentEditor());
@@ -957,6 +968,84 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
 MainWindow::~MainWindow()
 {
     delete ui;
+}
+
+void MainWindow::showGeminiSettingsPopup()
+{
+    geminiSettingsPopup->refreshStatus();
+
+    const QRect actionGeometry = ui->mainToolBar->actionGeometry(ui->actionGeminiApiSettings);
+    const QPoint popupPosition = ui->mainToolBar->mapToGlobal(actionGeometry.bottomLeft());
+
+    geminiSettingsPopup->move(popupPosition);
+    geminiSettingsPopup->show();
+}
+
+void MainWindow::formatCurrentDocumentWithGemini()
+{
+    ScintillaNext *editor = currentEditor();
+    if (!editor || !shouldFormatWithGemini(editor)) {
+        return;
+    }
+
+    int start = 0;
+    int end = editor->length();
+    if (!editor->selectionEmpty()) {
+        const int selection = editor->mainSelection();
+        start = editor->selectionNStart(selection);
+        end = editor->selectionNEnd(selection);
+    }
+
+    if (start > end) {
+        std::swap(start, end);
+    }
+
+    const QString text = QString::fromUtf8(editor->get_text_range(start, end));
+    if (text.trimmed().isEmpty()) {
+        QMessageBox::information(this, tr("Gemini Markdown Formatting"), tr("There is no text to format."));
+        return;
+    }
+
+    QString errorMessage;
+    const auto apiKey = geminiCredentialStore->loadApiKey(&errorMessage);
+    if (!apiKey) {
+        QMessageBox::warning(this, tr("Gemini API"), errorMessage.isEmpty() ? tr("Save a Gemini API key before formatting text.") : errorMessage);
+        showGeminiSettingsPopup();
+        return;
+    }
+
+    pendingGeminiEditor = editor;
+    pendingGeminiTargetStart = start;
+    pendingGeminiTargetEnd = end;
+
+    ui->actionFormatWithGemini->setEnabled(false);
+    geminiClient->formatMarkdown(text, geminiSettingsPopup->modelName(), *apiKey);
+}
+
+void MainWindow::applyGeminiFormattedMarkdown(const QString &markdown)
+{
+    ui->actionFormatWithGemini->setEnabled(true);
+
+    if (!pendingGeminiEditor) {
+        QMessageBox::warning(this, tr("Gemini Markdown Formatting"), tr("The document was closed before Gemini returned a response."));
+        return;
+    }
+
+    ScintillaNext *editor = pendingGeminiEditor;
+    const UndoAction undoAction(editor);
+
+    editor->setTargetRange(pendingGeminiTargetStart, pendingGeminiTargetEnd);
+    const QByteArray markdownBytes = markdown.toUtf8();
+    editor->replaceTarget(markdownBytes.length(), markdownBytes.constData());
+
+    pendingGeminiEditor = Q_NULLPTR;
+}
+
+void MainWindow::handleGeminiFormatError(const QString &errorMessage)
+{
+    ui->actionFormatWithGemini->setEnabled(true);
+    pendingGeminiEditor = Q_NULLPTR;
+    QMessageBox::warning(this, tr("Gemini Markdown Formatting"), tr("Gemini formatting failed: %1").arg(errorMessage));
 }
 
 void MainWindow::applyCustomShortcuts()
@@ -1991,6 +2080,8 @@ void MainWindow::restoreSettings()
 
     zoomLevel = settings->value("Editor/ZoomLevel", 0).toInt();
 
+    migrateToolbarSettingsForGemini();
+
     if (settings->contains("Gui/ToolBar")) {
         QStringList actionNames;
         actionNames = settings->value("Gui/ToolBar").toStringList();
@@ -1999,6 +2090,57 @@ void MainWindow::restoreSettings()
 
         ActionUtils::populateActionContainer(ui->mainToolBar, this, actionNames);
     }
+}
+
+void MainWindow::migrateToolbarSettingsForGemini()
+{
+    ApplicationSettings *settings = app->getSettings();
+
+    if (!settings->contains("Gui/ToolBar") || settings->value("Gui/GeminiToolBarMigrated", false).toBool()) {
+        return;
+    }
+
+    QStringList actionNames = settings->value("Gui/ToolBar").toStringList();
+    if (!actionNames.contains(QStringLiteral("FormatWithGemini")) || !actionNames.contains(QStringLiteral("GeminiApiSettings"))) {
+        const int macroSaveIndex = actionNames.indexOf(QStringLiteral("SaveCurrentRecordedMacro"));
+        const int insertIndex = macroSaveIndex == -1 ? actionNames.size() : macroSaveIndex + 1;
+
+        if (!actionNames.contains(QStringLiteral("GeminiApiSettings"))) {
+            actionNames.insert(insertIndex, QStringLiteral("GeminiApiSettings"));
+        }
+        if (!actionNames.contains(QStringLiteral("FormatWithGemini"))) {
+            actionNames.insert(insertIndex, QStringLiteral("FormatWithGemini"));
+        }
+    }
+
+    settings->setValue("Gui/ToolBar", actionNames);
+    settings->setValue("Gui/GeminiToolBarMigrated", true);
+}
+
+bool MainWindow::shouldFormatWithGemini(ScintillaNext *editor)
+{
+    const QString languageName = editor->languageName;
+    const QString suffix = editor->isFile() ? editor->getFileInfo().suffix().toLower() : QString();
+    const bool safeTextDocument = languageName == QStringLiteral("Markdown")
+            || languageName == QStringLiteral("Text")
+            || suffix.isEmpty()
+            || suffix == QStringLiteral("md")
+            || suffix == QStringLiteral("markdown")
+            || suffix == QStringLiteral("txt");
+
+    if (safeTextDocument) {
+        return true;
+    }
+
+    const auto reply = QMessageBox::warning(
+        this,
+        tr("Gemini Markdown Formatting"),
+        tr("This document is detected as %1. Formatting it with Gemini may replace code or structured content with Markdown. Continue?")
+            .arg(languageName.isEmpty() ? tr("an unknown file type") : languageName),
+        QMessageBox::Yes | QMessageBox::No,
+        QMessageBox::No);
+
+    return reply == QMessageBox::Yes;
 }
 
 ISearchResultsHandler *MainWindow::determineSearchResultsHandler()

--- a/src/dialogs/MainWindow.h
+++ b/src/dialogs/MainWindow.h
@@ -23,6 +23,7 @@
 #include <QMainWindow>
 #include <QLabel>
 #include <QActionGroup>
+#include <QPointer>
 
 #include "DockedEditor.h"
 
@@ -43,6 +44,9 @@ class ZoomEventWatcher;
 class Converter;
 class DefaultDirectoryManager;
 class TabsQuickActionsBar;
+class GeminiClient;
+class GeminiCredentialStore;
+class GeminiSettingsPopup;
 
 class MainWindow : public QMainWindow
 {
@@ -124,6 +128,7 @@ public slots:
     void addEditor(ScintillaNext *editor);
 
     void checkForUpdates(bool silent = false);
+    void formatCurrentDocumentWithGemini();
 
     void restoreWindowState();
 
@@ -144,6 +149,8 @@ private slots:
     void languageMenuTriggered();
     void checkForUpdatesFinished(QString url);
     void activateEditor(ScintillaNext *editor);
+    void applyGeminiFormattedMarkdown(const QString &markdown);
+    void handleGeminiFormatError(const QString &errorMessage);
 
 private:
     Ui::MainWindow *ui = Q_NULLPTR;
@@ -167,6 +174,9 @@ private:
 
     void saveSettings() const;
     void restoreSettings();
+    void migrateToolbarSettingsForGemini();
+    void showGeminiSettingsPopup();
+    bool shouldFormatWithGemini(ScintillaNext *editor);
 
     ISearchResultsHandler *determineSearchResultsHandler();
 
@@ -183,6 +193,14 @@ private:
     int zoomLevel = 0;
     int contextMenuPos = 0;
     QMenu *buildMenu(QStringList actionNames);
+
+    GeminiCredentialStore *geminiCredentialStore = Q_NULLPTR;
+    GeminiClient *geminiClient = Q_NULLPTR;
+    GeminiSettingsPopup *geminiSettingsPopup = Q_NULLPTR;
+
+    QPointer<ScintillaNext> pendingGeminiEditor;
+    int pendingGeminiTargetStart = 0;
+    int pendingGeminiTargetEnd = 0;
 };
 
 #endif // MAINWINDOW_H

--- a/src/dialogs/MainWindow.ui
+++ b/src/dialogs/MainWindow.ui
@@ -412,6 +412,8 @@
    <addaction name="actionPlayback"/>
    <addaction name="actionRunMacroMultipleTimes"/>
    <addaction name="actionSaveCurrentRecordedMacro"/>
+   <addaction name="actionFormatWithGemini"/>
+   <addaction name="actionGeminiApiSettings"/>
   </widget>
   <widget class="EditorInfoStatusBar" name="statusBar"/>
   <action name="actionNew">
@@ -976,6 +978,24 @@
    </property>
    <property name="text">
     <string>Save Current Recorded Macro...</string>
+   </property>
+  </action>
+  <action name="actionFormatWithGemini">
+   <property name="icon">
+    <iconset resource="../resources.qrc">
+     <normaloff>:/icons/NotepadNext.png</normaloff>:/icons/NotepadNext.png</iconset>
+   </property>
+   <property name="text">
+    <string>Format with Gemini</string>
+   </property>
+  </action>
+  <action name="actionGeminiApiSettings">
+   <property name="icon">
+    <iconset resource="../resources.qrc">
+     <normaloff>:/icons/cog.png</normaloff>:/icons/cog.png</iconset>
+   </property>
+   <property name="text">
+    <string>Gemini API</string>
    </property>
   </action>
   <action name="actionRunMacroMultipleTimes">


### PR DESCRIPTION
## Summary

This adds Gemini-powered Markdown formatting to the NotepadNext Qt/C++ desktop application.

## What changed

- Added `GeminiClient` for asynchronous Gemini REST `generateContent` requests using `x-goog-api-key`.
- Added `GeminiCredentialStore` for OS-backed API key storage:
  - Windows: DPAPI
  - macOS: Keychain
  - Linux: Secret Service over Qt DBus
- Added `GeminiSettingsPopup` for configuring the Gemini API key and model from the toolbar.
- Added toolbar actions for formatting with Gemini and opening the Gemini API settings popup.
- Extended the main window flow to format either the current selection or the whole active document.
- Added file type safety handling:
  - Markdown/Text documents are allowed automatically.
  - `.md`, `.markdown`, `.txt`, and extensionless files are allowed automatically.
  - Other detected language types show a warning and continue only after confirmation.
- Empty input is handled locally without making an API request.
- Successful Gemini responses replace the target Scintilla range using undo-aware replacement.
- Build artifacts and local AI context folders are ignored so local generated files are not committed.

## Screenshots

<img width="1356" height="840" alt="screen" src="https://github.com/user-attachments/assets/c7834f9e-0a0f-47ae-a937-2b3f72af03cf" />

## Testing

- Configured with CMake using Qt 6.4.2 MinGW.
- Built successfully with:

```powershell
C:\Program Files\CMake\bin\cmake.exe --build build-mingw --parallel 1
```

- Launched the built executable from `build-mingw` after deploying the required Qt/MinGW runtime DLLs locally.
- Verified `build-mingw/` is ignored and not staged for commit.

## Notes

- A real Gemini API request was not verified because no local Gemini API key was available during implementation.
- The API key is never shown back in the UI after it is saved; the popup only displays saved/not-saved status.