### PR TITLE
Add Shift+Enter shortcut for backward search

### DIFF
--- a/src/dialogs/FindReplaceDialog.cpp
+++ b/src/dialogs/FindReplaceDialog.cpp
@@ -153,8 +153,11 @@ FindReplaceDialog::FindReplaceDialog(ISearchResultsHandler *searchResults, MainW
     connect(ui->buttonCopyMarkedText, &QPushButton::clicked, this, &FindReplaceDialog::copyMarkedText);
 
     const auto findPrevious = [this]() {
-        if (ui->buttonFind->isVisible()) {
-            performFind(!ui->radioRegexSearch->isChecked());
+        const int curTab = tabBar->currentIndex();
+        if (curTab == FIND_TAB || curTab == REPLACE_TAB) {
+            // Always default to forward if regex search is checked
+            const bool regex = ui->radioRegexSearch->isChecked();
+            performFind(regex ? SearchDirection::Forwards : SearchDirection::Backwards);
         }
     };
     new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_Return), this, this, findPrevious, Qt::WidgetWithChildrenShortcut);
@@ -237,16 +240,16 @@ void FindReplaceDialog::updateReplaceList(const QString &text)
 
 void FindReplaceDialog::find()
 {
-    performFind(ui->checkBoxBackwardsDirection->isChecked());
+    performFind(ui->checkBoxBackwardsDirection->isChecked() ? SearchDirection::Backwards : SearchDirection::Forwards);
 }
 
-void FindReplaceDialog::performFind(bool backwards)
+void FindReplaceDialog::performFind(SearchDirection direction)
 {
     qInfo(Q_FUNC_INFO);
 
     prepareToPerformSearch();
 
-    Sci_CharacterRange range = backwards ? finder->findPrev() : finder->findNext();
+    Sci_CharacterRange range = direction == SearchDirection::Forwards ? finder->findNext() : finder->findPrev();
 
     if (ScintillaNext::isRangeValid(range)) {
         if (finder->didLatestSearchWrapAround()) {

--- a/src/dialogs/FindReplaceDialog.cpp
+++ b/src/dialogs/FindReplaceDialog.cpp
@@ -23,7 +23,7 @@
 
 #include <QStatusBar>
 #include <QLineEdit>
-#include <QKeyEvent>
+#include <QShortcut>
 #include <QClipboard>
 #include <QGuiApplication>
 
@@ -152,6 +152,14 @@ FindReplaceDialog::FindReplaceDialog(ISearchResultsHandler *searchResults, MainW
     connect(ui->buttonClearAllMarks, &QPushButton::clicked, this, &FindReplaceDialog::clearAllMarks);
     connect(ui->buttonCopyMarkedText, &QPushButton::clicked, this, &FindReplaceDialog::copyMarkedText);
 
+    const auto findPrevious = [this]() {
+        if (ui->buttonFind->isVisible()) {
+            performFind(!ui->radioRegexSearch->isChecked());
+        }
+    };
+    new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_Return), this, this, findPrevious, Qt::WidgetWithChildrenShortcut);
+    new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_Enter), this, this, findPrevious, Qt::WidgetWithChildrenShortcut);
+
     loadSettings();
 
     changeTab(tabBar->currentIndex());
@@ -229,17 +237,16 @@ void FindReplaceDialog::updateReplaceList(const QString &text)
 
 void FindReplaceDialog::find()
 {
+    performFind(ui->checkBoxBackwardsDirection->isChecked());
+}
+
+void FindReplaceDialog::performFind(bool backwards)
+{
     qInfo(Q_FUNC_INFO);
 
     prepareToPerformSearch();
 
-    Sci_CharacterRange range;
-    if(!ui->checkBoxBackwardsDirection->isChecked()) {
-        range = finder->findNext();
-    }
-    else{
-         range = finder->findPrev();
-    }
+    Sci_CharacterRange range = backwards ? finder->findPrev() : finder->findNext();
 
     if (ScintillaNext::isRangeValid(range)) {
         if (finder->didLatestSearchWrapAround()) {

--- a/src/dialogs/FindReplaceDialog.h
+++ b/src/dialogs/FindReplaceDialog.h
@@ -48,6 +48,12 @@ public:
         MARK_TAB = 2
     };
 
+    enum class SearchDirection
+    {
+        Forwards,
+        Backwards
+    };
+
     explicit FindReplaceDialog(ISearchResultsHandler *searchResults, MainWindow *window = nullptr);
     ~FindReplaceDialog() override;
 
@@ -92,7 +98,7 @@ private slots:
 
 private:
     QString findString();
-    void performFind(bool backwards);
+    void performFind(SearchDirection direction);
     void prepareToPerformSearch(bool replace=false);
     void loadSettings();
     void saveSettings();

--- a/src/dialogs/FindReplaceDialog.h
+++ b/src/dialogs/FindReplaceDialog.h
@@ -92,6 +92,7 @@ private slots:
 
 private:
     QString findString();
+    void performFind(bool backwards);
     void prepareToPerformSearch(bool replace=false);
     void loadSettings();
     void saveSettings();


### PR DESCRIPTION
## Description

Fixes #1082

The Find/Replace dialog currently requires manually enabling **Backward direction** to search for the previous match. This PR adds browser-style keyboard navigation: **Enter** keeps its existing behavior, while **Shift+Enter** searches backward.

Shift+Enter searches backward regardless of the **Backward direction** checkbox state. In regular expression mode, where backward searching is unsupported, it falls back to a forward search.

---

## Changes

**`src/dialogs/FindReplaceDialog.cpp`**
- Added dialog-wide shortcuts for both Shift+Return and Shift+Enter.
- Used `Qt::WidgetWithChildrenShortcut` so the shortcut works even when a button or another dialog control has focus.
- Limited the shortcut to the Find and Replace tabs by checking whether the Find button is visible, keeping the Mark tab behavior unchanged.
- Extracted the existing search logic into `performFind(bool backwards)`.
- Preserved the existing Find button behavior, including support for the **Backward direction** checkbox.

**`src/dialogs/FindReplaceDialog.h`**
- Added the private `performFind(bool backwards)` helper declaration.

Manual test after the fix below :

[Screencast from 2026-07-13 00-52-07.webm](https://github.com/user-attachments/assets/51fbd931-566f-4bc8-a539-b8caf547ff1e)
