### PR TITLE
Add QuickFindNext action (Ctrl+F3)

### DIFF
--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -421,6 +421,11 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
         }
     });
 
+    connect(ui->actionQuickFindNext, &QAction::triggered, this, [=,this]() {
+		showFindReplaceDialog(FindReplaceDialog::FIND_TAB, false);
+		FindReplaceDialog *f = findChild<FindReplaceDialog *>(QString(), Qt::FindDirectChildrenOnly);
+	});
+
     connect(ui->actionQuickFind, &QAction::triggered, this, [this]() {
         QuickFindWidget *quickFind = findChild<QuickFindWidget *>(QString(), Qt::FindDirectChildrenOnly);
 
@@ -1616,7 +1621,7 @@ void MainWindow::convertEOLs(int eolMode)
     ui->statusBar->refresh(editor);
 }
 
-void MainWindow::showFindReplaceDialog(int index)
+void MainWindow::showFindReplaceDialog(int index, bool show)
 {
     ScintillaNext *editor = currentEditor();
     FindReplaceDialog *frd = findChild<FindReplaceDialog *>(QString(), Qt::FindDirectChildrenOnly);
@@ -1656,6 +1661,10 @@ void MainWindow::showFindReplaceDialog(int index)
     frd->show();
     frd->raise();
     frd->activateWindow();
+	if (! show) {
+		frd->find();
+		frd->reject(); 
+	}
 }
 
 void MainWindow::updateFileStatusBasedUi(ScintillaNext *editor)

--- a/src/dialogs/MainWindow.h
+++ b/src/dialogs/MainWindow.h
@@ -104,7 +104,7 @@ public slots:
 
     void convertEOLs(int eolMode);
 
-    void showFindReplaceDialog(int index);
+    void showFindReplaceDialog(int index, bool show=true);
 
     void updateFileStatusBasedUi(ScintillaNext *editor);
     void updateEOLBasedUi(ScintillaNext *editor);

--- a/src/dialogs/MainWindow.ui
+++ b/src/dialogs/MainWindow.ui
@@ -239,6 +239,7 @@
     <addaction name="actionFindPrevious"/>
     <addaction name="actionReplace"/>
     <addaction name="separator"/>
+    <addaction name="actionQuickFindNext"/>
     <addaction name="actionQuickFind"/>
     <addaction name="actionGoToLine"/>
     <addaction name="separator"/>
@@ -900,6 +901,14 @@
   <action name="actionFindInFiles">
    <property name="text">
     <string>Find in Files...</string>
+   </property>
+  </action>
+  <action name="actionQuickFindNext">
+   <property name="text">
+    <string>Quick Find &amp;Next</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+F3</string>
    </property>
   </action>
   <action name="actionFindNext">


### PR DESCRIPTION
### Description:
This adds the QuickFindNext action, present in Notepad++ but missing in NotepadNext.

### Behavior: 
pressing Ctrl+F3 searches for the next occurrence of the word under the cursor (or the current selection, if any), without opening the Find dialog — matching Notepad++'s existing behavior.

This PR builds on top of the recently merged Fix Unfold All action (#1103).

### Changes:
Added actionQuickFindNext and wired it to the corresponding search logic
MainWindow.cpp — Modify the showFindReplaceDialog function to prevent the dialog box from opening.
MainWindow..h — change prototype of MainWindow::showFindReplaceDialog
Updated MainWindow.ui to register the new action and its shortcut (Ctrl+F3)

