### PR TITLE
Added fix for sort lines by selected text

### DIFF
--- a/src/ScintillaSorter.cpp
+++ b/src/ScintillaSorter.cpp
@@ -27,18 +27,33 @@ ScintillaSorter::ScintillaSorter(ScintillaNext *editor)
 void ScintillaSorter::sort(const Sorter &sorter)
 {
     const QByteArray eol = editor->eolString();
-    const QByteArray text = readEditorText();
-    QVector<QByteArrayView> lines = ByteArrayUtils::split(text, eol);
+    QByteArray text = readEditorText();
+    const QByteArray selectedText = editor->getSelText();
+    QVector<QByteArrayView> lines;
+    qsizetype textStartIndex = 0;
+
+    if (!selectedText.isEmpty())
+    {
+        textStartIndex = text.indexOf(selectedText);
+        lines = ByteArrayUtils::split(selectedText, eol);
+    }
+    else
+    {
+        lines = ByteArrayUtils::split(text, eol);
+    }
 
     sorter.sort(lines);
 
     QByteArray result = ByteArrayUtils::join(lines, eol);
-    writeEditorText(result);
+
+    text.replace(textStartIndex, result.size(), result.data());
+    writeEditorText(text);
 }
 
 const QByteArray ScintillaSorter::readEditorText()
 {
     sptr_t pointer = editor->characterPointer();
+
     int len = editor->length();
 
     return QByteArray::fromRawData(reinterpret_cast<const char *>(pointer), len);


### PR DESCRIPTION
When doing line operations -> sort lines ascending/descending now only the selected text is sorted

Example of three rows I want to Edit > Line Operations > Sort Lines Ascending:

### Action
5
2 (selected)
4 (selected)
1 (selected)
3

### Result:

5
1
2
4
3