### PR TITLE
Allow multiple search results to be copied

### DIFF
--- a/src/docks/SearchResultsDock.cpp
+++ b/src/docks/SearchResultsDock.cpp
@@ -43,9 +43,9 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
 
     connect(ui->treeWidget, &QTreeWidget::itemActivated, this, &SearchResultsDock::itemActivated);
     connect(ui->treeWidget, &QTreeWidget::itemExpanded, this, &SearchResultsDock::itemExpanded);
-    connect(ui->btnCopyResults, &QPushButton::released,this, &SearchResultsDock::copySearchResultsToClipboard);
+    connect(ui->btnCopyResults, &QToolButton::released,this, &SearchResultsDock::copyAllSearchResultsToClipboard);
 
-    connect(ui->treeWidget, &QTreeWidget::customContextMenuRequested, this, [=](const QPoint &pos) {
+    connect(ui->treeWidget, &QTreeWidget::customContextMenuRequested, this, [this](const QPoint &pos) {
         QTreeWidgetItem *item = ui->treeWidget->itemAt(pos);
 
         if (item == Q_NULLPTR) {
@@ -54,10 +54,12 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
 
         // Create the menu and show it
         QMenu menu(this);
+        menu.addAction(tr("Copy"), this, &SearchResultsDock::copySelectedSearchResultsToClipboard);
+        menu.addSeparator();
         menu.addAction(tr("Collapse All"), this, &SearchResultsDock::collapseAll);
         menu.addAction(tr("Expand All"), this, &SearchResultsDock::expandAll);
         menu.addSeparator();
-        menu.addAction(tr("Delete Entry"), this, [=]() { deleteEntry(item); });
+        menu.addAction(tr("Delete Entry"), this, [=, this]() { deleteEntry(item); });
         menu.addSeparator();
         menu.addAction(tr("Delete All"), this, &SearchResultsDock::deleteAll);
 
@@ -67,7 +69,7 @@ SearchResultsDock::SearchResultsDock(QWidget *parent) :
     ui->treeWidget->setItemDelegate(new SearchResultHighlighterDelegate(ui->treeWidget));
 
     ApplicationSettings *settings = qobject_cast<NotepadNextApplication*>(qApp)->getSettings();
-    auto updateTreeWidgetFont = [=]() {
+    auto updateTreeWidgetFont = [=, this]() {
         QFont f(settings->fontName(), settings->fontSize());
         ui->treeWidget->setFont(f);
         ui->treeWidget->resizeColumnToContents(0);
@@ -220,17 +222,34 @@ void SearchResultsDock::updateSearchStatus()
         currentFile->setText(0, QStringLiteral("%1 (%L2 hits)").arg(currentFilePath).arg(totalFileHitCount));
 }
 
-void SearchResultsDock::copySearchResultsToClipboard()
+void SearchResultsDock::copyAllSearchResultsToClipboard()
 {
     QStringList results;
     QTreeWidgetItemIterator it(ui->treeWidget);
 
     while (*it) {
         const QTreeWidgetItem *item = *it;
-        results.append(QStringLiteral("%1 %2").arg(item->text(0)).arg(item->text(1)));
+        results.append(QStringLiteral("%1 %2").arg(item->text(0), item->text(1)));
         ++it;
     }
 
     QGuiApplication::clipboard()->setText(results.join('\n'));
 }
 
+void SearchResultsDock::copySelectedSearchResultsToClipboard()
+{
+    QStringList results;
+    QTreeWidgetItemIterator it(ui->treeWidget);
+
+    while (*it) {
+        const QTreeWidgetItem *item = *it;
+
+        if (item->isSelected()) {
+            results.append(QStringLiteral("%1 %2").arg(item->text(0), item->text(1)));
+        }
+
+        ++it;
+    }
+
+    QGuiApplication::clipboard()->setText(results.join('\n'));
+}

--- a/src/docks/SearchResultsDock.h
+++ b/src/docks/SearchResultsDock.h
@@ -53,7 +53,8 @@ public slots:
 private slots:
     void itemActivated(QTreeWidgetItem *item, int column);
     void itemExpanded(QTreeWidgetItem *item);
-    void copySearchResultsToClipboard() ;
+    void copyAllSearchResultsToClipboard();
+    void copySelectedSearchResultsToClipboard();
 
 
 signals:

--- a/src/docks/SearchResultsDock.ui
+++ b/src/docks/SearchResultsDock.ui
@@ -33,12 +33,12 @@
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QPushButton" name="btnCopyResults">
+       <widget class="QToolButton" name="btnCopyResults">
         <property name="toolTip">
-         <string>Copy Results to Clipboard</string>
+         <string>Copy All Results to Clipboard</string>
         </property>
         <property name="text">
-         <string/>
+         <string>Copy All Results to Clipboard</string>
         </property>
         <property name="icon">
          <iconset resource="../resources.qrc">
@@ -75,6 +75,9 @@
       </property>
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::ExtendedSelection</enum>
       </property>
       <property name="verticalScrollMode">
        <enum>QAbstractItemView::ScrollPerItem</enum>


### PR DESCRIPTION
CC: @saberoueslati

This obviously doesn't make it selectable. I would still be open to that if there's a light-weight and non-invasive way to do it. Notepad++ collects all its search results in another text editor that it highly controls so it gives a bit more 'text-like' capabilities.

The other thing was in #1072 was the MainWindow.cpp changes. This is a problem...but I think the issue is larger than a specific check. In theory any `QDockWidget` should be able to add their own shortcuts (e.g. Lua Console, Debug Log, etc) and not require the main window to know about what shortcuts it needs.