### PR TITLE
Fix context menu caret behavior when right-clicking inside a selection

### DIFF
--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -2105,6 +2105,12 @@ void MainWindow::addEditor(ScintillaNext *editor)
     connect(editor, &ScintillaNext::customContextMenuRequested, this, [=, this](const QPoint &pos) {
         contextMenuPos = editor->positionFromPoint(pos.x(), pos.y());
 
+        // If the click landed outside the current selection, move the caret there
+        // and clear the selection so caret-based actions use the clicked location.
+        if (editor->selectionFromPoint(pos.x(), pos.y()) == -1) {
+            editor->setEmptySelection(contextMenuPos);
+        }
+
         QStringList actionNames = {
             "Cut",
             "Copy",


### PR DESCRIPTION
Fixes #780

The editor context menu had inconsistent behavior; this meant right-clicking outside a selection with the intent to act on that location would still operate on wherever the caret happened to be.

## Change

**MainWindow.cpp** — In the `customContextMenuRequested` handler inside `addEditor`, a call to `selectionFromPoint` now checks whether the right-click landed inside an existing selection. If it did, the selection and caret are left untouched. If it did not, `setEmptySelection` is called to move the caret to the clicked position, matching standard editor behavior.

## Behavior

- Right-clicking **inside** a selection preserves the selection; context menu actions operate on the selected text
- Right-clicking **outside** a selection clears it and moves the caret to the clicked position
- URL detection (`Copy URL`) is unaffected — `contextMenuPos` is still set before the check
- No new settings, files, or API changes

Manual test after the fix :

[Screencast from 2026-06-07 23-28-54.webm](https://github.com/user-attachments/assets/7f3c752f-f95f-4555-a453-d66f37df6a1a)
