### PR TITLE
Guard LUA_PATH_DEFAULT/LUA_CPATH_DEFAULT with #ifndef on POSIX

### DIFF
--- a/thirdparty/lua/src/luaconf.h
+++ b/thirdparty/lua/src/luaconf.h
@@ -208,12 +208,16 @@
 #define LUA_ROOT	"/usr/local/"
 #define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
 #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
+#ifndef LUA_PATH_DEFAULT
 #define LUA_PATH_DEFAULT  \
 		LUA_LDIR"?.lua;"  LUA_LDIR"?/init.lua;" \
 		LUA_CDIR"?.lua;"  LUA_CDIR"?/init.lua;" \
 		"./?.lua;" "./?/init.lua"
+#endif
+#ifndef LUA_CPATH_DEFAULT
 #define LUA_CPATH_DEFAULT \
 		LUA_CDIR"?.so;" LUA_CDIR"loadall.so;" "./?.so"
+#endif
 #endif			/* } */
 
 


### PR DESCRIPTION
compilation under Linux leads to a significant number of warnings due to LUA_PATH_DEFAULT/LUA_CPATH_DEFAULT
thirdparty/lua/src/luaconf.h guards LUA_PATH_DEFAULT and LUA_CPATH_DEFAULT with #ifndef only in the Windows branch (#if defined(_WIN32)). The POSIX branch (#else) redefines both macros unconditionally.
Since thirdparty/lua/CMakeLists.txt already sets LUA_PATH_DEFAULT="" via a compile definition (presumably to disable Lua's default library search path), this causes a "LUA_PATH_DEFAULT" redefined warning on Linux/macOS builds, and — more importantly — the value passed by CMake is silently overridden by luaconf.h's own definition, since it's the last one to apply. So the override never actually takes effect on non-Windows platforms.

Although this file is part of the Lua code and not NotepadNext, it remains a targeted, minimal fix, simply bringing POSIX behavior in line with that already present for Windows.

This PR adds the same #ifndef guards to the POSIX branch that already exist on Windows, so the macro can be properly overridden from CMake on all platforms, and the redefinition warning disappears.

Tested on OpenSUSE LEAP 16.0 (GCC 13) — warning no longer appears, and LUA_PATH_DEFAULT correctly resolves to the empty string set by CMake.