### PR TITLE
Fix invisible RTL text on Qt backend (MeasureWidths uses visual instead of logical positions)

### DIFF
--- a/thirdparty/scintilla/qt/ScintillaEditBase/PlatQt.cpp
+++ b/thirdparty/scintilla/qt/ScintillaEditBase/PlatQt.cpp
@@ -667,16 +667,29 @@ void SurfaceImpl::MeasureWidths(const Font *font,
 	QTextLine tl = tlay.createLine();
 	tlay.endLayout();
 	if (mode.codePage == SC_CP_UTF8) {
+		// Measure each character's advance width independently and accumulate in
+		// logical (document) order, rather than using QTextLine::cursorToX(), which
+		// returns *visual* bidi-reordered positions. Scintilla's EditView code relies
+		// on positions[] being monotonically non-decreasing in logical order to place
+		// styled runs, the caret, and selection highlights; for RTL text (e.g. Hebrew),
+		// cursorToX() violates that invariant and pushes glyphs outside the visible
+		// clip rectangle, making them appear invisible.
+		QFontMetricsF metrics(*FontPointer(font), GetPaintDevice());
 		int fit = su.size();
 		int ui=0;
 		size_t i=0;
+		XYPOSITION cumulativeWidth = 0;
 		while (ui<fit) {
 			const unsigned char uch = text[i];
 			const unsigned int byteCount = UTF8BytesOfLead[uch];
 			const int codeUnits = UTF16LengthFromUTF8ByteCount(byteCount);
-			qreal xPosition = tl.cursorToX(ui+codeUnits);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+			cumulativeWidth += metrics.horizontalAdvance(su.mid(ui, codeUnits));
+#else
+			cumulativeWidth += metrics.width(su.mid(ui, codeUnits));
+#endif
 			for (size_t bytePos=0; (bytePos<byteCount) && (i<text.length()); bytePos++) {
-				positions[i++] = xPosition;
+				positions[i++] = cumulativeWidth;
 			}
 			ui += codeUnits;
 		}
@@ -765,21 +778,26 @@ void SurfaceImpl::MeasureWidthsUTF8(const Font *font,
 {
 	if (!font)
 		return;
+	// See the comment in MeasureWidths(): measure per-character in logical order
+	// rather than using QTextLine::cursorToX(), which returns visual bidi-reordered
+	// positions and breaks position monotonicity for RTL text.
 	QString su = QString::fromUtf8(text.data(), static_cast<int>(text.length()));
-	QTextLayout tlay(su, *FontPointer(font), GetPaintDevice());
-	tlay.beginLayout();
-	QTextLine tl = tlay.createLine();
-	tlay.endLayout();
+	QFontMetricsF metrics(*FontPointer(font), GetPaintDevice());
 	int fit = su.size();
 	int ui=0;
 	size_t i=0;
+	XYPOSITION cumulativeWidth = 0;
 	while (ui<fit) {
 		const unsigned char uch = text[i];
 		const unsigned int byteCount = UTF8BytesOfLead[uch];
 		const int codeUnits = UTF16LengthFromUTF8ByteCount(byteCount);
-		qreal xPosition = tl.cursorToX(ui+codeUnits);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		cumulativeWidth += metrics.horizontalAdvance(su.mid(ui, codeUnits));
+#else
+		cumulativeWidth += metrics.width(su.mid(ui, codeUnits));
+#endif
 		for (size_t bytePos=0; (bytePos<byteCount) && (i<text.length()); bytePos++) {
-			positions[i++] = xPosition;
+			positions[i++] = cumulativeWidth;
 		}
 		ui += codeUnits;
 	}


### PR DESCRIPTION
## Summary

RTL-only lines (e.g. typing Hebrew alone on a line) render invisibly. Mixed LTR+RTL lines (e.g. `Hi היי`) render correctly, which pointed at a positioning bug rather than a font/shaping issue.

Root cause: `Surface::MeasureWidths()` is expected to return per-character pixel positions that are monotonically non-decreasing in *logical* (document) order — Scintilla's `EditView.cxx` uses this to place styled runs, the caret, and selection highlights along a line. The Win32 (`SurfaceD2D::MeasurePositions`) and Cocoa backends already provide this by summing cluster advance widths in text order, independent of visual/bidi reordering.

The Qt backend's `SurfaceImpl::MeasureWidths`/`MeasureWidthsUTF8` (`PlatQt.cpp`) instead used `QTextLine::cursorToX()`, which returns *visual* bidi-reordered positions. For a line containing only RTL characters, Qt auto-detects the paragraph as right-to-left, and `cursorToX()` returns positions that *decrease* as the logical index increases — violating the monotonicity invariant `EditView.cxx` depends on. This pushes glyphs for the line outside the visible/clipped drawing rectangle, making pure-RTL lines appear invisible. A leading LTR run (as in `Hi היי`) happens to anchor enough of the line in-bounds to look correct.

## Fix

Changed `MeasureWidths` (UTF-8 codepage branch) and `MeasureWidthsUTF8` in `thirdparty/scintilla/qt/ScintillaEditBase/PlatQt.cpp` to accumulate each character's advance width independently via `QFontMetricsF::horizontalAdvance()`, summed in logical order — guaranteeing the required monotonic-non-decreasing invariant regardless of text direction, matching the approach already used on Win32/Cocoa.

Glyph *painting* (`DrawTextNoClip`/`DrawTextClipped`, etc.) already goes through `QPainter::drawText()`, which performs correct Unicode bidi shaping/reordering on its own — so visual rendering quality for LTR text and RTL glyph shaping is unaffected by this change.

Known trade-off: per-character measurement loses cross-character contextual shaping (ligatures, ligature-based kerning, Arabic's position-dependent glyph forms) for *measurement* purposes only. Hebrew (the reported case) has minimal contextual shaping, so this is not noticeable. Arabic text should no longer be invisible, though pixel-perfect character spacing for heavily-shaped scripts could still have minor rounding differences from what `QPainter::drawText` actually paints — a possible follow-up if anyone hits it.

Out of scope for this PR: implementing `SurfaceImpl::Layout()`/`IScreenLineLayout` and wiring up `Message::SetBidirectional` (currently unimplemented on the Qt backend, unlike Win32/Cocoa). That's needed for fully correct RTL caret movement and multi-rectangle RTL selection highlighting, but is a separate, larger feature addition — not required to fix the reported invisible-text bug, since `EditModel::BidirectionalEnabled()` is never true today on Qt builds (nothing calls `SetBidirectional`).

## Test plan

- [x] Built locally via `cmake -S . -B build -DCMAKE_PREFIX_PATH=$(brew --prefix qt) -DCMAKE_BUILD_TYPE=Debug && cmake --build build --target NotepadNext -j`
- [x] Typed `היי` alone on a line — now visible (previously invisible)
- [x] Typed `Hi היי` on a line — still renders correctly (no regression)
- [ ] Would appreciate additional testing with Arabic and other RTL/complex scripts from anyone able to test them

🤖 Generated with [Claude Code](https://claude.com/claude-code)