### PR TITLE
Fix Find/Replace dialog size and auto-shrink to fit screen

### DIFF
--- a/src/dialogs/FindReplaceDialog.cpp
+++ b/src/dialogs/FindReplaceDialog.cpp
@@ -26,6 +26,7 @@
 #include <QShortcut>
 #include <QClipboard>
 #include <QGuiApplication>
+#include <QScreen>
 
 #include "ScintillaNext.h"
 #include "MainWindow.h"
@@ -574,6 +575,18 @@ void FindReplaceDialog::loadSettings()
     settings.beginGroup("FindReplaceDialog");
 
     restoreGeometry(settings.value("geometry").toByteArray());
+
+    // Defensively clamp the restored size in case a previously persisted geometry
+    // is larger than the available screen (e.g. from an older version that let the
+    // dialog grow to fit a very long recent search string). This lets users recover
+    // automatically without having to edit or delete notepadnext.ini.
+    if (const QScreen *screen = QGuiApplication::primaryScreen()) {
+        const QSize available = screen->availableGeometry().size();
+        const QSize current = size();
+        const QSize clamped = current.boundedTo(available);
+        if (clamped != current)
+            resize(clamped);
+    }
 
     ui->comboFind->addItems(settings.value("RecentSearchList").toStringList());
     ui->comboReplace->addItems(settings.value("RecentReplaceList").toStringList());

--- a/src/dialogs/FindReplaceDialog.ui
+++ b/src/dialogs/FindReplaceDialog.ui
@@ -418,6 +418,9 @@
            <property name="insertPolicy">
             <enum>QComboBox::NoInsert</enum>
            </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+           </property>
           </widget>
          </item>
          <item row="1" column="0">
@@ -446,6 +449,9 @@
            </property>
            <property name="insertPolicy">
             <enum>QComboBox::NoInsert</enum>
+           </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
## Summary

Fixes the Find/Replace dialog growing to an excessive width. Entering a long string in the Find or Replace combo box expanded the editable combos to fit their content, forcing the whole dialog wider — and that oversized size was persisted, so it reopened huge every time.

## Root cause

`comboFind` and `comboReplace` are `editable` with a `MinimumExpanding` policy and no `sizeAdjustPolicy`, so their size hint grew to fit the longest content. That width got saved via `saveGeometry()` and restored on the next open.

## Changes

- **`FindReplaceDialog.ui`** — set `sizeAdjustPolicy = AdjustToMinimumContentsLengthWithIcon` on both combos so their size hint no longer depends on content length. Prevents the problem going forward.
- **`FindReplaceDialog.cpp`** — in `loadSettings()`, clamp the restored geometry to the available screen size, so users who already have an oversized dialog saved in `notepadnext.ini` recover automatically.

## Testing

- Long strings in Find/Replace no longer widen the dialog.
- A pre-existing oversized geometry now opens clamped to the screen.
- Recent-item history and geometry persistence still work.