### PR TITLE
Fix Unfold All action wired to Fold All instead of actionUnfoldAll

### DIFF
--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -733,7 +733,7 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     connect(zoomEventWatcher, &ZoomEventWatcher::zoomOut, ui->actionZoomOut, &QAction::trigger);
 
     connectEditorAction(ui->actionFoldAll, &ScintillaNext::foldAll, SC_FOLDACTION_CONTRACT | SC_FOLDACTION_CONTRACT_EVERY_LEVEL);
-    connectEditorAction(ui->actionFoldAll, &ScintillaNext::foldAll, SC_FOLDACTION_EXPAND | SC_FOLDACTION_CONTRACT_EVERY_LEVEL);
+    connectEditorAction(ui->actionUnfoldAll, &ScintillaNext::foldAll, SC_FOLDACTION_EXPAND | SC_FOLDACTION_CONTRACT_EVERY_LEVEL);
 
     connectEditorAction(ui->actionFoldLevel1, &ScintillaNext::foldAllLevels, 0);
     connectEditorAction(ui->actionFoldLevel2, &ScintillaNext::foldAllLevels, 1);


### PR DESCRIPTION
There's a problem with folding: Alt+Shift+0 does nothing, and Fold All unfolds everything instead of folding when content is already folded. There is an error on line 741, actionFoldAll should be actionUnfoldAll