### PR TITLE
Add language keyword candidates to auto-completion

### DIFF
--- a/src/NotepadNextApplication.cpp
+++ b/src/NotepadNextApplication.cpp
@@ -295,6 +295,7 @@ void NotepadNextApplication::setEditorLanguage(ScintillaNext *editor, const QStr
     getLuaState()->setVariable("skip_tabwidth", skipTabWidth);
 
     getLuaState()->execute("SetLanguage(languageName)");
+    editor->languageKeywords = getLuaState()->executeAndReturn<QStringList>("return GetLanguageKeywords(languageName)");
 }
 
 QString NotepadNextApplication::detectLanguage(ScintillaNext *editor) const

--- a/src/NotepadNextApplication.cpp
+++ b/src/NotepadNextApplication.cpp
@@ -295,7 +295,12 @@ void NotepadNextApplication::setEditorLanguage(ScintillaNext *editor, const QStr
     getLuaState()->setVariable("skip_tabwidth", skipTabWidth);
 
     getLuaState()->execute("SetLanguage(languageName)");
-    editor->languageKeywords = getLuaState()->executeAndReturn<QStringList>("return GetLanguageKeywords(languageName)");
+}
+
+QStringList NotepadNextApplication::getLanguageKeywords(const QString &languageName) const
+{
+    getLuaState()->setVariable("languageName", languageName);
+    return getLuaState()->executeAndReturn<QStringList>("return GetLanguageKeywords(languageName)");
 }
 
 QString NotepadNextApplication::detectLanguage(ScintillaNext *editor) const

--- a/src/NotepadNextApplication.h
+++ b/src/NotepadNextApplication.h
@@ -59,6 +59,7 @@ public:
 
     QStringList getLanguages() const;
     void setEditorLanguage(ScintillaNext *editor, const QString &languageName) const;
+    QStringList getLanguageKeywords(const QString &languageName) const;
 
     QString detectLanguage(ScintillaNext *editor) const;
     QString detectLanguageFromExtension(const QString &extension) const;

--- a/src/ScintillaNext.h
+++ b/src/ScintillaNext.h
@@ -26,6 +26,7 @@
 #include <QDateTime>
 #include <QFile>
 #include <QFileInfo>
+#include <QStringList>
 
 
 
@@ -123,6 +124,7 @@ public:
 
     QString languageName;
     QByteArray languageSingleLineComment;
+    QStringList languageKeywords;
 
     #include "ScintillaEnums.h"
 

--- a/src/ScintillaNext.h
+++ b/src/ScintillaNext.h
@@ -26,7 +26,6 @@
 #include <QDateTime>
 #include <QFile>
 #include <QFileInfo>
-#include <QStringList>
 
 
 
@@ -124,7 +123,6 @@ public:
 
     QString languageName;
     QByteArray languageSingleLineComment;
-    QStringList languageKeywords;
 
     #include "ScintillaEnums.h"
 

--- a/src/decorators/AutoCompletion.cpp
+++ b/src/decorators/AutoCompletion.cpp
@@ -20,6 +20,8 @@
 #include "AutoCompletion.h"
 
 #include <QSet>
+#include <QString>
+#include <Qt>
 
 
 using namespace Scintilla;
@@ -70,6 +72,14 @@ void AutoCompletion::showAutoCompletion()
         words.insert(editor->get_text_range(start, end));
         return end;
     }, { endPos, (Sci_PositionCR)editor->length()});
+
+    // Add matching language keywords
+    const QString currentWordStr = QString::fromUtf8(current_word);
+    for (const QString &kw : editor->languageKeywords) {
+        if (kw.startsWith(currentWordStr, Qt::CaseSensitive)) {
+            words.insert(kw.toUtf8());
+        }
+    }
 
     if (!words.isEmpty()) {
         editor->autoCShow(current_word.length(), words.values().join(' '));

--- a/src/decorators/AutoCompletion.cpp
+++ b/src/decorators/AutoCompletion.cpp
@@ -18,7 +18,9 @@
 
 
 #include "AutoCompletion.h"
+#include "NotepadNextApplication.h"
 
+#include <QApplication>
 #include <QSet>
 #include <QString>
 #include <Qt>
@@ -31,6 +33,11 @@ AutoCompletion::AutoCompletion(ScintillaNext *editor) :
 {
     editor->autoCSetOrder(SC_ORDER_PERFORMSORT);
     editor->autoCSetMaxHeight(10);
+
+    connect(editor, &ScintillaNext::lexerChanged, this, [this]() {
+        NotepadNextApplication *app = qobject_cast<NotepadNextApplication *>(qApp);
+        keywords = app->getLanguageKeywords(this->editor->languageName);
+    });
 }
 
 void AutoCompletion::notify(const NotificationData *pscn)
@@ -75,7 +82,7 @@ void AutoCompletion::showAutoCompletion()
 
     // Add matching language keywords
     const QString currentWordStr = QString::fromUtf8(current_word);
-    for (const QString &kw : editor->languageKeywords) {
+    for (const QString &kw : keywords) {
         if (kw.startsWith(currentWordStr, Qt::CaseSensitive)) {
             words.insert(kw.toUtf8());
         }

--- a/src/decorators/AutoCompletion.h
+++ b/src/decorators/AutoCompletion.h
@@ -22,6 +22,8 @@
 
 #include "EditorDecorator.h"
 
+#include <QStringList>
+
 
 class AutoCompletion : public EditorDecorator
 {
@@ -33,6 +35,9 @@ public:
 public slots:
     void notify(const Scintilla::NotificationData *pscn) override;
     void showAutoCompletion();
+
+private:
+    QStringList keywords;
 };
 
 #endif // AUTOCOMPLETION_H

--- a/src/scripts/init.lua
+++ b/src/scripts/init.lua
@@ -102,6 +102,44 @@ function SetLanguage(languageName)
     editor.Property["fold.compact"] = "0"
 end
 
+function GetLanguageKeywords(languageName)
+    local L = languages[languageName]
+
+    if not L or not L.keywords then
+        return {}
+    end
+
+    local seen = {}
+
+    local function collectKeywords(lang)
+        if not lang then return end
+        if lang.keywords then
+            for _, kwString in pairs(lang.keywords) do
+                for token in kwString:gmatch("%S+") do
+                    seen[token] = true
+                end
+            end
+        end
+    end
+
+    collectKeywords(L)
+
+    if L.additionalLanguages then
+        for _, language in pairs(L.additionalLanguages) do
+            collectKeywords(languages[language])
+        end
+    end
+
+    local result = {}
+    for token, _ in pairs(seen) do
+        result[#result + 1] = token
+    end
+
+    table.sort(result)
+
+    return result
+end
+
 languages = {}
 languages["ActionScript"] = require("actionscript")
 languages["ADA"] = require("ada")


### PR DESCRIPTION
## Description

Fixes #839

NotepadNext's auto-completion only suggests words already present in the document. This PR adds language keyword candidates to the completion list so keywords appear as suggestions even before they have been typed in the file. The change is gated by the existing **Auto Completion** preference and requires no new settings.

---

## Changes

**`src/ScintillaNext.h`**
- Added `#include <QStringList>` and a public `QStringList languageKeywords` member to hold the active language's keyword list alongside the existing `languageName` and `languageSingleLineComment` fields.

**`src/scripts/init.lua`**
- Added `GetLanguageKeywords(languageName)` helper that reads `languages[languageName].keywords`, splits each space-separated keyword string into individual tokens, deduplicates them, recurses into `additionalLanguages` (matching `SetLanguage`'s behaviour), and returns a sorted array. Returns `{}` for languages with no keyword definitions (e.g. plain Text).

**`src/NotepadNextApplication.cpp`**
- Added one line at the end of `setEditorLanguage()` — calls `GetLanguageKeywords(languageName)` through the Lua state and stores the result in `editor->languageKeywords`. The field is unconditionally reassigned on every language change, so switching to Text or any other keyword-less language clears it automatically.

**`src/decorators/AutoCompletion.cpp`**
- Extended `showAutoCompletion()` to iterate `editor->languageKeywords` after the document scan, inserting any keyword that starts with the current prefix into the existing `QSet<QByteArray>` candidate set. Deduplication is handled for free by the set. The 3-character minimum, `SCFIND_MATCHCASE` case-sensitivity, `SC_ORDER_PERFORMSORT` ordering, and the single `Editor/AutoCompletion` preference toggle are all preserved.

Video of manual test below :

[Screencast from 2026-06-02 21-34-24.webm](https://github.com/user-attachments/assets/a76cf7ae-181e-4522-8c63-3f2f67693f34)

