### PR TITLE
Make search result text selectable and copyable

### DIFF
--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -335,7 +335,16 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     connectEditorAction(ui->actionUndo, &ScintillaNext::undo);
     connectEditorAction(ui->actionRedo, &ScintillaNext::redo);
     connectEditorAction(ui->actionCut, &ScintillaNext::cutAllowLine);
-    connectEditorAction(ui->actionCopy, &ScintillaNext::copyAllowLine);
+    connect(ui->actionCopy, &QAction::triggered, this, [this]() {
+        SearchResultsDock *searchResultsDock = findChild<SearchResultsDock *>();
+        if (searchResultsDock != Q_NULLPTR && searchResultsDock->copySelectedResultText()) {
+            return;
+        }
+
+        if (auto* editor = currentEditor()) {
+            editor->copyAllowLine();
+        }
+    });
     connectEditorAction(ui->actionDelete, &ScintillaNext::clear);
     connectEditorAction(ui->actionPaste, &ScintillaNext::paste);
     connectEditorAction(ui->actionSelectAll, &ScintillaNext::selectAll);

--- a/src/docks/SearchResultsDock.cpp
+++ b/src/docks/SearchResultsDock.cpp
@@ -25,11 +25,166 @@
 #include "ScintillaNext.h"
 #include "ui_SearchResultsDock.h"
 
-#include <QKeyEvent>
-#include <QPointer>
-#include <QMenu>
-#include <QShortcut>
+#include <QAction>
+#include <QApplication>
 #include <QClipboard>
+#include <QEvent>
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QMenu>
+#include <QMouseEvent>
+#include <QPointer>
+#include <QShortcut>
+#include <QTextCharFormat>
+#include <QTextCursor>
+#include <QTextDocument>
+#include <QTextEdit>
+
+#include <functional>
+#include <utility>
+
+
+namespace {
+
+const QColor ResultRowBackground(220, 220, 220);
+
+class SearchResultTextEdit : public QTextEdit
+{
+public:
+    using ActivationHandler = std::function<void()>;
+    using SelectionClearHandler = std::function<void()>;
+
+    explicit SearchResultTextEdit(QWidget *parent = nullptr) :
+        QTextEdit(parent)
+    {
+        setReadOnly(true);
+        setAcceptRichText(false);
+        setFrameShape(QFrame::NoFrame);
+        setLineWrapMode(QTextEdit::NoWrap);
+        setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
+        setViewportMargins(4, 1, 4, 1);
+        document()->setDocumentMargin(0);
+        setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+        setProperty("searchResultTextEdit", true);
+    }
+
+    void setActivationHandler(ActivationHandler handler)
+    {
+        activationHandler = std::move(handler);
+    }
+
+    void setSelectionClearHandler(SelectionClearHandler handler)
+    {
+        selectionClearHandler = std::move(handler);
+    }
+
+    QSize sizeHint() const override
+    {
+        const QFontMetrics fm(font());
+        const int width = static_cast<int>(document()->idealWidth()) + 10;
+        const int height = fm.height() + 4;
+        return {width, height};
+    }
+
+    QSize minimumSizeHint() const override
+    {
+        return {0, sizeHint().height()};
+    }
+
+protected:
+    void mousePressEvent(QMouseEvent *event) override
+    {
+        if (event->button() == Qt::LeftButton && selectionClearHandler) {
+            selectionClearHandler();
+        }
+
+        QTextEdit::mousePressEvent(event);
+    }
+
+    void keyPressEvent(QKeyEvent *event) override
+    {
+        if (event->matches(QKeySequence::Copy) && textCursor().hasSelection()) {
+            QString text = textCursor().selectedText();
+            text.replace(QChar::ParagraphSeparator, '\n');
+            text.replace(QChar::LineSeparator, '\n');
+            QGuiApplication::clipboard()->setText(text);
+            event->accept();
+            return;
+        }
+
+        QTextEdit::keyPressEvent(event);
+    }
+
+    void mouseDoubleClickEvent(QMouseEvent *event) override
+    {
+        QTextEdit::mouseDoubleClickEvent(event);
+
+        if (activationHandler) {
+            activationHandler();
+        }
+    }
+
+private:
+    ActivationHandler activationHandler;
+    SelectionClearHandler selectionClearHandler;
+};
+
+QString selectedPlainText(QTextEdit *textEdit)
+{
+    QString text = textEdit->textCursor().selectedText();
+    text.replace(QChar::ParagraphSeparator, '\n');
+    text.replace(QChar::LineSeparator, '\n');
+    return text;
+}
+
+bool copySelectedPlainText(QTextEdit *textEdit)
+{
+    if (textEdit == Q_NULLPTR || !textEdit->textCursor().hasSelection()) {
+        return false;
+    }
+
+    QGuiApplication::clipboard()->setText(selectedPlainText(textEdit));
+    return true;
+}
+
+bool isSearchResultTextEdit(QTextEdit *textEdit)
+{
+    return textEdit != Q_NULLPTR && textEdit->property("searchResultTextEdit").toBool();
+}
+
+void applyResultPalette(QTextEdit *textEdit)
+{
+    QPalette pal = textEdit->palette();
+    pal.setColor(QPalette::Base, ResultRowBackground);
+    pal.setColor(QPalette::Window, ResultRowBackground);
+    textEdit->setPalette(pal);
+    textEdit->viewport()->setPalette(pal);
+}
+
+void setHighlightedResultText(QTextEdit *textEdit, const QString &line, int startPositionFromBeginning, int endPositionFromBeginning)
+{
+    textEdit->setPlainText(line);
+
+    const int start = qBound(0, startPositionFromBeginning, line.size());
+    const int end = qBound(start, endPositionFromBeginning, line.size());
+    QTextCursor cursor(textEdit->document());
+    cursor.setPosition(start);
+    cursor.setPosition(end, QTextCursor::KeepAnchor);
+
+    QTextCharFormat highlightFormat;
+    highlightFormat.setBackground(Qt::yellow);
+    highlightFormat.setForeground(Qt::red);
+    highlightFormat.setFontWeight(QFont::Bold);
+    cursor.mergeCharFormat(highlightFormat);
+
+    cursor.clearSelection();
+    cursor.movePosition(QTextCursor::Start);
+    textEdit->setTextCursor(cursor);
+}
+
+}
 
 
 SearchResultsDock::SearchResultsDock(QWidget *parent) :
@@ -37,6 +192,7 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
     ui(new Ui::SearchResultsDock)
 {
     ui->setupUi(this);
+    ui->treeWidget->viewport()->installEventFilter(this);
 
     // Close the results when escape is pressed
     new QShortcut(QKeySequence::Cancel, this, this, &SearchResultsDock::close, Qt::WidgetWithChildrenShortcut);
@@ -45,7 +201,7 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
     connect(ui->treeWidget, &QTreeWidget::itemExpanded, this, &SearchResultsDock::itemExpanded);
     connect(ui->btnCopyResults, &QPushButton::released,this, &SearchResultsDock::copySearchResultsToClipboard);
 
-    connect(ui->treeWidget, &QTreeWidget::customContextMenuRequested, this, [=](const QPoint &pos) {
+    connect(ui->treeWidget, &QTreeWidget::customContextMenuRequested, this, [this](const QPoint &pos) {
         QTreeWidgetItem *item = ui->treeWidget->itemAt(pos);
 
         if (item == Q_NULLPTR) {
@@ -54,23 +210,38 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
 
         // Create the menu and show it
         QMenu menu(this);
+        if (item->childCount() == 0 && item->parent() != Q_NULLPTR && item->data(1, SearchResultData::LineNumber).isValid()) {
+            menu.addAction(tr("Copy Selected Line"), this, [item]() {
+                QGuiApplication::clipboard()->setText(item->text(1));
+            });
+            menu.addSeparator();
+        }
         menu.addAction(tr("Collapse All"), this, &SearchResultsDock::collapseAll);
         menu.addAction(tr("Expand All"), this, &SearchResultsDock::expandAll);
         menu.addSeparator();
-        menu.addAction(tr("Delete Entry"), this, [=]() { deleteEntry(item); });
+        menu.addAction(tr("Delete Entry"), this, [this, item]() { deleteEntry(item); });
         menu.addSeparator();
         menu.addAction(tr("Delete All"), this, &SearchResultsDock::deleteAll);
 
         menu.exec(QCursor::pos());
     });
 
+    ui->treeWidget->setUniformRowHeights(false);
     ui->treeWidget->setItemDelegate(new SearchResultHighlighterDelegate(ui->treeWidget));
 
     ApplicationSettings *settings = qobject_cast<NotepadNextApplication*>(qApp)->getSettings();
-    auto updateTreeWidgetFont = [=]() {
+    auto updateTreeWidgetFont = [this, settings]() {
         QFont f(settings->fontName(), settings->fontSize());
         ui->treeWidget->setFont(f);
+        for (QTextEdit *textEdit : ui->treeWidget->viewport()->findChildren<QTextEdit*>()) {
+            if (textEdit->property("searchResultTextEdit").toBool()) {
+                textEdit->setFont(f);
+                textEdit->document()->adjustSize();
+                textEdit->updateGeometry();
+            }
+        }
         ui->treeWidget->resizeColumnToContents(0);
+        ui->treeWidget->resizeColumnToContents(1);
     };
     connect(settings, &ApplicationSettings::fontNameChanged, this, updateTreeWidgetFont);
     connect(settings, &ApplicationSettings::fontSizeChanged, this, updateTreeWidgetFont);
@@ -80,6 +251,19 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
 SearchResultsDock::~SearchResultsDock()
 {
     delete ui;
+}
+
+bool SearchResultsDock::eventFilter(QObject *obj, QEvent *event)
+{
+    if (obj == ui->treeWidget->viewport() && event->type() == QEvent::MouseButtonPress) {
+        auto *mouseEvent = static_cast<QMouseEvent *>(event);
+
+        if (mouseEvent->button() == Qt::LeftButton) {
+            clearResultTextSelections();
+        }
+    }
+
+    return QDockWidget::eventFilter(obj, event);
 }
 
 void SearchResultsDock::newSearch(const QString searchTerm)
@@ -131,14 +315,47 @@ void SearchResultsDock::newResultsEntry(const QString line, int lineNumber, int 
 
     // Scintilla internally references line numbers starting at 0, however it needs displayed starting at 1
     item->setText(0, QString::number(lineNumber + 1));
-    item->setBackground(0, QBrush(QColor(220, 220, 220)));
+    item->setBackground(0, QBrush(ResultRowBackground));
     item->setTextAlignment(0, Qt::AlignRight);
 
     item->setData(1, SearchResultData::LineNumber, lineNumber);
     item->setData(1, SearchResultData::LinePosStart, startPositionFromBeginning);
     item->setData(1, SearchResultData::LinePosEnd, endPositionFromBeginning);
-    item->setData(1, Qt::UserRole + 3, true); // <- Flag to enable highlight
     item->setText(1, line);
+
+    auto *resultTextEdit = new SearchResultTextEdit(ui->treeWidget);
+    resultTextEdit->setFont(ui->treeWidget->font());
+    applyResultPalette(resultTextEdit);
+    setHighlightedResultText(resultTextEdit, line, startPositionFromBeginning, endPositionFromBeginning);
+    resultTextEdit->setActivationHandler([this, item]() {
+        itemActivated(item, 1);
+    });
+    resultTextEdit->setSelectionClearHandler([this]() {
+        clearResultTextSelections();
+    });
+    resultTextEdit->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(resultTextEdit, &QWidget::customContextMenuRequested, this, [this, item, resultTextEdit](const QPoint &pos) {
+        QMenu menu(this);
+
+        QAction *copyAction = menu.addAction(tr("Copy"), this, [resultTextEdit]() {
+            copySelectedPlainText(resultTextEdit);
+        });
+        copyAction->setEnabled(resultTextEdit->textCursor().hasSelection());
+        menu.addAction(tr("Copy Selected Line"), this, [item]() {
+            QGuiApplication::clipboard()->setText(item->text(1));
+        });
+
+        menu.addSeparator();
+        menu.addAction(tr("Collapse All"), this, &SearchResultsDock::collapseAll);
+        menu.addAction(tr("Expand All"), this, &SearchResultsDock::expandAll);
+        menu.addSeparator();
+        menu.addAction(tr("Delete Entry"), this, [this, item]() { deleteEntry(item); });
+        menu.addSeparator();
+        menu.addAction(tr("Delete All"), this, &SearchResultsDock::deleteAll);
+
+        menu.exec(resultTextEdit->mapToGlobal(pos));
+    });
+    ui->treeWidget->setItemWidget(item, 1, resultTextEdit);
 
     totalFileHitCount += hitCount;
     totalHitCount += hitCount;
@@ -156,6 +373,44 @@ void SearchResultsDock::completeSearch()
 
     ui->treeWidget->resizeColumnToContents(0);
     ui->treeWidget->resizeColumnToContents(1);
+}
+
+bool SearchResultsDock::copySelectedResultText()
+{
+    for (QWidget *widget = QApplication::focusWidget(); widget != Q_NULLPTR; widget = widget->parentWidget()) {
+        auto *textEdit = qobject_cast<QTextEdit *>(widget);
+
+        if (isSearchResultTextEdit(textEdit)) {
+            return copySelectedPlainText(textEdit);
+        }
+    }
+
+    if (QApplication::activePopupWidget() == Q_NULLPTR) {
+        return false;
+    }
+
+    for (QTextEdit *textEdit : ui->treeWidget->findChildren<QTextEdit*>()) {
+        if (isSearchResultTextEdit(textEdit) && copySelectedPlainText(textEdit)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void SearchResultsDock::clearResultTextSelections()
+{
+    for (QTextEdit *textEdit : ui->treeWidget->findChildren<QTextEdit*>()) {
+        if (!isSearchResultTextEdit(textEdit)) {
+            continue;
+        }
+
+        QTextCursor cursor = textEdit->textCursor();
+        if (cursor.hasSelection()) {
+            cursor.clearSelection();
+            textEdit->setTextCursor(cursor);
+        }
+    }
 }
 
 void SearchResultsDock::collapseAll() const
@@ -233,4 +488,3 @@ void SearchResultsDock::copySearchResultsToClipboard()
 
     QGuiApplication::clipboard()->setText(results.join('\n'));
 }
-

--- a/src/docks/SearchResultsDock.h
+++ b/src/docks/SearchResultsDock.h
@@ -43,6 +43,7 @@ public:
     void newFileEntry(ScintillaNext *editor) override;
     void newResultsEntry(const QString line, int lineNumber, int startPositionFromBeginning, int endPositionFromBeginning, int hitCount=1) override;
     void completeSearch() override;
+    bool copySelectedResultText();
 
 public slots:
     void collapseAll() const;
@@ -59,8 +60,12 @@ private slots:
 signals:
     void searchResultActivated(ScintillaNext *editor, int lineNumber, int startPositionFromBeginning, int endPositionFromBeginning);
 
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
 private:
     void updateSearchStatus();
+    void clearResultTextSelections();
     Ui::SearchResultsDock *ui;
 
     QString searchTerm;


### PR DESCRIPTION
## Description

Closes #825

This PR makes text inside Search Results rows selectable and copyable without changing the existing copy-all behavior. Individual result text can now be selected with the mouse and copied as plain text via `Ctrl+C`, `Edit > Copy`, or the right-click context menu. The toolbar copy button still copies all search results.

---

## Changes

**`src/docks/SearchResultsDock.cpp`**
- Added an embedded read-only `QTextEdit` for individual search result rows so result text can be selected directly.
- Added plain-text copy support for selected result text, without copying highlight formatting.
- Added result-row context menu support for `Copy` and `Copy Selected Line`.
- Added `Copy Selected Line` to the tree row context menu so right-clicking the line-number cell also supports copying the full result line.
- Preserved double-click activation so opening/navigating to a search result still works.
- Clears previous result-text selection when left-clicking in Search Results.
- Updates embedded result text widget fonts when the configured editor font changes.
- Kept the existing toolbar copy button behavior for copying all search results.

**`src/docks/SearchResultsDock.h`**
- Added `copySelectedResultText()` so the main window copy action can copy selected Search Results text when appropriate.
- Added event filtering and selection-clearing helpers for result text selection handling.

**`src/dialogs/MainWindow.cpp`**
- Updated `Edit > Copy` to first copy selected Search Results text when a result-text selection exists, then fall back to the current editor copy behavior.

---

## Manual Testing

- Ran a search and selected part of an individual result row.
- Verified `Ctrl+C` copies only the selected result text as plain text.
- Verified `Edit > Copy` copies selected result text even after opening the Edit menu.
- Verified the result text right-click menu `Copy` copies selected text.
- Verified `Copy Selected Line` copies the full result line from the result text context menu.
- Verified `Copy Selected Line` is also available when right-clicking the line-number cell.
- Verified the toolbar copy button still copies all search results.
- Verified double-clicking a result still navigates to the match.

Video of basic manual test below:

[Screencast from 2026-06-08 23-04-01.webm](https://github.com/user-attachments/assets/2df076eb-175b-4074-a3eb-4d511d432676)
