### PR TITLE
Add Hungarian (hu_HU) translation

### DIFF
--- a/i18n/NotepadNext_hu.ts
+++ b/i18n/NotepadNext_hu.ts
@@ -2202,7 +2202,7 @@
     <message>
         <location filename="../src/dialogs/PreferencesDialog.ui" line="220"/>
         <source>Follow Current Document</source>
-        <translation>Az aktuális dokumentum mappájának követése</translation>
+        <translation>Az aktuális mappa</translation>
     </message>
     <message>
         <location filename="../src/dialogs/PreferencesDialog.ui" line="227"/>

--- a/i18n/NotepadNext_hu.ts
+++ b/i18n/NotepadNext_hu.ts
@@ -1,0 +1,2367 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu_HU" sourcelanguage="en">
+<context>
+    <name>ColumnEditorDialog</name>
+    <message>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="20"/>
+        <source>Column Mode</source>
+        <translation>Oszlop mód</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="32"/>
+        <source>Text</source>
+        <translation>Szöveg</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="47"/>
+        <source>Numbers</source>
+        <translation>Számok</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="59"/>
+        <source>Start:</source>
+        <translation>Kezdőérték:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/ColumnEditorDialog.ui" line="76"/>
+        <source>Step:</source>
+        <translation>Lépésköz:</translation>
+    </message>
+</context>
+<context>
+    <name>DebugLogDock</name>
+    <message>
+        <location filename="../src/docks/DebugLogDock.ui" line="14"/>
+        <source>Debug Log</source>
+        <translation>Hibakeresési napló</translation>
+    </message>
+</context>
+<context>
+    <name>EditorInfoStatusBar</name>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="100"/>
+        <source>Length: %L1    Lines: %L2</source>
+        <translation>Hossz: %L1    Sorok: %L2</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="109"/>
+        <source>Sel: N/A</source>
+        <translation>Kijel.: –</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="119"/>
+        <source>Sel: %L1 | %L2</source>
+        <translation>Kijel.: %L1 | %L2</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="123"/>
+        <source>Ln: %L1    Col: %L2    </source>
+        <translation>Sor: %L1    Oszlop: %L2    </translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="139"/>
+        <source>Macintosh (CR)</source>
+        <translation>Macintosh (CR)</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="142"/>
+        <source>Windows (CR LF)</source>
+        <translation>Windows (CR LF)</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="145"/>
+        <source>Unix (LF)</source>
+        <translation>Unix (LF)</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="155"/>
+        <source>ANSI</source>
+        <translation>ANSI</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="159"/>
+        <source>UTF-8</source>
+        <translation>UTF-8</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="160"/>
+        <source>UTF-8 BOM</source>
+        <translation>UTF-8 BOM</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="161"/>
+        <source>UTF-16LE BOM</source>
+        <translation>UTF-16LE BOM</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="162"/>
+        <source>UTF-16BE BOM</source>
+        <translation>UTF-16BE BOM</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="178"/>
+        <source>OVR</source>
+        <extracomment>This is a short abbreviation to indicate characters will be replaced when typing</extracomment>
+        <translation>ÁTÍ</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/EditorInfoStatusBar.cpp" line="182"/>
+        <source>INS</source>
+        <extracomment>This is a short abbreviation to indicate characters will be inserted when typing</extracomment>
+        <translation>BESZ</translation>
+    </message>
+</context>
+<context>
+    <name>EditorInspectorDock</name>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.ui" line="14"/>
+        <source>Editor Inspector</source>
+        <translation>Szerkesztő vizsgáló</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="36"/>
+        <source>Position Information</source>
+        <translation>Pozícióinformációk</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="39"/>
+        <source>Current Position</source>
+        <translation>Aktuális pozíció</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="40"/>
+        <source>Current Position (x, y)</source>
+        <translation>Aktuális pozíció (x, y)</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="41"/>
+        <source>Column</source>
+        <translation>Oszlop</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="43"/>
+        <source>Current Style</source>
+        <translation>Aktuális stílus</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="44"/>
+        <source>Current Line</source>
+        <translation>Aktuális sor</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="45"/>
+        <source>Line Length</source>
+        <translation>Sor hossza</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="46"/>
+        <source>Line End Position</source>
+        <translation>Sorvég pozíciója</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="47"/>
+        <source>Line Indentation</source>
+        <translation>Sor behúzása</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="48"/>
+        <source>Line Indent Position</source>
+        <translation>Sor behúzásának pozíciója</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="52"/>
+        <source>Selection Information</source>
+        <translation>Kijelölés információk</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="55"/>
+        <source>Mode</source>
+        <translation>Mód</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="69"/>
+        <source>Is Rectangle</source>
+        <translation>Téglalap alakú</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="70"/>
+        <source>Selection Empty</source>
+        <translation>Kijelölés üres</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="71"/>
+        <source>Main Selection</source>
+        <translation>Fő kijelölés</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="72"/>
+        <source># of Selections</source>
+        <translation>Kijelölések száma</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="75"/>
+        <source>Multiple Selections</source>
+        <translation>Többszörös kijelölés</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="80"/>
+        <source>Document Information</source>
+        <translation>Dokumentuminformációk</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="83"/>
+        <source>Length</source>
+        <translation>Hossz</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="84"/>
+        <source>Line Count</source>
+        <translation>Sorok száma</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="88"/>
+        <source>View Information</source>
+        <translation>Nézet információk</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="91"/>
+        <source>Lines on Screen</source>
+        <translation>Képernyőn látható sorok</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="92"/>
+        <source>First Visible Line</source>
+        <translation>Első látható sor</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="93"/>
+        <source>X Offset</source>
+        <translation>X eltolás</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="97"/>
+        <source>Fold Information</source>
+        <translation>Összehajtás információk</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="100"/>
+        <source>Visible From Doc Line</source>
+        <translation>Látható dokumentumsor</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="101"/>
+        <source>Doc Line From Visible</source>
+        <translation>Dokumentumsor a láthatóból</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="102"/>
+        <source>Fold Level</source>
+        <translation>Összehajtási szint</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="103"/>
+        <source>Is Fold Header</source>
+        <translation>Összehajtási fejléc</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="104"/>
+        <source>Fold Parent</source>
+        <translation>Szülő összehajtás</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="105"/>
+        <source>Last Child</source>
+        <translation>Utolsó alárendelt elem</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="106"/>
+        <source>Contracted Fold Next</source>
+        <translation>Következő összecsukott rész</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="173"/>
+        <source>Caret</source>
+        <translation>Kurzor</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="177"/>
+        <source>Anchor</source>
+        <translation>Horgony</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="181"/>
+        <source>Caret Virtual Space</source>
+        <translation>Kurzor virtuális térköze</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/EditorInspectorDock.cpp" line="185"/>
+        <source>Anchor Virtual Space</source>
+        <translation>Horgony virtuális térköze</translation>
+    </message>
+</context>
+<context>
+    <name>FileList</name>
+    <message>
+        <location filename="../src/docks/FileListDock.ui" line="14"/>
+        <source>File List</source>
+        <translation>Fájllista</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/FileListDock.ui" line="51"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/FileListDock.ui" line="90"/>
+        <source>Sort by File Name</source>
+        <translation>Rendezés fájlnév szerint</translation>
+    </message>
+</context>
+<context>
+    <name>FindReplaceDialog</name>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="20"/>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="247"/>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="59"/>
+        <source>Find</source>
+        <translation>Keresés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="69"/>
+        <source>Search Mode</source>
+        <translation>Keresési mód</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="90"/>
+        <source>&amp;Normal</source>
+        <translation>&amp;Normál</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="106"/>
+        <source>E&amp;xtended (\n, \r, \t, \0, \x...)</source>
+        <translation>K&amp;iterjesztett (\n, \r, \t, \0, \x...)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="124"/>
+        <source>Re&amp;gular expression</source>
+        <translation>Re&amp;guláris kifejezés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="140"/>
+        <source>&amp;. matches newline</source>
+        <translation>&amp;. illeszkedik az újsorra</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="179"/>
+        <source>Transparenc&amp;y</source>
+        <translation>Átlátszósá&amp;g</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="200"/>
+        <source>On losing focus</source>
+        <translation>Fókuszvesztéskor</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="210"/>
+        <source>Always</source>
+        <translation>Mindig</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="260"/>
+        <source>Coun&amp;t</source>
+        <translation>S&amp;zámlálás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="270"/>
+        <source>&amp;Replace</source>
+        <translation>&amp;Csere</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="277"/>
+        <source>Replace &amp;All</source>
+        <translation>Összes &amp;cseréje</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="284"/>
+        <source>Replace All in &amp;Opened Documents</source>
+        <translation>Összes csere a megi&amp;nyitott dokumentumokban</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="291"/>
+        <source>Find All in All &amp;Opened Documents</source>
+        <translation>Keresés az összes megi&amp;nyitott dokumentumban</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="301"/>
+        <source>Find All in Current Document</source>
+        <translation>Keresés az aktuális dokumentumban</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="311"/>
+        <source>Close</source>
+        <translation>Bezárás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="367"/>
+        <source>&amp;Find:</source>
+        <translation>&amp;Keresés:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="399"/>
+        <source>Replace:</source>
+        <translation>Csere:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="445"/>
+        <source>Backward direction</source>
+        <translation>Visszafelé irány</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="452"/>
+        <source>Match &amp;whole word only</source>
+        <translation>Csak &amp;teljes szó</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="459"/>
+        <source>Match &amp;case</source>
+        <translation>Kis-/nagy&amp;betű érzékeny</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.ui" line="466"/>
+        <source>Wra&amp;p Around</source>
+        <translation>K&amp;örbeforduló keresés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="60"/>
+        <source>Replace</source>
+        <translation>Csere</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="144"/>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="341"/>
+        <source>Replaced %Ln matches</source>
+        <translation>
+            <numerusform>%Ln egyezés lecserélve</numerusform>
+            <numerusform>%Ln egyezés lecserélve</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="239"/>
+        <source>The end of the document has been reached. Found 1st occurrence from the top.</source>
+        <translation>A dokumentum végéhez értünk. Az első előfordulás felülről megtalálva.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="250"/>
+        <source>No matches found.</source>
+        <translation>Nincs találat.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="313"/>
+        <source>1 occurrence was replaced</source>
+        <translation>1 előfordulás lecserélve</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="322"/>
+        <source>No more occurrences were found</source>
+        <translation>Nincs több előfordulás</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dialogs/FindReplaceDialog.cpp" line="352"/>
+        <source>Found %Ln matches</source>
+        <translation>
+            <numerusform>%Ln egyezés található</numerusform>
+            <numerusform>%Ln egyezés található</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>FolderAsWorkspaceDock</name>
+    <message>
+        <location filename="../src/docks/FolderAsWorkspaceDock.ui" line="14"/>
+        <source>Folder as Workspace</source>
+        <translation>Mappa mint munkaterület</translation>
+    </message>
+</context>
+<context>
+    <name>LanguageInspectorDock</name>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="14"/>
+        <source>Language Inspector</source>
+        <translation>Nyelvi vizsgáló</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="56"/>
+        <source>Language:</source>
+        <translation>Nyelv:</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="70"/>
+        <source>Lexer:</source>
+        <translation>Lexer:</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="86"/>
+        <source>Properties:</source>
+        <translation>Tulajdonságok:</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="100"/>
+        <source>Property</source>
+        <translation>Tulajdonság</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="105"/>
+        <source>Type</source>
+        <translation>Típus</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="110"/>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="151"/>
+        <source>Description</source>
+        <translation>Leírás</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="115"/>
+        <source>Value</source>
+        <translation>Érték</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="123"/>
+        <source>Keywords:</source>
+        <translation>Kulcsszavak:</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="146"/>
+        <source>ID</source>
+        <translation>Azonosító</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="159"/>
+        <source>Styles:</source>
+        <translation>Stílusok:</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.ui" line="166"/>
+        <source>TextLabel</source>
+        <translation>Szövegcímke</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/LanguageInspectorDock.cpp" line="146"/>
+        <source>Position %1 Style %2</source>
+        <translation>Pozíció: %1, stílus: %2</translation>
+    </message>
+</context>
+<context>
+    <name>LuaConsoleDock</name>
+    <message>
+        <location filename="../src/docks/LuaConsoleDock.ui" line="17"/>
+        <source>Lua Console</source>
+        <translation>Lua konzol</translation>
+    </message>
+</context>
+<context>
+    <name>MacroEditorDialog</name>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="14"/>
+        <source>Macro Editor</source>
+        <translation>Makrószerkeztő</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="48"/>
+        <source>Name</source>
+        <translation>Név</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="58"/>
+        <source>Shortcut</source>
+        <translation>Gyorsbillentyű</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="67"/>
+        <source>Steps:</source>
+        <translation>Lépések:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="95"/>
+        <source>Insert Macro Step</source>
+        <translation>Makrólépés beszúrása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="110"/>
+        <source>Delete Selected Macro Step</source>
+        <translation>Kijelölt makrólépés törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="125"/>
+        <source>Move Selected Macro Step Up</source>
+        <translation>Kijelölt makrólépés mozgatása felfelé</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="140"/>
+        <source>Move Selected Macro Step Down</source>
+        <translation>Kijelölt makrólépés mozgatása lefelé</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="176"/>
+        <source>Copy Selected Macro</source>
+        <translation>Kijelölt makró másolása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.ui" line="191"/>
+        <source>Delete Selected Macro</source>
+        <translation>Kijelölt makró törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
+        <source>Delete Macro</source>
+        <translation>Makró törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.cpp" line="129"/>
+        <source>Are you sure you want to delete &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Biztosan törölni szeretné a(z) &lt;b&gt;%1&lt;/b&gt; makrót?</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroEditorDialog.cpp" line="150"/>
+        <source>(Copy)</source>
+        <translation>(Másolat)</translation>
+    </message>
+</context>
+<context>
+    <name>MacroRunDialog</name>
+    <message>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="14"/>
+        <source>Run a Macro Multiple Times</source>
+        <translation>Makró futtatása többször</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="31"/>
+        <source>Macro:</source>
+        <translation>Makró:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="56"/>
+        <source>Run Until End of File</source>
+        <translation>Futtatás a fájl végéig</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="63"/>
+        <source>Execute...</source>
+        <translation>Végrehajtás...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="116"/>
+        <source>times</source>
+        <translation>alkalommal</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="166"/>
+        <source>Run</source>
+        <translation>Futtatás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroRunDialog.ui" line="173"/>
+        <source>Cancel</source>
+        <translation>Mégse</translation>
+    </message>
+</context>
+<context>
+    <name>MacroSaveDialog</name>
+    <message>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="14"/>
+        <source>Save Macro</source>
+        <translation>Makró mentése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="25"/>
+        <source>Name:</source>
+        <translation>Név:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="39"/>
+        <source>Shortcut:</source>
+        <translation>Gyorsbillentyű:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="82"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MacroSaveDialog.ui" line="89"/>
+        <source>Cancel</source>
+        <translation>Mégse</translation>
+    </message>
+</context>
+<context>
+    <name>MacroStepTableModel</name>
+    <message>
+        <location filename="../src/MacroStepTableModel.cpp" line="34"/>
+        <source>Name</source>
+        <translation>Név</translation>
+    </message>
+    <message>
+        <location filename="../src/MacroStepTableModel.cpp" line="36"/>
+        <source>Text</source>
+        <translation>Szöveg</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="17"/>
+        <source>Notepad Next[*]</source>
+        <translation>Notepad Next[*]</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="33"/>
+        <source>+</source>
+        <translation>+</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="48"/>
+        <source>&amp;File</source>
+        <translation>&amp;Fájl</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="52"/>
+        <source>Close More</source>
+        <translation>Több bezárása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="60"/>
+        <source>&amp;Recent Files</source>
+        <translation>&amp;Legutóbbi fájlok</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="69"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1450"/>
+        <source>Export As</source>
+        <translation>Exportálás mint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="97"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Szerkesztés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="101"/>
+        <source>Copy More</source>
+        <translation>Speciális másolás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="109"/>
+        <source>Indent</source>
+        <translation>Behúzás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="116"/>
+        <source>EOL Conversion</source>
+        <translation>Sortörés átalakítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="124"/>
+        <source>Convert Case</source>
+        <translation>Betűméret átalakítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="131"/>
+        <source>Line Operations</source>
+        <translation>Sorműveletek</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="154"/>
+        <source>Comment/Uncomment</source>
+        <translation>Megjegyzés/Megjegyzés törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="162"/>
+        <source>Copy As</source>
+        <translation>Másolás mint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="169"/>
+        <source>Encoding/Decoding</source>
+        <translation>Kódolás/Dekódolás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="200"/>
+        <source>Search</source>
+        <translation>Keresés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="204"/>
+        <source>Bookmarks</source>
+        <translation>Könyvjelzők</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="220"/>
+        <source>Mark All Occurrences</source>
+        <translation>Összes előfordulás megjelölése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="228"/>
+        <source>Clear Marks</source>
+        <translation>Jelölések törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="251"/>
+        <source>&amp;View</source>
+        <translation>&amp;Nézet</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="255"/>
+        <source>&amp;Zoom</source>
+        <translation>&amp;Nagyítás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="264"/>
+        <source>Show Symbol</source>
+        <translation>Szimbólum megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="275"/>
+        <source>Fold Level</source>
+        <translation>Összehajtási szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="289"/>
+        <source>Unfold Level</source>
+        <translation>Kihajtási szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="315"/>
+        <source>Language</source>
+        <translation>Nyelv</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="320"/>
+        <source>Settings</source>
+        <translation>Beállítások</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="326"/>
+        <source>Macro</source>
+        <translation>Makró</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="337"/>
+        <source>Help</source>
+        <translation>Súgó</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="348"/>
+        <source>Encoding</source>
+        <translation>Kódolás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="364"/>
+        <source>Main Tool Bar</source>
+        <translation>Fő eszköztár</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="424"/>
+        <source>&amp;New</source>
+        <translation>Ú&amp;j</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="427"/>
+        <source>Create a new file</source>
+        <translation>Új fájl létrehozása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="430"/>
+        <source>Ctrl+N</source>
+        <translation>Ctrl+N</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="440"/>
+        <source>&amp;Open...</source>
+        <translation>&amp;Megnyitás...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="443"/>
+        <source>Ctrl+O</source>
+        <translation>Ctrl+O</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="456"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Mentés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="459"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1962"/>
+        <source>Save</source>
+        <translation>Mentés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="462"/>
+        <source>Ctrl+S</source>
+        <translation>Ctrl+S</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="467"/>
+        <source>E&amp;xit</source>
+        <translation>K&amp;ilépés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="480"/>
+        <source>&amp;Undo</source>
+        <translation>&amp;Visszavonás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="483"/>
+        <source>Ctrl+Z</source>
+        <translation>Ctrl+Z</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="493"/>
+        <source>&amp;Redo</source>
+        <translation>&amp;Újra</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="496"/>
+        <source>Ctrl+Y</source>
+        <translation>Ctrl+Y</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="506"/>
+        <source>Cu&amp;t</source>
+        <translation>Ki&amp;vágás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="509"/>
+        <source>Ctrl+X</source>
+        <translation>Ctrl+X</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="519"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Másolás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="522"/>
+        <source>Ctrl+C</source>
+        <translation>Ctrl+C</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="532"/>
+        <source>&amp;Paste</source>
+        <translation>&amp;Beillesztés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="535"/>
+        <source>Ctrl+V</source>
+        <translation>Ctrl+V</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="540"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Törlés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="543"/>
+        <source>Del</source>
+        <translation>Del</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="548"/>
+        <source>Copy Full Path</source>
+        <translation>Teljes elérési út másolása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="553"/>
+        <source>Copy File Name</source>
+        <translation>Fájlnév másolása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="558"/>
+        <source>Copy File Directory</source>
+        <translation>Fájl mappájának másolása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="567"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Bezárás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="570"/>
+        <source>Close the current file</source>
+        <translation>Az aktuális fájl bezárása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="573"/>
+        <source>Ctrl+W</source>
+        <translation>Ctrl+W</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="578"/>
+        <source>Save &amp;As...</source>
+        <translation>Mentés &amp;más névvel...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="581"/>
+        <source>Ctrl+Alt+S</source>
+        <translation>Ctrl+Alt+S</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="586"/>
+        <source>Save a Copy As...</source>
+        <translation>Másolat mentése más névvel...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="595"/>
+        <source>Sav&amp;e All</source>
+        <translation>Össz&amp;es mentése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="598"/>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="603"/>
+        <source>Select A&amp;ll</source>
+        <translation>Összes ki&amp;jelölése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="606"/>
+        <source>Ctrl+A</source>
+        <translation>Ctrl+A</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="615"/>
+        <source>Increase Indent</source>
+        <translation>Behúzás növelése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="624"/>
+        <source>Decrease Indent</source>
+        <translation>Behúzás csökkentése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="629"/>
+        <source>Rename...</source>
+        <translation>Átnevezés...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="638"/>
+        <source>Re&amp;load</source>
+        <translation>Újratö&amp;ltés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="646"/>
+        <source>Windows (CR LF)</source>
+        <translation>Windows (CR LF)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="654"/>
+        <source>Unix (LF)</source>
+        <translation>Unix (LF)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="662"/>
+        <source>Macintosh (CR)</source>
+        <translation>Macintosh (CR)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="667"/>
+        <source>UPPER CASE</source>
+        <translation>NAGYBETŰS</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="670"/>
+        <source>Convert text to upper case</source>
+        <translation>Szöveg átalakítása nagybetűssé</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="675"/>
+        <source>lower case</source>
+        <translation>kisbetűs</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="678"/>
+        <source>Convert text to lower case</source>
+        <translation>Szöveg átalakítása kisbetűssé</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="683"/>
+        <source>Duplicate Current Line</source>
+        <translation>Aktuális sor megkettőzése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="686"/>
+        <source>Alt+Down</source>
+        <translation>Alt+Le</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="691"/>
+        <source>Split Lines</source>
+        <translation>Sorok felosztása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="696"/>
+        <source>Join Lines</source>
+        <translation>Sorok egyesítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="699"/>
+        <source>Ctrl+J</source>
+        <translation>Ctrl+J</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="704"/>
+        <source>Move Selected Lines Up</source>
+        <translation>Kijelölt sorok mozgatása felfelé</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="707"/>
+        <source>Ctrl+Shift+Up</source>
+        <translation>Ctrl+Shift+Fel</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="712"/>
+        <source>Move Selected Lines Down</source>
+        <translation>Kijelölt sorok mozgatása lefelé</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="715"/>
+        <source>Ctrl+Shift+Down</source>
+        <translation>Ctrl+Shift+Le</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="724"/>
+        <source>Clos&amp;e All</source>
+        <translation>Össz&amp;es bezárása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="727"/>
+        <source>Close All files</source>
+        <translation>Minden fájl bezárása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="730"/>
+        <source>Ctrl+Shift+W</source>
+        <translation>Ctrl+Shift+W</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="735"/>
+        <source>Close All Except Active Document</source>
+        <translation>Összes bezárása az aktív dokumentum kivételével</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="740"/>
+        <source>Close All to the Left</source>
+        <translation>Összes bezárása balra</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="745"/>
+        <source>Close All to the Right</source>
+        <translation>Összes bezárása jobbra</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="755"/>
+        <source>Zoom &amp;In</source>
+        <translation>Nagyítás &amp;be</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="758"/>
+        <source>Ctrl++</source>
+        <translation>Ctrl++</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="768"/>
+        <source>Zoom &amp;Out</source>
+        <translation>Nagyítás &amp;ki</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="771"/>
+        <source>Ctrl+-</source>
+        <translation>Ctrl+-</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="776"/>
+        <source>Reset Zoom</source>
+        <translation>Nagyítás visszaállítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="779"/>
+        <source>Ctrl+0</source>
+        <translation>Ctrl+0</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="784"/>
+        <source>About Qt</source>
+        <translation>A Qt névjegye</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="796"/>
+        <source>About Notepad Next</source>
+        <translation>A Notepad Next névjegye</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="807"/>
+        <source>Show Whitespace</source>
+        <translation>Szóközök megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="815"/>
+        <source>Show End of Line</source>
+        <translation>Sorvég megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="828"/>
+        <source>Show All Characters</source>
+        <translation>Összes karakter megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="841"/>
+        <source>Show Indent Guide</source>
+        <translation>Behúzásvezető megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="849"/>
+        <source>Show Wrap Symbol</source>
+        <translation>Sortörés szimbólum megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="862"/>
+        <source>Word Wrap</source>
+        <translation>Szótörés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="867"/>
+        <source>Restore Recently Closed File</source>
+        <translation>Nemrég bezárt fájl visszaállítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="870"/>
+        <source>Ctrl+Shift+T</source>
+        <translation>Ctrl+Shift+T</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="875"/>
+        <source>Open All Recent Files</source>
+        <translation>Összes legutóbbi fájl megnyitása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="880"/>
+        <source>Clear Recent Files List</source>
+        <translation>Legutóbbi fájlok listájának törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="890"/>
+        <source>&amp;Find...</source>
+        <translation>&amp;Keresés...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="893"/>
+        <source>Ctrl+F</source>
+        <translation>Ctrl+F</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="898"/>
+        <source>Find in Files...</source>
+        <translation>Keresés fájlokban...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="903"/>
+        <source>Find &amp;Next</source>
+        <translation>Következő &amp;találat</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="906"/>
+        <source>F3</source>
+        <translation>F3</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="911"/>
+        <source>Find &amp;Previous</source>
+        <translation>&amp;Előző találat</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="914"/>
+        <source>Shift+F3</source>
+        <translation>Shift+F3</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="924"/>
+        <source>&amp;Replace...</source>
+        <translation>&amp;Csere...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="927"/>
+        <source>Ctrl+H</source>
+        <translation>Ctrl+H</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="935"/>
+        <source>Full Screen</source>
+        <translation>Teljes képernyő</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="938"/>
+        <source>F11</source>
+        <translation>F11</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="951"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="756"/>
+        <source>Start Recording</source>
+        <translation>Rögzítés indítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="963"/>
+        <source>Playback</source>
+        <translation>Lejátszás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="966"/>
+        <source>Ctrl+Shift+P</source>
+        <translation>Ctrl+Shift+P</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="978"/>
+        <source>Save Current Recorded Macro...</source>
+        <translation>Aktuálisan rögzített makró mentése...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="990"/>
+        <source>Run a Macro Multiple Times...</source>
+        <translation>Makró futtatása többször...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="999"/>
+        <source>Preferences...</source>
+        <translation>Beállítások...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1007"/>
+        <source>Quick Find</source>
+        <translation>Gyorskeresés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1010"/>
+        <source>Ctrl+Alt+I</source>
+        <translation>Ctrl+Alt+I</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1015"/>
+        <source>Select Next Instance</source>
+        <translation>Következő előfordulás kijelölése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1018"/>
+        <source>Ctrl+D</source>
+        <translation>Ctrl+D</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1027"/>
+        <source>Move to Trash...</source>
+        <translation>Áthelyezés a kukába...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1030"/>
+        <source>Move to Trash</source>
+        <translation>Áthelyezés a kukába</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1035"/>
+        <source>Check for Updates...</source>
+        <translation>Frissítések keresése...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1040"/>
+        <source>&amp;Go to Line...</source>
+        <translation>&amp;Ugrás sorra...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1043"/>
+        <source>Ctrl+G</source>
+        <translation>Ctrl+G</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1052"/>
+        <source>Print...</source>
+        <translation>Nyomtatás...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1055"/>
+        <source>Ctrl+P</source>
+        <translation>Ctrl+P</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1060"/>
+        <source>Open Folder as Workspace...</source>
+        <translation>Mappa megnyitása munkaterületként...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1065"/>
+        <source>Toggle Single Line Comment</source>
+        <translation>Egysoros megjegyzés ki-/bekapcsolása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1068"/>
+        <source>Ctrl+/</source>
+        <translation>Ctrl+/</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1073"/>
+        <source>Single Line Comment</source>
+        <translation>Egysoros megjegyzés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1076"/>
+        <source>Ctrl+K</source>
+        <translation>Ctrl+K</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1081"/>
+        <source>Single Line Uncomment</source>
+        <translation>Egysoros megjegyzés törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1084"/>
+        <source>Ctrl+Shift+K</source>
+        <translation>Ctrl+Shift+K</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1096"/>
+        <source>Edit Macros...</source>
+        <translation>Makrók szerkesztése...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1104"/>
+        <source>This is not currently implemented</source>
+        <translation>Ez jelenleg nincs megvalósítva</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1109"/>
+        <source>Column Mode...</source>
+        <translation>Oszlop mód...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1114"/>
+        <source>Export as HTML...</source>
+        <translation>Exportálás HTML-ként...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1119"/>
+        <source>Export as RTF...</source>
+        <translation>Exportálás RTF-ként...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1124"/>
+        <source>Copy as HTML</source>
+        <translation>Másolás HTML-ként</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1129"/>
+        <source>Copy as RTF</source>
+        <translation>Másolás RTF-ként</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1134"/>
+        <source>Base 64 Encode</source>
+        <translation>Base64 kódolás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1139"/>
+        <source>URL Encode</source>
+        <translation>URL kódolás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1144"/>
+        <source>Base 64 Decode</source>
+        <translation>Base64 dekódolás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1149"/>
+        <source>URL Decode</source>
+        <translation>URL dekódolás</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1154"/>
+        <source>Copy URL</source>
+        <translation>URL másolása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1159"/>
+        <source>Remove Empty Lines</source>
+        <translation>Üres sorok törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1168"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1171"/>
+        <source>Show in Explorer</source>
+        <translation>Megjelenítés a fájlkezelőben</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1180"/>
+        <source>Open %1 Here</source>
+        <translation>%1 megnyitása itt</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1185"/>
+        <source>Toggle Bookmark</source>
+        <translation>Könyvjelző ki-/bekapcsolása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1188"/>
+        <source>Ctrl+F2</source>
+        <translation>Ctrl+F2</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1193"/>
+        <source>Next Bookmark</source>
+        <translation>Következő könyvjelző</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1196"/>
+        <source>F2</source>
+        <translation>F2</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1201"/>
+        <source>Previous Bookmark</source>
+        <translation>Előző könyvjelző</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1204"/>
+        <source>Shift+F2</source>
+        <translation>Shift+F2</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1209"/>
+        <source>Clear Bookmarks</source>
+        <translation>Könyvjelzők törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1214"/>
+        <source>Invert Bookmarks</source>
+        <translation>Könyvjelzők megfordítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1219"/>
+        <source>Next Tab</source>
+        <translation>Következő lap</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1222"/>
+        <source>Ctrl+Tab</source>
+        <translation>Ctrl+Tab</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1230"/>
+        <source>Previous Tab</source>
+        <translation>Előző lap</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1233"/>
+        <source>Ctrl+Shift+Tab</source>
+        <translation>Ctrl+Shift+Tab</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1241"/>
+        <source>Fold Level 1</source>
+        <translation>Összehajtás: 1. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1244"/>
+        <source>Alt+1</source>
+        <translation>Alt+1</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1249"/>
+        <source>Fold Level 2</source>
+        <translation>Összehajtás: 2. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1252"/>
+        <source>Alt+2</source>
+        <translation>Alt+2</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1257"/>
+        <source>Fold Level 3</source>
+        <translation>Összehajtás: 3. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1260"/>
+        <source>Alt+3</source>
+        <translation>Alt+3</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1265"/>
+        <source>Fold Level 4</source>
+        <translation>Összehajtás: 4. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1268"/>
+        <source>Alt+4</source>
+        <translation>Alt+4</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1273"/>
+        <source>Unfold Level 1</source>
+        <translation>Kihajtás: 1. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1276"/>
+        <source>Alt+Shift+1</source>
+        <translation>Alt+Shift+1</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1281"/>
+        <source>Unfold Level 2</source>
+        <translation>Kihajtás: 2. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1284"/>
+        <source>Alt+Shift+2</source>
+        <translation>Alt+Shift+2</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1289"/>
+        <source>Unfold Level 3</source>
+        <translation>Kihajtás: 3. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1292"/>
+        <source>Alt+Shift+3</source>
+        <translation>Alt+Shift+3</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1297"/>
+        <source>Unfold Level 4</source>
+        <translation>Kihajtás: 4. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1300"/>
+        <source>Alt+Shift+4</source>
+        <translation>Alt+Shift+4</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1305"/>
+        <source>Fold All</source>
+        <translation>Összes összehajtása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1308"/>
+        <source>Alt+0</source>
+        <translation>Alt+0</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1313"/>
+        <source>Unfold All</source>
+        <translation>Összes kihajtása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1316"/>
+        <source>Alt+Shift+0</source>
+        <translation>Alt+Shift+0</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1321"/>
+        <source>Fold Level 5</source>
+        <translation>Összehajtás: 5. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1324"/>
+        <source>Alt+5</source>
+        <translation>Alt+5</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1329"/>
+        <source>Fold Level 6</source>
+        <translation>Összehajtás: 6. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1332"/>
+        <source>Alt+6</source>
+        <translation>Alt+6</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1337"/>
+        <source>Fold Level 7</source>
+        <translation>Összehajtás: 7. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1340"/>
+        <source>Alt+7</source>
+        <translation>Alt+7</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1345"/>
+        <source>Fold Level 8</source>
+        <translation>Összehajtás: 8. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1348"/>
+        <source>Alt+8</source>
+        <translation>Alt+8</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1353"/>
+        <source>Fold Level 9</source>
+        <translation>Összehajtás: 9. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1356"/>
+        <source>Alt+9</source>
+        <translation>Alt+9</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1361"/>
+        <source>Unfold Level 5</source>
+        <translation>Kihajtás: 5. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1364"/>
+        <source>Alt+Shift+5</source>
+        <translation>Alt+Shift+5</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1369"/>
+        <source>Unfold Level 6</source>
+        <translation>Kihajtás: 6. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1372"/>
+        <source>Alt+Shift+6</source>
+        <translation>Alt+Shift+6</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1377"/>
+        <source>Unfold Level 7</source>
+        <translation>Kihajtás: 7. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1380"/>
+        <source>Alt+Shift+7</source>
+        <translation>Alt+Shift+7</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1385"/>
+        <source>Unfold Level 8</source>
+        <translation>Kihajtás: 8. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1388"/>
+        <source>Alt+Shift+8</source>
+        <translation>Alt+Shift+8</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1393"/>
+        <source>Unfold Level 9</source>
+        <translation>Kihajtás: 9. szint</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1396"/>
+        <source>Alt+Shift+9</source>
+        <translation>Alt+Shift+9</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1401"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1404"/>
+        <source>Toggle Overtype</source>
+        <translation>Átírás mód ki-/bekapcsolása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1407"/>
+        <source>Ins</source>
+        <translation>Ins</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1415"/>
+        <source>Debug Info...</source>
+        <translation>Hibakeresési információ...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1420"/>
+        <source>Cut Bookmarked Lines</source>
+        <translation>Könyvjelzőzött sorok kivágása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1425"/>
+        <source>Copy Bookmarked Lines</source>
+        <translation>Könyvjelzőzött sorok másolása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1430"/>
+        <source>Delete Bookmarked Lines</source>
+        <translation>Könyvjelzőzött sorok törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1435"/>
+        <source>Mark Style 1</source>
+        <translation>Jelölési stílus 1</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1443"/>
+        <source>Mark Style 2</source>
+        <translation>Jelölési stílus 2</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1451"/>
+        <source>Clear Style 1</source>
+        <translation>1. stílus törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1459"/>
+        <source>Clear Style 2</source>
+        <translation>2. stílus törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1467"/>
+        <source>Mark Style 3</source>
+        <translation>Jelölési stílus 3</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1475"/>
+        <source>Clear Style 3</source>
+        <translation>3. stílus törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1483"/>
+        <location filename="../src/dialogs/MainWindow.ui" line="1486"/>
+        <source>Clear All Styles</source>
+        <translation>Összes stílus törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1491"/>
+        <source>Remove Duplicate Lines</source>
+        <translation>Ismétlődő sorok eltávolítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1496"/>
+        <source>Remove Consecutive Duplicate Lines</source>
+        <translation>Egymást követő ismétlődő sorok eltávolítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1501"/>
+        <source>Sort Lines Ascending</source>
+        <translation>Sorok rendezése növekvő sorrendbe</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1506"/>
+        <source>Sort Lines Descending</source>
+        <translation>Sorok rendezése csökkenő sorrendbe</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1511"/>
+        <source>Sort Lines Ascending (Case-Insensitive)</source>
+        <translation>Sorok rendezése növekvő sorrendbe (kis-/nagybetű érzékenység nélkül)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1516"/>
+        <source>Sort Lines Descending (Case-Insensitive)</source>
+        <translation>Sorok rendezése csökkenő sorrendbe (kis-/nagybetű érzékenység nélkül)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1521"/>
+        <source>Sort Lines by Length Ascending</source>
+        <translation>Sorok rendezése hossz szerint növekvő sorrendbe</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1526"/>
+        <source>Sort Lines by Length Descending</source>
+        <translation>Sorok rendezése hossz szerint csökkenő sorrendbe</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.ui" line="1531"/>
+        <source>Reverse Line Order</source>
+        <translation>Sorok sorrendjének megfordítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="412"/>
+        <source>Go to line</source>
+        <translation>Ugrás sorra</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="412"/>
+        <source>Line Number (1 - %1)</source>
+        <translation>Sorszám (1 - %1)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="747"/>
+        <source>Stop Recording</source>
+        <translation>Rögzítés leállítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="852"/>
+        <source>Debug Info</source>
+        <translation>Hibakeresési információ</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1073"/>
+        <source>New %1</source>
+        <translation>Új %1</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1133"/>
+        <source>Create File</source>
+        <translation>Fájl létrehozása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1133"/>
+        <source>&lt;b&gt;%1&lt;/b&gt; does not exist. Do you want to create it?</source>
+        <translation>A(z) &lt;b&gt;%1&lt;/b&gt; nem létezik. Szeretné létrehozni?</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1953"/>
+        <source>Save File</source>
+        <translation>Fájl mentése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1211"/>
+        <source>Open Folder as Workspace</source>
+        <translation>Mappa megnyitása munkaterületként</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1234"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1896"/>
+        <source>Reload File</source>
+        <translation>Fájl újratöltése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1234"/>
+        <source>Are you sure you want to reload &lt;b&gt;%1&lt;/b&gt;? Any unsaved changes will be lost.</source>
+        <translation>Biztosan újra szeretné tölteni a(z) &lt;b&gt;%1&lt;/b&gt; fájlt? A nem mentett módosítások elvesznek.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1406"/>
+        <source>Save a Copy As</source>
+        <translation>Másolat mentése más névvel</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1491"/>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1508"/>
+        <source>Rename</source>
+        <translation>Átnevezés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1508"/>
+        <source>Name:</source>
+        <translation>Név:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1528"/>
+        <source>Delete File</source>
+        <translation>Fájl törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1528"/>
+        <source>Are you sure you want to move &lt;b&gt;%1&lt;/b&gt; to the trash?</source>
+        <translation>Biztosan a kukába szeretné helyezni a(z) &lt;b&gt;%1&lt;/b&gt; fájlt?</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1538"/>
+        <source>Error Deleting File</source>
+        <translation>Hiba a fájl törlésekor</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1538"/>
+        <source>Something went wrong deleting &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Hiba történt a(z) &lt;b&gt;%1&lt;/b&gt; törlése közben.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1635"/>
+        <source>Administrator</source>
+        <translation>Rendszergazda</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1896"/>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been modified by another program. Do you want to reload it?</source>
+        <translation>A(z) &lt;b&gt;%1&lt;/b&gt; fájlt egy másik program módosította. Szeretné újratölteni?</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1922"/>
+        <source>Read error</source>
+        <translation>Olvasási hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1923"/>
+        <source>Write error</source>
+        <translation>Írási hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1924"/>
+        <source>Fatal error</source>
+        <translation>Végzetes hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1925"/>
+        <source>Resource error</source>
+        <translation>Erőforrás-hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1926"/>
+        <source>Open error</source>
+        <translation>Megnyitási hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1927"/>
+        <source>Abort error</source>
+        <translation>Megszakítási hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1928"/>
+        <source>Timeout error</source>
+        <translation>Időtúllépési hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1929"/>
+        <source>Unspecified error</source>
+        <translation>Meghatározatlan hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1930"/>
+        <source>Remove error</source>
+        <translation>Eltávolítási hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1931"/>
+        <source>Rename error</source>
+        <translation>Átnevezési hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1932"/>
+        <source>Position error</source>
+        <translation>Pozicionálási hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1933"/>
+        <source>Resize error</source>
+        <translation>Átméretezési hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1934"/>
+        <source>Permissions error</source>
+        <translation>Jogosultsági hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1935"/>
+        <source>Copy error</source>
+        <translation>Másolási hiba</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1936"/>
+        <source>Unknown error (%1)</source>
+        <translation>Ismeretlen hiba (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1939"/>
+        <source>Error Saving File</source>
+        <translation>Hiba a fájl mentésekor</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1940"/>
+        <source>An error occurred when saving &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Error: %2</source>
+        <translation>Hiba történt a(z) &lt;b&gt;%1&lt;/b&gt; mentése közben.&lt;br&gt;&lt;br&gt;Hiba: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1946"/>
+        <source>Zoom: %1%</source>
+        <translation>Nagyítás: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1958"/>
+        <source>Save changes to &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation>Menti a(z) &lt;b&gt;%1&lt;/b&gt; módosításait?</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dialogs/MainWindow.cpp" line="1959"/>
+        <source>There are %n files with unsaved changes. Save them?</source>
+        <translation>
+            <numerusform>%n fájlnak vannak nem mentett módosításai. Menti őket?</numerusform>
+            <numerusform>%n fájlnak vannak nem mentett módosításai. Menti őket?</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1962"/>
+        <source>Save All</source>
+        <translation>Összes mentése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1963"/>
+        <source>Discard All</source>
+        <translation>Összes elvetése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="1963"/>
+        <source>Discard</source>
+        <translation>Elvetés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/MainWindow.cpp" line="2138"/>
+        <source>No updates are available at this time.</source>
+        <translation>Jelenleg nem érhetők el frissítések.</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesDialog</name>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="14"/>
+        <source>Preferences</source>
+        <translation>Beállítások</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="37"/>
+        <source>Show menu bar</source>
+        <translation>Menüsor megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="44"/>
+        <source>Show toolbar</source>
+        <translation>Eszköztár megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="51"/>
+        <source>Show status bar</source>
+        <translation>Állapotsor megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="58"/>
+        <source>Restore previous session</source>
+        <translation>Előző munkamenet visszaállítása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="70"/>
+        <source>Unsaved changes</source>
+        <translation>Nem mentett módosítások</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="77"/>
+        <source>Temporary files</source>
+        <translation>Ideiglenes fájlok</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="89"/>
+        <source>Recenter find/replace dialog when opened</source>
+        <translation>Keresés/csere párbeszédablak középre igazítása megnyitáskor</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="96"/>
+        <source>Combine search results</source>
+        <translation>Keresési eredmények összevonása</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="114"/>
+        <source>Translation:</source>
+        <translation>Fordítás:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="123"/>
+        <source>Exit on last tab closed</source>
+        <translation>Kilépés az utolsó lap bezárásakor</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="132"/>
+        <source>Default Font</source>
+        <translation>Alapértelmezett betűtípus</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="138"/>
+        <source>Font</source>
+        <translation>Betűtípus</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="148"/>
+        <source>Font Size</source>
+        <translation>Betűméret</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="155"/>
+        <source>pt</source>
+        <translation>pt</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="188"/>
+        <source>Default Line Endings</source>
+        <translation>Alapértelmezett sortörés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="200"/>
+        <source>Highlight URLs</source>
+        <translation>URL-ek kiemelése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="207"/>
+        <source>Show Line Numbers</source>
+        <translation>Sorszámok megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="214"/>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="122"/>
+        <source>Default Directory</source>
+        <translation>Alapértelmezett mappa</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="220"/>
+        <source>Follow Current Document</source>
+        <translation>Az aktuális dokumentum mappájának követése</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="227"/>
+        <source>Last Used Directory</source>
+        <translation>Utoljára használt mappa</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="246"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="277"/>
+        <source>TextLabel</source>
+        <translation>Szövegcímke</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.ui" line="289"/>
+        <source>An application restart is required to apply certain settings.</source>
+        <translation>Egyes beállítások alkalmazásához az alkalmazás újraindítása szükséges.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
+        <source>Warning</source>
+        <translation>Figyelmeztetés</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="56"/>
+        <source>This feature is experimental and it should not be considered safe for critically important work. It may lead to possible data loss. Use at your own risk.</source>
+        <translation>Ez a funkció kísérleti jellegű, és kritikusan fontos munkánál nem tekinthető biztonságosnak. Adatvesztést okozhat. Saját felelősségére használja.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="85"/>
+        <source>System Default</source>
+        <translation>Rendszer alapértelmezett</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="86"/>
+        <source>Windows (CR LF)</source>
+        <translation>Windows (CR LF)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="87"/>
+        <source>Linux (LF)</source>
+        <translation>Linux (LF)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="88"/>
+        <source>Macintosh (CR)</source>
+        <translation>Macintosh (CR)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/PreferencesDialog.cpp" line="185"/>
+        <source>&lt;System Default&gt;</source>
+        <translation>&lt;Rendszer alapértelmezett&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>QuickFindWidget</name>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="17"/>
+        <source>Frame</source>
+        <translation>Keret</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="32"/>
+        <source>Find...</source>
+        <translation>Keresés...</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="44"/>
+        <source>Match case</source>
+        <translation>Kis-/nagybetű érzékeny</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="47"/>
+        <source>Aa</source>
+        <translation>Aa</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="57"/>
+        <source>Match whole word</source>
+        <translation>Teljes szó egyezés</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="60"/>
+        <source>|A|</source>
+        <translation>|A|</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="70"/>
+        <source>Use regular expression</source>
+        <translation>Reguláris kifejezés használata</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="73"/>
+        <source>. *</source>
+        <translation>. *</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.ui" line="76"/>
+        <source>Alt+E</source>
+        <translation>Alt+E</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/QuickFindWidget.cpp" line="238"/>
+        <source>%L1/%L2</source>
+        <translation>%L1/%L2</translation>
+    </message>
+</context>
+<context>
+    <name>SearchResultsDock</name>
+    <message>
+        <location filename="../src/docks/SearchResultsDock.ui" line="14"/>
+        <source>Search Results</source>
+        <translation>Keresési eredmények</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/SearchResultsDock.ui" line="38"/>
+        <source>Copy Results to Clipboard</source>
+        <translation>Eredmények másolása a vágólapra</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="57"/>
+        <source>Collapse All</source>
+        <translation>Összes összecsukása</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="58"/>
+        <source>Expand All</source>
+        <translation>Összes kinyitása</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="60"/>
+        <source>Delete Entry</source>
+        <translation>Bejegyzés törlése</translation>
+    </message>
+    <message>
+        <location filename="../src/docks/SearchResultsDock.cpp" line="62"/>
+        <source>Delete All</source>
+        <translation>Összes törlése</translation>
+    </message>
+</context>
+<context>
+    <name>TabsQuickActionsBar</name>
+    <message>
+        <location filename="../src/widgets/TabsQuickActionsBar.cpp" line="40"/>
+        <source>Create a new file</source>
+        <translation>Új fájl létrehozása</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/TabsQuickActionsBar.cpp" line="43"/>
+        <source>Show opened files list</source>
+        <translation>Megnyitott fájlok listájának megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/TabsQuickActionsBar.cpp" line="49"/>
+        <source>Close the current file</source>
+        <translation>Az aktuális fájl bezárása</translation>
+    </message>
+</context>
+</TS>

--- a/i18n/NotepadNext_hu.ts
+++ b/i18n/NotepadNext_hu.ts
@@ -2151,7 +2151,7 @@
     <message>
         <location filename="../src/dialogs/PreferencesDialog.ui" line="114"/>
         <source>Translation:</source>
-        <translation>Fordítás:</translation>
+        <translation>Felület nyelve:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/PreferencesDialog.ui" line="123"/>

--- a/i18n/NotepadNext_hu.ts
+++ b/i18n/NotepadNext_hu.ts
@@ -415,7 +415,7 @@
     <message>
         <location filename="../src/dialogs/FindReplaceDialog.ui" line="445"/>
         <source>Backward direction</source>
-        <translation>Visszafelé irány</translation>
+        <translation>Visszafelé</translation>
     </message>
     <message>
         <location filename="../src/dialogs/FindReplaceDialog.ui" line="452"/>
@@ -565,7 +565,7 @@
     <message>
         <location filename="../src/dialogs/MacroEditorDialog.ui" line="14"/>
         <source>Macro Editor</source>
-        <translation>Makrószerkeztő</translation>
+        <translation>Makrószerkesztő</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MacroEditorDialog.ui" line="48"/>
@@ -828,7 +828,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="289"/>
         <source>Unfold Level</source>
-        <translation>Kihajtási szint</translation>
+        <translation>Kibontási szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="315"/>
@@ -1229,7 +1229,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="862"/>
         <source>Word Wrap</source>
-        <translation>Szótörés</translation>
+        <translation>Sortörés</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="867"/>
@@ -1606,7 +1606,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1273"/>
         <source>Unfold Level 1</source>
-        <translation>Kihajtás: 1. szint</translation>
+        <translation>Kibontás: 1. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1276"/>
@@ -1616,7 +1616,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1281"/>
         <source>Unfold Level 2</source>
-        <translation>Kihajtás: 2. szint</translation>
+        <translation>Kibontás: 2. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1284"/>
@@ -1626,7 +1626,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1289"/>
         <source>Unfold Level 3</source>
-        <translation>Kihajtás: 3. szint</translation>
+        <translation>Kibontás: 3. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1292"/>
@@ -1636,7 +1636,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1297"/>
         <source>Unfold Level 4</source>
-        <translation>Kihajtás: 4. szint</translation>
+        <translation>Kibontás: 4. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1300"/>
@@ -1656,7 +1656,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1313"/>
         <source>Unfold All</source>
-        <translation>Összes kihajtása</translation>
+        <translation>Összes kibontása</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1316"/>
@@ -1716,7 +1716,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1361"/>
         <source>Unfold Level 5</source>
-        <translation>Kihajtás: 5. szint</translation>
+        <translation>Kibontás: 5. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1364"/>
@@ -1726,7 +1726,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1369"/>
         <source>Unfold Level 6</source>
-        <translation>Kihajtás: 6. szint</translation>
+        <translation>Kibontás: 6. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1372"/>
@@ -1736,7 +1736,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1377"/>
         <source>Unfold Level 7</source>
-        <translation>Kihajtás: 7. szint</translation>
+        <translation>Kibontás: 7. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1380"/>
@@ -1746,7 +1746,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1385"/>
         <source>Unfold Level 8</source>
-        <translation>Kihajtás: 8. szint</translation>
+        <translation>Kibontás: 8. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1388"/>
@@ -1756,7 +1756,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1393"/>
         <source>Unfold Level 9</source>
-        <translation>Kihajtás: 9. szint</translation>
+        <translation>Kibontás: 9. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1396"/>

--- a/i18n/NotepadNext_hu.ts
+++ b/i18n/NotepadNext_hu.ts
@@ -242,7 +242,7 @@
     <message>
         <location filename="../src/docks/EditorInspectorDock.cpp" line="97"/>
         <source>Fold Information</source>
-        <translation>Összehajtás információk</translation>
+        <translation>Összecsukás információk</translation>
     </message>
     <message>
         <location filename="../src/docks/EditorInspectorDock.cpp" line="100"/>
@@ -257,12 +257,12 @@
     <message>
         <location filename="../src/docks/EditorInspectorDock.cpp" line="102"/>
         <source>Fold Level</source>
-        <translation>Összehajtási szint</translation>
+        <translation>Összecsukási szint</translation>
     </message>
     <message>
         <location filename="../src/docks/EditorInspectorDock.cpp" line="103"/>
         <source>Is Fold Header</source>
-        <translation>Összehajtási fejléc</translation>
+        <translation>Összecsukási fejléc</translation>
     </message>
     <message>
         <location filename="../src/docks/EditorInspectorDock.cpp" line="104"/>
@@ -823,7 +823,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="275"/>
         <source>Fold Level</source>
-        <translation>Összehajtási szint</translation>
+        <translation>Összecsukási szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="289"/>
@@ -999,7 +999,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="578"/>
         <source>Save &amp;As...</source>
-        <translation>Mentés &amp;más névvel...</translation>
+        <translation>Mentés &amp;más néven...</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="581"/>
@@ -1009,7 +1009,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="586"/>
         <source>Save a Copy As...</source>
-        <translation>Másolat mentése más névvel...</translation>
+        <translation>Másolat mentése más néven...</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="595"/>
@@ -1566,7 +1566,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1241"/>
         <source>Fold Level 1</source>
-        <translation>Összehajtás: 1. szint</translation>
+        <translation>Összecsukás: 1. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1244"/>
@@ -1576,7 +1576,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1249"/>
         <source>Fold Level 2</source>
-        <translation>Összehajtás: 2. szint</translation>
+        <translation>Összecsukás: 2. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1252"/>
@@ -1586,7 +1586,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1257"/>
         <source>Fold Level 3</source>
-        <translation>Összehajtás: 3. szint</translation>
+        <translation>Összecsukás: 3. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1260"/>
@@ -1596,7 +1596,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1265"/>
         <source>Fold Level 4</source>
-        <translation>Összehajtás: 4. szint</translation>
+        <translation>Összecsukás: 4. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1268"/>
@@ -1666,7 +1666,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1321"/>
         <source>Fold Level 5</source>
-        <translation>Összehajtás: 5. szint</translation>
+        <translation>Összecsukás: 5. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1324"/>
@@ -1676,7 +1676,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1329"/>
         <source>Fold Level 6</source>
-        <translation>Összehajtás: 6. szint</translation>
+        <translation>Összecsukás: 6. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1332"/>
@@ -1686,7 +1686,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1337"/>
         <source>Fold Level 7</source>
-        <translation>Összehajtás: 7. szint</translation>
+        <translation>Összecsukás: 7. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1340"/>
@@ -1696,7 +1696,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1345"/>
         <source>Fold Level 8</source>
-        <translation>Összehajtás: 8. szint</translation>
+        <translation>Összecsukás: 8. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1348"/>
@@ -1706,7 +1706,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1353"/>
         <source>Fold Level 9</source>
-        <translation>Összehajtás: 9. szint</translation>
+        <translation>Összecsukás: 9. szint</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.ui" line="1356"/>
@@ -1934,7 +1934,7 @@
     <message>
         <location filename="../src/dialogs/MainWindow.cpp" line="1406"/>
         <source>Save a Copy As</source>
-        <translation>Másolat mentése más névvel</translation>
+        <translation>Másolat mentése más néven</translation>
     </message>
     <message>
         <location filename="../src/dialogs/MainWindow.cpp" line="1491"/>


### PR DESCRIPTION
Complete Hungarian localization covering all 457 UI strings. Follows the same Qt .ts format as other translations in the project.## Hungarian (Magyar) translation

  This PR adds a complete Hungarian localization for NotepadNext.
  
  - **Language code:** `hu_HU`
  - **File:** `i18n/NotepadNext_hu.ts`
  - **Coverage:** 457/457 strings translated (100%)
  - **Format:** Qt .ts 2.1, valid XML

  All UI strings have been translated including menus, dialogs, status bar,
  find/replace, preferences, and all dock panels.