### PR TITLE
Add Shift+Scroll horizontal scrolling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,6 +183,8 @@ qt_add_executable(NotepadNext
 	ScintillaSorter.h ScintillaSorter.cpp
 	widgets/TabsQuickActionsBar.cpp
 	widgets/TabsQuickActionsBar.h
+	ShiftMiddleClickBlocker.h ShiftMiddleClickBlocker.cpp
+	ShiftWheelToHorizontalScrollFilter.h ShiftWheelToHorizontalScrollFilter.cpp
 )
 
 set_target_properties(NotepadNext PROPERTIES

--- a/src/ShiftMiddleClickBlocker.cpp
+++ b/src/ShiftMiddleClickBlocker.cpp
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ShiftMiddleClickBlocker.h"
+
+#include <QEvent>
+#include <QMouseEvent>
+
+ShiftMiddleClickBlocker::ShiftMiddleClickBlocker(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool ShiftMiddleClickBlocker::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() != QEvent::MouseButtonPress && event->type() != QEvent::MouseButtonDblClick) {
+        return QObject::eventFilter(obj, event);
+    }
+
+    auto *mouseEvent = static_cast<QMouseEvent *>(event);
+
+    if (mouseEvent->button() == Qt::MiddleButton && (mouseEvent->modifiers() & Qt::ShiftModifier)) {
+        return true;
+    }
+
+    return QObject::eventFilter(obj, event);
+}

--- a/src/ShiftMiddleClickBlocker.h
+++ b/src/ShiftMiddleClickBlocker.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+class ShiftMiddleClickBlocker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ShiftMiddleClickBlocker(QObject *parent = nullptr);
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+};

--- a/src/ShiftWheelToHorizontalScrollFilter.cpp
+++ b/src/ShiftWheelToHorizontalScrollFilter.cpp
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ShiftWheelToHorizontalScrollFilter.h"
+
+#include <QApplication>
+#include <QEvent>
+#include <QWheelEvent>
+
+
+bool isHorizontalWheelEvent(QWheelEvent *event)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    return event->angleDelta().y() == 0;
+#else
+    return event->orientation() == Qt::Horizontal;
+#endif
+}
+
+ShiftWheelToHorizontalScrollFilter::ShiftWheelToHorizontalScrollFilter(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool ShiftWheelToHorizontalScrollFilter::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() != QEvent::Wheel) {
+        return QObject::eventFilter(obj, event);
+    }
+
+    auto *wheelEvent = static_cast<QWheelEvent *>(event);
+
+    if (!(wheelEvent->modifiers() & Qt::ShiftModifier)
+        || (wheelEvent->modifiers() & Qt::ControlModifier)
+        || isHorizontalWheelEvent(wheelEvent)) {
+        return QObject::eventFilter(obj, event);
+    }
+
+    const QPoint angleDelta(wheelEvent->angleDelta().y(), wheelEvent->angleDelta().x());
+
+    const QPoint pixelDelta(wheelEvent->pixelDelta().y(), wheelEvent->pixelDelta().x());
+
+    QWheelEvent horizontalEvent(
+        wheelEvent->position(),
+        wheelEvent->globalPosition(),
+        pixelDelta,
+        angleDelta,
+        wheelEvent->buttons(),
+        wheelEvent->modifiers() & ~Qt::ShiftModifier,
+        wheelEvent->phase(),
+        wheelEvent->inverted(),
+        wheelEvent->source(),
+        wheelEvent->pointingDevice());
+
+    QApplication::sendEvent(obj, &horizontalEvent);
+    return true;
+}

--- a/src/ShiftWheelToHorizontalScrollFilter.h
+++ b/src/ShiftWheelToHorizontalScrollFilter.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+class ShiftWheelToHorizontalScrollFilter : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ShiftWheelToHorizontalScrollFilter(QObject *parent = nullptr);
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+};

--- a/src/ZoomEventWatcher.cpp
+++ b/src/ZoomEventWatcher.cpp
@@ -20,6 +20,7 @@
 #include "ZoomEventWatcher.h"
 
 #include <QEvent>
+#include <QMouseEvent>
 #include <QWheelEvent>
 #include <QApplication>
 
@@ -48,11 +49,24 @@ ZoomEventWatcher::ZoomEventWatcher(QObject *parent)
 
 bool ZoomEventWatcher::eventFilter(QObject *obj, QEvent *event)
 {
+    if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::MouseButtonDblClick) {
+        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+
+        // Scintilla pastes the primary selection on middle-click. Suppress an
+        // accidental wheel-button press while Shift is held for horizontal scrolling.
+        if (mouseEvent->button() == Qt::MiddleButton
+                && (mouseEvent->modifiers() & Qt::ShiftModifier)) {
+            return true;
+        }
+    }
+
     if (event->type() == QEvent::Wheel) {
         QWheelEvent *wheelEvent = static_cast<QWheelEvent *>(event);
+        const bool horizontal = isWheelEventHorizontal(wheelEvent);
+        const Qt::KeyboardModifiers modifiers = wheelEvent->modifiers();
 
-        if (!isWheelEventHorizontal(wheelEvent)) {
-            if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
+        if (!horizontal) {
+            if (modifiers & Qt::ControlModifier) {
                 if (wheelEventYDelta(wheelEvent) > 0) {
                     emit zoomIn();
                 } else {
@@ -60,6 +74,23 @@ bool ZoomEventWatcher::eventFilter(QObject *obj, QEvent *event)
                 }
                 return true;
             }
+        }
+
+        if ((modifiers & Qt::ShiftModifier) && !(modifiers & Qt::ControlModifier)) {
+            const QPoint angleDelta = horizontal
+                    ? wheelEvent->angleDelta()
+                    : QPoint(wheelEvent->angleDelta().y(), wheelEvent->angleDelta().x());
+            const QPoint pixelDelta = horizontal
+                    ? wheelEvent->pixelDelta()
+                    : QPoint(wheelEvent->pixelDelta().y(), wheelEvent->pixelDelta().x());
+
+            QWheelEvent horizontalEvent(wheelEvent->position(), wheelEvent->globalPosition(),
+                                        pixelDelta, angleDelta, wheelEvent->buttons(),
+                                        modifiers & ~Qt::ShiftModifier, wheelEvent->phase(),
+                                        wheelEvent->inverted(), wheelEvent->source(),
+                                        wheelEvent->pointingDevice());
+            QApplication::sendEvent(obj, &horizontalEvent);
+            return true;
         }
     }
 

--- a/src/ZoomEventWatcher.cpp
+++ b/src/ZoomEventWatcher.cpp
@@ -20,7 +20,6 @@
 #include "ZoomEventWatcher.h"
 
 #include <QEvent>
-#include <QMouseEvent>
 #include <QWheelEvent>
 #include <QApplication>
 
@@ -49,24 +48,11 @@ ZoomEventWatcher::ZoomEventWatcher(QObject *parent)
 
 bool ZoomEventWatcher::eventFilter(QObject *obj, QEvent *event)
 {
-    if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::MouseButtonDblClick) {
-        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-
-        // Scintilla pastes the primary selection on middle-click. Suppress an
-        // accidental wheel-button press while Shift is held for horizontal scrolling.
-        if (mouseEvent->button() == Qt::MiddleButton
-                && (mouseEvent->modifiers() & Qt::ShiftModifier)) {
-            return true;
-        }
-    }
-
     if (event->type() == QEvent::Wheel) {
         QWheelEvent *wheelEvent = static_cast<QWheelEvent *>(event);
-        const bool horizontal = isWheelEventHorizontal(wheelEvent);
-        const Qt::KeyboardModifiers modifiers = wheelEvent->modifiers();
 
-        if (!horizontal) {
-            if (modifiers & Qt::ControlModifier) {
+        if (!isWheelEventHorizontal(wheelEvent)) {
+            if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
                 if (wheelEventYDelta(wheelEvent) > 0) {
                     emit zoomIn();
                 } else {
@@ -74,23 +60,6 @@ bool ZoomEventWatcher::eventFilter(QObject *obj, QEvent *event)
                 }
                 return true;
             }
-        }
-
-        if ((modifiers & Qt::ShiftModifier) && !(modifiers & Qt::ControlModifier)) {
-            const QPoint angleDelta = horizontal
-                    ? wheelEvent->angleDelta()
-                    : QPoint(wheelEvent->angleDelta().y(), wheelEvent->angleDelta().x());
-            const QPoint pixelDelta = horizontal
-                    ? wheelEvent->pixelDelta()
-                    : QPoint(wheelEvent->pixelDelta().y(), wheelEvent->pixelDelta().x());
-
-            QWheelEvent horizontalEvent(wheelEvent->position(), wheelEvent->globalPosition(),
-                                        pixelDelta, angleDelta, wheelEvent->buttons(),
-                                        modifiers & ~Qt::ShiftModifier, wheelEvent->phase(),
-                                        wheelEvent->inverted(), wheelEvent->source(),
-                                        wheelEvent->pointingDevice());
-            QApplication::sendEvent(obj, &horizontalEvent);
-            return true;
         }
     }
 

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -81,6 +81,9 @@
 #include "MacroEditorDialog.h"
 
 #include "ZoomEventWatcher.h"
+#include "ShiftMiddleClickBlocker.h"
+#include "ShiftWheelToHorizontalScrollFilter.h"
+
 #include "FileDialogHelpers.h"
 
 #include "HtmlConverter.h"
@@ -94,7 +97,9 @@
 MainWindow::MainWindow(NotepadNextApplication *app) :
     ui(new Ui::MainWindow),
     app(app),
-    zoomEventWatcher(new ZoomEventWatcher(this))
+    zoomEventWatcher(new ZoomEventWatcher(this)),
+    shiftMiddleClickBlocker(new ShiftMiddleClickBlocker(this)),
+    shiftWheelToHorizontalScrollFilter(new ShiftWheelToHorizontalScrollFilter(this))
 {
     qInfo(Q_FUNC_INFO);
 
@@ -2094,8 +2099,15 @@ void MainWindow::addEditor(ScintillaNext *editor)
     connect(editor, &ScintillaNext::renamed, this, [=, this]() { updateFileStatusBasedUi(editor); });
     connect(editor, &ScintillaNext::updateUi, this, &MainWindow::updateDocumentBasedUi);
 
-    // Watch for wheel events that need handling before the ScintillaEditBase widget: Ctrl+Scroll and pinch-to-zoom
-    // keep the zoom level equal across all editors, while Shift+Scroll is translated to horizontal scrolling.
+    // Scintilla pastes the primary selection on middle-click. Suppress an
+    // accidental wheel-button press while Shift is held for horizontal scrolling.
+    editor->viewport()->installEventFilter(shiftMiddleClickBlocker);
+
+    // Translate shift+vertical wheel to vertical
+    editor->viewport()->installEventFilter(shiftWheelToHorizontalScrollFilter);
+
+    // Watch for any zoom events (Ctrl+Scroll or pinch-to-zoom (Qt translates it as Ctrl+Scroll)) so that the event
+    // can be handled before the ScintillaEditBase widget, so that it can be applied to all editors to keep zoom level equal.
     // NOTE: Need to install this on the scroll area's viewport, not on the editor widget itself...that was painful to learn
     editor->viewport()->installEventFilter(zoomEventWatcher);
 

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -2094,8 +2094,8 @@ void MainWindow::addEditor(ScintillaNext *editor)
     connect(editor, &ScintillaNext::renamed, this, [=, this]() { updateFileStatusBasedUi(editor); });
     connect(editor, &ScintillaNext::updateUi, this, &MainWindow::updateDocumentBasedUi);
 
-    // Watch for any zoom events (Ctrl+Scroll or pinch-to-zoom (Qt translates it as Ctrl+Scroll)) so that the event
-    // can be handled before the ScintillaEditBase widget, so that it can be applied to all editors to keep zoom level equal.
+    // Watch for wheel events that need handling before the ScintillaEditBase widget: Ctrl+Scroll and pinch-to-zoom
+    // keep the zoom level equal across all editors, while Shift+Scroll is translated to horizontal scrolling.
     // NOTE: Need to install this on the scroll area's viewport, not on the editor widget itself...that was painful to learn
     editor->viewport()->installEventFilter(zoomEventWatcher);
 

--- a/src/dialogs/MainWindow.h
+++ b/src/dialogs/MainWindow.h
@@ -40,6 +40,8 @@ class Macro;
 class Settings;
 class QuickFindWidget;
 class ZoomEventWatcher;
+class ShiftMiddleClickBlocker;
+class ShiftWheelToHorizontalScrollFilter;
 class Converter;
 class DefaultDirectoryManager;
 class TabsQuickActionsBar;
@@ -196,6 +198,8 @@ private:
     DefaultDirectoryManager *defaultDirectoryManager;
 
     ZoomEventWatcher *zoomEventWatcher;
+    ShiftMiddleClickBlocker *shiftMiddleClickBlocker;
+    ShiftWheelToHorizontalScrollFilter *shiftWheelToHorizontalScrollFilter;
     int zoomLevel = 0;
     int contextMenuPos = 0;
     QMenu *buildMenu(QStringList actionNames);


### PR DESCRIPTION
## Description

Fixes #742

Qt does not consistently translate Shift+Scroll into horizontal scrolling. This PR extends the existing editor wheel-event watcher to provide that behavior while preserving Ctrl+Scroll zoom and existing horizontal wheel input.

It also prevents accidental primary-selection pastes caused by the physical scroll wheel occasionally registering as a middle-button press while Shift is held.

---

## Changes

**`src/ZoomEventWatcher.cpp`**

- Extended the existing viewport event filter to handle Shift+Scroll.
- Transposes vertical angle and pixel deltas into horizontal deltas.
- Preserves events that already arrive horizontally instead of transposing them again.
- Removes the Shift modifier before forwarding the event, preventing Qt from treating it as a page-sized scrollbar movement.
- Preserves the original scroll phase, inversion state, event source, and pointing device.
- Keeps Ctrl+Scroll and Ctrl+Shift+Scroll mapped to zoom.
- Suppresses Shift+middle-button presses before they reach Scintilla, preventing accidental Linux/X11 primary-selection pastes while beginning horizontal scrolling.
- Leaves regular middle-click paste without Shift unchanged.

**`src/dialogs/MainWindow.cpp`**

- Updated the existing viewport event-filter comment to document both zoom handling and Shift+Scroll translation.
- The existing watcher remains installed on every editor viewport, including editors in split views.

No new setting or preference is required, and no vendored Scintilla files are modified.

Manual test after changes below :

[Screencast from 2026-07-13 00-12-51.webm](https://github.com/user-attachments/assets/573b14b1-1847-41f1-ad5e-198905ea8d86)
