### PR TITLE
Add XML Tools > Pretty Print XML to the Edit menu

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ qt_add_executable(NotepadNext
 	SpinBoxDelegate.h
 	TranslationManager.h
 	UndoAction.h
+	XmlFormatter.h
 	ZoomEventWatcher.h
 	resources.qrc
 	scripts.qrc
@@ -94,6 +95,7 @@ qt_add_executable(NotepadNext
 	SpinBoxDelegate.cpp
 	TranslationManager.cpp
 	UndoAction.cpp
+	XmlFormatter.cpp
 	ZoomEventWatcher.cpp
 	decorators/ApplicationDecorator.cpp
 	decorators/ApplicationDecorator.h

--- a/src/XmlFormatter.cpp
+++ b/src/XmlFormatter.cpp
@@ -1,0 +1,105 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "XmlFormatter.h"
+
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
+
+bool XmlFormatter::format(const QByteArray &input, QByteArray &output, QString &errorString, int indent)
+{
+    QXmlStreamReader reader(input);
+
+    QByteArray prolog;
+    QByteArray body;
+    QXmlStreamWriter writer(&body);
+    writer.setAutoFormatting(true);
+    writer.setAutoFormattingIndent(indent);
+
+    while (!reader.atEnd()) {
+        reader.readNext();
+
+        switch (reader.tokenType()) {
+        case QXmlStreamReader::StartDocument: {
+            const QString version = reader.documentVersion().isEmpty() ? QStringLiteral("1.0") : reader.documentVersion().toString();
+
+            prolog += QStringLiteral("<?xml version=\"%1\"").arg(version).toUtf8();
+            if (!reader.documentEncoding().isEmpty()) {
+                prolog += " encoding=\"UTF-8\"";
+            }
+            if (reader.isStandaloneDocument()) {
+                prolog += " standalone=\"yes\"";
+            }
+            prolog += "?>\n";
+            break;
+        }
+        case QXmlStreamReader::EndDocument:
+            break;
+        case QXmlStreamReader::StartElement:
+            writer.writeStartElement(reader.qualifiedName().toString());
+            for (const QXmlStreamNamespaceDeclaration &ns : reader.namespaceDeclarations()) {
+                const QString qualifiedName = ns.prefix().isEmpty() ? QStringLiteral("xmlns") : QStringLiteral("xmlns:%1").arg(ns.prefix());
+                writer.writeAttribute(qualifiedName, ns.namespaceUri().toString());
+            }
+            for (const QXmlStreamAttribute &attr : reader.attributes()) {
+                writer.writeAttribute(attr.qualifiedName().toString(), attr.value().toString());
+            }
+            break;
+        case QXmlStreamReader::EndElement:
+            writer.writeEndElement();
+            break;
+        case QXmlStreamReader::Characters:
+            if (reader.isCDATA()) {
+                writer.writeCDATA(reader.text().toString());
+            }
+            else if (!reader.isWhitespace()) {
+                writer.writeCharacters(reader.text().toString());
+            }
+            break;
+        case QXmlStreamReader::Comment:
+            writer.writeComment(reader.text().toString());
+            break;
+        case QXmlStreamReader::ProcessingInstruction:
+            writer.writeProcessingInstruction(reader.processingInstructionTarget().toString(), reader.processingInstructionData().toString());
+            break;
+        case QXmlStreamReader::DTD:
+            writer.writeDTD(reader.text().toString());
+            break;
+        case QXmlStreamReader::EntityReference:
+            writer.writeEntityReference(reader.name().toString());
+            break;
+        default:
+            break;
+        }
+    }
+
+    if (reader.hasError()) {
+        errorString = QStringLiteral("%1 (line %2, column %3)")
+            .arg(reader.errorString())
+            .arg(reader.lineNumber())
+            .arg(reader.columnNumber());
+        return false;
+    }
+
+    if (body.startsWith('\n')) {
+        body.remove(0, 1);
+    }
+
+    output = prolog + body;
+    return true;
+}

--- a/src/XmlFormatter.h
+++ b/src/XmlFormatter.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2026 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+
+class XmlFormatter
+{
+public:
+    static bool format(const QByteArray &input, QByteArray &output, QString &errorString, int indent = 2);
+};

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -23,6 +23,7 @@
 #include "MarkerAppDecorator.h"
 #include "ScintillaSorter.h"
 #include "URLFinder.h"
+#include "XmlFormatter.h"
 #include "SessionManager.h"
 #include "UndoAction.h"
 #include "ui_MainWindow.h"
@@ -201,6 +202,25 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
         ScintillaNext *editor = currentEditor();
         const QByteArray selection = editor->getSelText();
         editor->replaceSel(QByteArray::fromPercentEncoding(selection).constData());
+    });
+    connect(ui->actionXmlPrettyPrint, &QAction::triggered, this, [this]() {
+        ScintillaNext *editor = currentEditor();
+
+        sptr_t pointer = editor->characterPointer();
+        int len = editor->length();
+        const QByteArray input = QByteArray::fromRawData(reinterpret_cast<const char *>(pointer), len);
+
+        QByteArray output;
+        QString errorString;
+
+        if (!XmlFormatter::format(input, output, errorString)) {
+            QMessageBox::warning(this, tr("Pretty Print XML"), errorString);
+            return;
+        }
+
+        const UndoAction ua(editor);
+        editor->targetWholeDocument();
+        editor->replaceTarget(-1, output.constData());
     });
     connect(ui->actionCopyURL, &QAction::triggered, this, [this]() {
         ScintillaNext *editor = currentEditor();

--- a/src/dialogs/MainWindow.ui
+++ b/src/dialogs/MainWindow.ui
@@ -174,6 +174,12 @@
      <addaction name="actionBase64Decode"/>
      <addaction name="actionURLDecode"/>
     </widget>
+    <widget class="QMenu" name="menuXmlTools">
+     <property name="title">
+      <string>XML Tools</string>
+     </property>
+     <addaction name="actionXmlPrettyPrint"/>
+    </widget>
     <addaction name="actionUndo"/>
     <addaction name="actionRedo"/>
     <addaction name="separator"/>
@@ -192,6 +198,7 @@
     <addaction name="menuLine_Operations"/>
     <addaction name="menuCommentUncomment"/>
     <addaction name="menuEncodingDecoding"/>
+    <addaction name="menuXmlTools"/>
     <addaction name="separator"/>
     <addaction name="actionColumnMode"/>
    </widget>
@@ -1151,6 +1158,11 @@
   <action name="actionURLDecode">
    <property name="text">
     <string>URL Decode</string>
+   </property>
+  </action>
+  <action name="actionXmlPrettyPrint">
+   <property name="text">
+    <string>Pretty Print XML</string>
    </property>
   </action>
   <action name="actionCopyURL">


### PR DESCRIPTION
Adds an "XML Tools" submenu under Edit with a single "Pretty Print XML" action, reformatting the whole document equivalently to xmllint --format.

Implementation notes

Uses QXmlStreamReader/QXmlStreamWriter from Qt6::Core rather than QDomDocument, to avoid adding a Qt6::Xml dependency.
Follows the ScintillaSorter pattern for reading/writing the buffer, wrapped in UndoAction so the transform is a single undo step.
Malformed input shows a warning with line/column and leaves the buffer untouched.

Scope choices

Placed under Edit rather than View since it mutates the buffer, consistent with Convert Case and Line Operations.
Operates on the whole document rather than the selection, matching xmllint --format. Selection support would be a reasonable follow-up.

Known divergence from xmllint: QXmlStreamWriter normalises attribute quoting and always emits a UTF-8 declaration.

The macOS job passes on Qt 6.10 and fails only on 6.5 and 6.8, which suggests the AGL reference comes from Qt's own CMake config and was dropped upstream between 6.8 and 6.10. That would make this a Qt-version issue in CI rather than anything in this diff.