### PR TITLE
Fix deprecated implicit `this` capture in `[=]` lambdas (C++20)

### DIFF
--- a/src/DockedEditor.cpp
+++ b/src/DockedEditor.cpp
@@ -67,7 +67,7 @@ DockedEditor::DockedEditor(QWidget *parent) : QObject(parent)
     dockManager = new ads::CDockManager(parent);
     dockManager->setStyleSheet("");
 
-    connect(dockManager, &ads::CDockManager::focusedDockWidgetChanged, this, [=](ads::CDockWidget* old, ads::CDockWidget* now) {
+    connect(dockManager, &ads::CDockManager::focusedDockWidgetChanged, this, [=, this](ads::CDockWidget* old, ads::CDockWidget* now) {
         Q_UNUSED(old)
 
         ScintillaNext *editor = qobject_cast<ScintillaNext *>(now->widget());
@@ -77,11 +77,11 @@ DockedEditor::DockedEditor(QWidget *parent) : QObject(parent)
         emit editorActivated(editor);
     });
 
-    connect(dockManager, &ads::CDockManager::dockAreaCreated, this, [=](ads::CDockAreaWidget* DockArea) {
+    connect(dockManager, &ads::CDockManager::dockAreaCreated, this, [=, this](ads::CDockAreaWidget* DockArea) {
         DockedEditorTitleBar *titleBar = qobject_cast<DockedEditorTitleBar *>(DockArea->titleBar());
         connect(titleBar, &DockedEditorTitleBar::doubleClicked, this, &DockedEditor::titleBarDoubleClicked);
 
-        connect(DockArea->titleBar()->tabBar(), &ads::CDockAreaTabBar::tabMoved, this, [=](int from, int to) {
+        connect(DockArea->titleBar()->tabBar(), &ads::CDockAreaTabBar::tabMoved, this, [=, this](int from, int to) {
             Q_UNUSED(from);
             Q_UNUSED(to);
 
@@ -175,7 +175,7 @@ void DockedEditor::addEditor(ScintillaNext *editor)
     dockWidget->setFeature(ads::CDockWidget::DockWidgetFeature::DockWidgetFloatable, false);
 
     dockWidget->tabWidget()->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(dockWidget->tabWidget(), &QWidget::customContextMenuRequested, this, [=](const QPoint &pos) {
+    connect(dockWidget->tabWidget(), &QWidget::customContextMenuRequested, this, [=, this](const QPoint &pos) {
         Q_UNUSED(pos)
 
         emit contextMenuRequestedForEditor(editor);
@@ -195,7 +195,7 @@ void DockedEditor::addEditor(ScintillaNext *editor)
     }
     else {
         dockWidget->tabWidget()->setIcon(QIcon(editor->canSaveToDisk() ? ":/icons/unsaved.png" : ":/icons/saved.png"));
-        connect(editor, &ScintillaNext::savePointChanged, dockWidget, [=](bool dirty) {
+        connect(editor, &ScintillaNext::savePointChanged, dockWidget, [=, this](bool dirty) {
             Q_UNUSED(dirty)
             const bool actuallyDirty = editor->canSaveToDisk();
             const QString iconPath = actuallyDirty ? ":/icons/unsaved.png" : ":/icons/saved.png";
@@ -204,8 +204,8 @@ void DockedEditor::addEditor(ScintillaNext *editor)
     }
 
     connect(editor, &ScintillaNext::closed, dockWidget, &ads::CDockWidget::closeDockWidget);
-    connect(editor, &ScintillaNext::closed, this, [=]() { emit editorClosed(editor); });
-    connect(editor, &ScintillaNext::renamed, this, [=]() { editorRenamed(editor); });
+    connect(editor, &ScintillaNext::closed, this, [=, this]() { emit editorClosed(editor); });
+    connect(editor, &ScintillaNext::renamed, this, [=, this]() { editorRenamed(editor); });
 
     connect(dockWidget, &ads::CDockWidget::closeRequested, this, &DockedEditor::dockWidgetCloseRequested);
 

--- a/src/EditorManager.cpp
+++ b/src/EditorManager.cpp
@@ -46,20 +46,20 @@ const int MARK_HIDELINESUNDERLINE = 21;
 EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
     : QObject(parent), settings(settings)
 {
-    connect(this, &EditorManager::editorCreated, this, [=](ScintillaNext *editor) {
-        connect(editor, &ScintillaNext::closed, this, [=]() {
+    connect(this, &EditorManager::editorCreated, this, [=, this](ScintillaNext *editor) {
+        connect(editor, &ScintillaNext::closed, this, [=, this]() {
             emit editorClosed(editor);
         });
     });
 
-    connect(settings, &ApplicationSettings::showWrapSymbolChanged, this, [=](bool b) {
+    connect(settings, &ApplicationSettings::showWrapSymbolChanged, this, [=, this](bool b) {
         for (auto &editor : getEditors()) {
             editor->setWrapVisualFlags(b ? SC_WRAPVISUALFLAG_END : SC_WRAPVISUALFLAG_NONE);
         }
     });
 
 
-    connect(settings, &ApplicationSettings::showWhitespaceChanged, this, [=](bool b) {
+    connect(settings, &ApplicationSettings::showWhitespaceChanged, this, [=, this](bool b) {
         // TODO: could make SCWS_VISIBLEALWAYS configurable via settings. Probably not worth
         // taking up menu space e.g. show all, show leading, show trailing
         for (auto &editor : getEditors()) {
@@ -67,19 +67,19 @@ EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
         }
     });
 
-    connect(settings, &ApplicationSettings::showEndOfLineChanged, this, [=](bool b) {
+    connect(settings, &ApplicationSettings::showEndOfLineChanged, this, [=, this](bool b) {
         for (auto &editor : getEditors()) {
             editor->setViewEOL(b);
         }
     });
 
-    connect(settings, &ApplicationSettings::showIndentGuideChanged, this, [=](bool b) {
+    connect(settings, &ApplicationSettings::showIndentGuideChanged, this, [=, this](bool b) {
         for (auto &editor : getEditors()) {
             editor->setIndentationGuides(b ? SC_IV_LOOKBOTH : SC_IV_NONE);
         }
     });
 
-    connect(settings, &ApplicationSettings::wordWrapChanged, this, [=](bool b) {
+    connect(settings, &ApplicationSettings::wordWrapChanged, this, [=, this](bool b) {
         if (b) {
             for (auto &editor : getEditors()) {
                 editor->setWrapMode(SC_WRAP_WORD);
@@ -95,7 +95,7 @@ EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
         }
     });
 
-    connect(settings, &ApplicationSettings::fontNameChanged, this, [=](QString fontName){
+    connect(settings, &ApplicationSettings::fontNameChanged, this, [=, this](QString fontName){
         for (auto &editor : getEditors()) {
             for (int i = 0; i <= STYLE_MAX; ++i) {
                 editor->styleSetFont(i, fontName.toUtf8().data());
@@ -103,7 +103,7 @@ EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
         }
     });
 
-    connect(settings, &ApplicationSettings::fontSizeChanged, this, [=](int fontSize){
+    connect(settings, &ApplicationSettings::fontSizeChanged, this, [=, this](int fontSize){
         for (auto &editor : getEditors()) {
             for (int i = 0; i <= STYLE_MAX; ++i) {
                 editor->styleSetSize(i, fontSize);
@@ -111,7 +111,7 @@ EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
         }
     });
 
-    connect(settings, &ApplicationSettings::urlHighlightingChanged, this, [=](bool b){
+    connect(settings, &ApplicationSettings::urlHighlightingChanged, this, [=, this](bool b){
         for (auto &editor : getEditors()) {
             URLFinder *decorator = editor->findChild<URLFinder *>(QString(), Qt::FindDirectChildrenOnly);
             if (decorator) {
@@ -120,7 +120,7 @@ EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
         }
     });
 
-    connect(settings, &ApplicationSettings::showLineNumbersChanged, this, [=](bool b){
+    connect(settings, &ApplicationSettings::showLineNumbersChanged, this, [=, this](bool b){
         for (auto &editor : getEditors()) {
             LineNumbers *decorator = editor->findChild<LineNumbers *>(QString(), Qt::FindDirectChildrenOnly);
             if (decorator) {
@@ -129,7 +129,7 @@ EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
         }
     });
 
-    connect(settings, &ApplicationSettings::autoCompletionChanged, this, [=](bool b){
+    connect(settings, &ApplicationSettings::autoCompletionChanged, this, [=, this](bool b){
         for (auto &editor : getEditors()) {
             AutoCompletion *decorator = editor->findChild<AutoCompletion *>(QString(), Qt::FindDirectChildrenOnly);
             if (decorator) {

--- a/src/decorators/BetterMultiSelection.cpp
+++ b/src/decorators/BetterMultiSelection.cpp
@@ -229,7 +229,7 @@ void BetterMultiSelection::EditSelections(std::function<void(Selection &selectio
 }
 
 std::function<void(Selection &selection)> BetterMultiSelection::SimpleEdit(int message) {
-    return [=](Selection &selection) {
+    return [=, this](Selection &selection) {
         editor->setSelection(selection.caret, selection.anchor);
         editor->send(message);
 

--- a/src/decorators/BraceMatch.cpp
+++ b/src/decorators/BraceMatch.cpp
@@ -46,7 +46,7 @@ BraceMatch::BraceMatch(ScintillaNext *editor) :
     editor->indicSetUnder(braceBadlight, true);
     editor->braceBadLightIndicator(true, braceBadlight);
 
-    connect(this, &EditorDecorator::stateChanged, [=](bool b) {
+    connect(this, &EditorDecorator::stateChanged, [=, this](bool b) {
         if (b) {
             doHighlighting();
         }

--- a/src/decorators/HTMLAutoCompleteDecorator.cpp
+++ b/src/decorators/HTMLAutoCompleteDecorator.cpp
@@ -29,7 +29,7 @@ static const QByteArrayList voidTags = { "area", "base", "br", "col", "embed", "
 HTMLAutoCompleteDecorator::HTMLAutoCompleteDecorator(ScintillaNext *editor)
     : EditorDecorator(editor)
 {
-    connect(editor, &ScintillaNext::lexerChanged, this, [=]() {
+    connect(editor, &ScintillaNext::lexerChanged, this, [=, this]() {
         QString language = editor->languageName;
         setEnabled(language == "HTML");
     });

--- a/src/decorators/LineNumbers.cpp
+++ b/src/decorators/LineNumbers.cpp
@@ -41,7 +41,7 @@ LineNumbers::LineNumbers(ScintillaNext *editor) :
 {
     editor->setMarginWidthN(0, 0);
 
-    connect(this, &EditorDecorator::stateChanged, editor, [=](bool b) {
+    connect(this, &EditorDecorator::stateChanged, editor, [=, this](bool b) {
         if (b) {
             adjustMarginWidth();
         }

--- a/src/decorators/URLFinder.cpp
+++ b/src/decorators/URLFinder.cpp
@@ -43,7 +43,7 @@ URLFinder::URLFinder(ScintillaNext *editor) :
     timer->setSingleShot(true);
     connect(timer, &QTimer::timeout, this, &URLFinder::findURLs);
 
-    connect(this, &EditorDecorator::stateChanged, this, [=](bool b) {
+    connect(this, &EditorDecorator::stateChanged, this, [=, this](bool b) {
         if (b) {
             connect(editor, &ScintillaNext::resized, timer, qOverload<>(&QTimer::start));
             connect(editor, &ScintillaNext::reloaded, timer, qOverload<>(&QTimer::start));

--- a/src/dialogs/ColumnEditorDialog.cpp
+++ b/src/dialogs/ColumnEditorDialog.cpp
@@ -37,17 +37,17 @@ ColumnEditorDialog::ColumnEditorDialog(MainWindow *parent) :
     ui->sbxStep->setMaximum(std::numeric_limits<int>::max());
     ui->sbxStep->setMinimum(std::numeric_limits<int>::min());
 
-    connect(ui->gbxText, &QGroupBox::toggled, ui->gbxNumbers, [=](bool on) {
+    connect(ui->gbxText, &QGroupBox::toggled, ui->gbxNumbers, [=, this](bool on) {
         ui->gbxNumbers->setChecked(!on);
     });
 
-    connect(ui->gbxNumbers, &QGroupBox::toggled, ui->gbxText, [=](bool on) {
+    connect(ui->gbxNumbers, &QGroupBox::toggled, ui->gbxText, [=, this](bool on) {
         ui->gbxText->setChecked(!on);
     });
 
-    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, [=]() {
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, [=, this]() {
         if (ui->gbxText->isChecked() && !ui->txtText->text().isEmpty()) {
-            insertTextStartingAtCurrentColumn([=]() { return ui->txtText->text(); });
+            insertTextStartingAtCurrentColumn([=, this]() { return ui->txtText->text(); });
         }
         else if (ui->gbxNumbers->isChecked()) {
             int currentValue = ui->sbxStart->value();

--- a/src/dialogs/FindReplaceDialog.cpp
+++ b/src/dialogs/FindReplaceDialog.cpp
@@ -80,17 +80,17 @@ FindReplaceDialog::FindReplaceDialog(ISearchResultsHandler *searchResults, MainW
     connect(ui->comboReplace, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), ui->comboReplace->lineEdit(), &QLineEdit::selectAll);
 
     // Force focus on the find text box
-    connect(this, &FindReplaceDialog::windowActivated, [=]() {
+    connect(this, &FindReplaceDialog::windowActivated, [=, this]() {
         ui->comboFind->setFocus();
         ui->comboFind->lineEdit()->selectAll();
     });
 
-    connect(this, &QDialog::rejected, [=]() {
+    connect(this, &QDialog::rejected, [=, this]() {
         statusBar->clearMessage();
         savePosition();
     });
 
-    connect(ui->radioRegexSearch, &QRadioButton::toggled, this, [=](bool checked) {
+    connect(ui->radioRegexSearch, &QRadioButton::toggled, this, [=, this](bool checked) {
         ui->checkBoxBackwardsDirection->setDisabled(checked);
         ui->checkBoxMatchWholeWord->setDisabled(checked);
         ui->checkBoxRegexMatchesNewline->setEnabled(checked);
@@ -102,7 +102,7 @@ FindReplaceDialog::FindReplaceDialog(ISearchResultsHandler *searchResults, MainW
 
     connect(ui->buttonFind, &QPushButton::clicked, this, &FindReplaceDialog::find);
     connect(ui->buttonCount, &QPushButton::clicked, this, &FindReplaceDialog::count);
-    connect(ui->buttonFindAllInCurrent, &QPushButton::clicked, this, [=]() {
+    connect(ui->buttonFindAllInCurrent, &QPushButton::clicked, this, [=, this]() {
         prepareToPerformSearch();
 
         searchResultsHandler->newSearch(findString());
@@ -113,7 +113,7 @@ FindReplaceDialog::FindReplaceDialog(ISearchResultsHandler *searchResults, MainW
 
         close();
     });
-    connect(ui->buttonFindAllInDocuments, &QPushButton::clicked, this, [=]() {
+    connect(ui->buttonFindAllInDocuments, &QPushButton::clicked, this, [=, this]() {
         prepareToPerformSearch();
 
         searchResultsHandler->newSearch(findString());
@@ -126,7 +126,7 @@ FindReplaceDialog::FindReplaceDialog(ISearchResultsHandler *searchResults, MainW
     });
     connect(ui->buttonReplace, &QPushButton::clicked, this, &FindReplaceDialog::replace);
     connect(ui->buttonReplaceAll, &QPushButton::clicked, this, &FindReplaceDialog::replaceAll);
-    connect(ui->buttonReplaceAllInDocuments, &QPushButton::clicked, this, [=]() {
+    connect(ui->buttonReplaceAllInDocuments, &QPushButton::clicked, this, [=, this]() {
         prepareToPerformSearch(true);
 
         QString replaceText = replaceString();
@@ -424,10 +424,10 @@ void FindReplaceDialog::adjustOpacityWhenLosingFocus(bool checked)
     qInfo(Q_FUNC_INFO);
 
     if (checked) {
-        connect(this, &FindReplaceDialog::windowActivated, [=]() {
+        connect(this, &FindReplaceDialog::windowActivated, [=, this]() {
             this->adjustOpacity(100);
         });
-        connect(this, &FindReplaceDialog::windowDeactivated, [=]() {
+        connect(this, &FindReplaceDialog::windowDeactivated, [=, this]() {
             this->adjustOpacity(ui->horizontalSlider->value());
         });
         adjustOpacity(100);

--- a/src/dialogs/MacroRunDialog.cpp
+++ b/src/dialogs/MacroRunDialog.cpp
@@ -30,7 +30,7 @@ MacroRunDialog::MacroRunDialog(QWidget *parent, MacroManager *mm) :
 {
     ui->setupUi(this);
 
-    connect(ui->buttonRun, &QPushButton::clicked, this, [=]() {
+    connect(ui->buttonRun, &QPushButton::clicked, this, [=, this]() {
         Macro *selectedMacro = ui->comboBox->currentData().value<Macro*>();
         int times = -1; // for end of file
 

--- a/src/dialogs/MacroSaveDialog.cpp
+++ b/src/dialogs/MacroSaveDialog.cpp
@@ -28,7 +28,7 @@ MacroSaveDialog::MacroSaveDialog(QWidget *parent) :
 
     ui->setupUi(this);
 
-    connect(ui->editName, &QLineEdit::textChanged, [=](const QString &text) {
+    connect(ui->editName, &QLineEdit::textChanged, [=, this](const QString &text) {
         ui->buttonOk->setEnabled(text.trimmed().size() > 0);
     });
 }

--- a/src/dialogs/PreferencesDialog.cpp
+++ b/src/dialogs/PreferencesDialog.cpp
@@ -47,7 +47,7 @@ PreferencesDialog::PreferencesDialog(ApplicationSettings *settings, QWidget *par
     MapSettingToCheckBox(ui->checkBoxRecenterSearchDialog, &ApplicationSettings::centerSearchDialog, &ApplicationSettings::setCenterSearchDialog, &ApplicationSettings::centerSearchDialogChanged);
 
     MapSettingToGroupBox(ui->gbxRestorePreviousSession, &ApplicationSettings::restorePreviousSession, &ApplicationSettings::setRestorePreviousSession, &ApplicationSettings::restorePreviousSessionChanged);
-    connect(ui->gbxRestorePreviousSession, &QGroupBox::toggled, this, [=](bool checked) {
+    connect(ui->gbxRestorePreviousSession, &QGroupBox::toggled, this, [=, this](bool checked) {
         if (!checked) {
             ui->checkBoxUnsavedFiles->setChecked(false);
             ui->checkBoxRestoreTempFiles->setChecked(false);
@@ -63,7 +63,7 @@ PreferencesDialog::PreferencesDialog(ApplicationSettings *settings, QWidget *par
     MapSettingToCheckBox(ui->checkBoxCombineSearchResults, &ApplicationSettings::combineSearchResults, &ApplicationSettings::setCombineSearchResults, &ApplicationSettings::combineSearchResultsChanged);
 
     populateTranslationComboBox();
-    connect(ui->comboBoxTranslation, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=](int index) {
+    connect(ui->comboBoxTranslation, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=, this](int index) {
         settings->setTranslation(ui->comboBoxTranslation->itemData(index).toString());
         showApplicationRestartRequired();
     });
@@ -71,10 +71,10 @@ PreferencesDialog::PreferencesDialog(ApplicationSettings *settings, QWidget *par
     MapSettingToCheckBox(ui->checkBoxExitOnLastTabClosed, &ApplicationSettings::exitOnLastTabClosed, &ApplicationSettings::setExitOnLastTabClosed, &ApplicationSettings::exitOnLastTabClosedChanged);
 
     ui->fcbDefaultFont->setCurrentFont(QFont(settings->fontName()));
-    connect(ui->fcbDefaultFont, &QFontComboBox::currentFontChanged, this, [=](const QFont &f) {
+    connect(ui->fcbDefaultFont, &QFontComboBox::currentFontChanged, this, [=, this](const QFont &f) {
         settings->setFontName(f.family());
     });
-    connect(settings, &ApplicationSettings::fontNameChanged, this, [=](QString fontName){
+    connect(settings, &ApplicationSettings::fontNameChanged, this, [=, this](QString fontName){
         ui->fcbDefaultFont->setCurrentFont(QFont(fontName));
     });
 
@@ -91,10 +91,10 @@ PreferencesDialog::PreferencesDialog(ApplicationSettings *settings, QWidget *par
     int index = ui->comboBoxLineEndings->findData(settings->defaultEOLMode());
     ui->comboBoxLineEndings->setCurrentIndex(index == -1 ? 0 : index);
 
-    connect(ui->comboBoxLineEndings, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=](int index) {
+    connect(ui->comboBoxLineEndings, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=, this](int index) {
         settings->setDefaultEOLMode(ui->comboBoxLineEndings->itemData(index).toString());
     });
-    connect(settings, &ApplicationSettings::defaultEOLModeChanged, this, [=](QString defaultEOLMode) {
+    connect(settings, &ApplicationSettings::defaultEOLModeChanged, this, [=, this](QString defaultEOLMode) {
         int index = ui->comboBoxLineEndings->findData(defaultEOLMode);
         ui->comboBoxLineEndings->setCurrentIndex(index == -1 ? 0 : index);
     });
@@ -108,17 +108,17 @@ PreferencesDialog::PreferencesDialog(ApplicationSettings *settings, QWidget *par
     buttonGroup->addButton(ui->radioLastUsedDirectory, ApplicationSettings::RememberLastUsed);
     buttonGroup->addButton(ui->radioHardCoded, ApplicationSettings::HardCoded);
 
-    connect(buttonGroup, &QButtonGroup::idClicked, this, [=](int id) {
+    connect(buttonGroup, &QButtonGroup::idClicked, this, [=, this](int id) {
         ApplicationSettings::DefaultDirectoryBehaviorEnum e = static_cast<ApplicationSettings::DefaultDirectoryBehaviorEnum>(id);
         settings->setDefaultDirectoryBehavior(e);
     });
 
-    connect(ui->radioHardCoded, &QRadioButton::toggled, this, [=](bool checked){
+    connect(ui->radioHardCoded, &QRadioButton::toggled, this, [=, this](bool checked){
         ui->btnSelectHardCodedPath->setEnabled(checked);
         ui->txtHardCodedPath->setEnabled(checked);
     });
 
-    connect(ui->btnSelectHardCodedPath, &QToolButton::clicked, this, [=]() {
+    connect(ui->btnSelectHardCodedPath, &QToolButton::clicked, this, [=, this]() {
         QString dir = QFileDialog::getExistingDirectory(this, tr("Default Directory"));
         if (dir.isEmpty()) return; // user cancelled
 
@@ -126,7 +126,7 @@ PreferencesDialog::PreferencesDialog(ApplicationSettings *settings, QWidget *par
         ui->txtHardCodedPath->setText(QDir::toNativeSeparators(dir));
     });
 
-    connect(ui->txtHardCodedPath, &QLineEdit::editingFinished, this, [=]() {
+    connect(ui->txtHardCodedPath, &QLineEdit::editingFinished, this, [=, this]() {
         QString dir = ui->txtHardCodedPath->text();
         settings->setDefaultDirectory(QDir::fromNativeSeparators(dir));
         ui->txtHardCodedPath->setText(QDir::toNativeSeparators(dir));

--- a/src/docks/DebugLogDock.cpp
+++ b/src/docks/DebugLogDock.cpp
@@ -39,7 +39,7 @@ DebugLogDock::DebugLogDock(QWidget *parent) :
     output = ui->txtDebugOutput;
     DebugManager::addMessageHandler(debugLogDockMessageHandler);
 
-    connect(this, &QDockWidget::visibilityChanged, this, [=](bool visible) {
+    connect(this, &QDockWidget::visibilityChanged, this, [=, this](bool visible) {
         if (visible) {
             ui->txtDebugOutput->horizontalScrollBar()->setValue(0);
         }

--- a/src/docks/EditorInspectorDock.cpp
+++ b/src/docks/EditorInspectorDock.cpp
@@ -105,7 +105,7 @@ EditorInspectorDock::EditorInspectorDock(MainWindow *parent) :
     newItem(foldInfo, tr("Last Child"), [](ScintillaNext *editor) { return QString::number(editor->lastChild(editor->lineFromPosition(editor->currentPos()), -1) + 1); });
     newItem(foldInfo, tr("Contracted Fold Next"), [](ScintillaNext *editor) { return QString::number(editor->contractedFoldNext(editor->lineFromPosition(editor->currentPos())) + 1); });
 
-    connect(this, &QDockWidget::visibilityChanged, this, [=](bool visible) {
+    connect(this, &QDockWidget::visibilityChanged, this, [=, this](bool visible) {
         if (visible) {
             connectToEditor(parent->currentEditor());
             connect(parent, &MainWindow::editorActivated, this, &EditorInspectorDock::connectToEditor);

--- a/src/docks/FileListDock.cpp
+++ b/src/docks/FileListDock.cpp
@@ -40,16 +40,16 @@ FileListDock::FileListDock(MainWindow *parent) :
     ui->actionSortbyFileName->setChecked(settings.get(sortByName));
 
     // Track it if it changes
-    connect(ui->actionSortbyFileName, &QAction::toggled, this, [=](bool b) {
+    connect(ui->actionSortbyFileName, &QAction::toggled, this, [=, this](bool b) {
         ApplicationSettings settings;
         settings.set(sortByName, b);
         refreshList();
     });
 
-    connect(this, &QDockWidget::visibilityChanged, this, [=](bool visible) {
+    connect(this, &QDockWidget::visibilityChanged, this, [=, this](bool visible) {
         if (visible) {
             // Only get events when the dock is visible
-            connect(window->getDockedEditor(), &DockedEditor::editorAdded, this, [=](ScintillaNext *editor) {
+            connect(window->getDockedEditor(), &DockedEditor::editorAdded, this, [=, this](ScintillaNext *editor) {
                 Q_UNUSED(editor);
 
                 // The editor could get added on any DockArea and doesn't necessarily get appended to the end of the FileList, so refresh everything

--- a/src/docks/LanguageInspectorDock.cpp
+++ b/src/docks/LanguageInspectorDock.cpp
@@ -101,7 +101,7 @@ LanguageInspectorDock::LanguageInspectorDock(MainWindow *parent) :
     ComboBoxDelegate *fontComboDelegate = new ComboBoxDelegate(fontNames, this);
     ui->tblStyles->setItemDelegateForColumn(4, fontComboDelegate);
 
-    connect(this, &QDockWidget::visibilityChanged, this, [=](bool visible) {
+    connect(this, &QDockWidget::visibilityChanged, this, [=, this](bool visible) {
         if (visible) {
             connectToEditor(parent->currentEditor());
             connect(parent, &MainWindow::editorActivated, this, &LanguageInspectorDock::connectToEditor);
@@ -123,7 +123,7 @@ void LanguageInspectorDock::connectToEditor(ScintillaNext *editor)
     disconnectFromEditor();
 
     editorConnection = connect(editor, &ScintillaNext::updateUi, this, &LanguageInspectorDock::updatePositionInfo);
-    documentConnection = connect(editor, &ScintillaNext::lexerChanged, this, [=]() { updateLexerInfo(editor); });
+    documentConnection = connect(editor, &ScintillaNext::lexerChanged, this, [=, this]() { updateLexerInfo(editor); });
 
     updateLexerInfo(editor);
 }
@@ -209,7 +209,7 @@ void LanguageInspectorDock::updatePropertyInfo(ScintillaNext *editor)
     ui->tblProperties->resizeColumnToContents(3);
 
     ui->tblProperties->disconnect();
-    connect(ui->tblProperties, &QTableWidget::itemChanged, this, [=](QTableWidgetItem *item) {
+    connect(ui->tblProperties, &QTableWidget::itemChanged, this, [=, this](QTableWidgetItem *item) {
         const QString property = ui->tblProperties->item(item->row(), 0)->text();
 
         editor->setProperty(property.toLatin1().constData(), item->text().toLatin1().constData());

--- a/src/docks/LuaConsoleDock.cpp
+++ b/src/docks/LuaConsoleDock.cpp
@@ -190,7 +190,7 @@ LuaConsoleDock::LuaConsoleDock(LuaState *l, QWidget *parent) :
     input->setMaximumHeight(input->textHeight(0));
     input->installEventFilter(this);
 
-    connect(input, &ScintillaNext::updateUi, [=](Scintilla::Update flags) {
+    connect(input, &ScintillaNext::updateUi, [=, this](Scintilla::Update flags) {
         Q_UNUSED(flags);
         int curPos = input->currentPos();
         int bracePos = INVALID_POSITION;

--- a/src/widgets/EditorInfoStatusBar.cpp
+++ b/src/widgets/EditorInfoStatusBar.cpp
@@ -38,7 +38,7 @@ EditorInfoStatusBar::EditorInfoStatusBar(QMainWindow *window) :
     eolFormat = new StatusLabel(100);
     addPermanentWidget(eolFormat, 0);
     eolFormat->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(qobject_cast<StatusLabel*>(eolFormat), &StatusLabel::customContextMenuRequested, this, [=](const QPoint &pos) {
+    connect(qobject_cast<StatusLabel*>(eolFormat), &StatusLabel::customContextMenuRequested, this, [=, this](const QPoint &pos) {
         emit customContextMenuRequestedForEOLLabel(eolFormat->mapToGlobal(pos));
     });
 
@@ -52,7 +52,7 @@ EditorInfoStatusBar::EditorInfoStatusBar(QMainWindow *window) :
 
     connect(w, &MainWindow::editorActivated, this, &EditorInfoStatusBar::connectToEditor);
 
-    connect(qobject_cast<StatusLabel*>(overType), &StatusLabel::clicked, w, [=]() {
+    connect(qobject_cast<StatusLabel*>(overType), &StatusLabel::clicked, w, [=, this]() {
         ScintillaNext *editor = w->currentEditor();
         editor->editToggleOvertype();
         updateOverType(editor);
@@ -77,7 +77,7 @@ void EditorInfoStatusBar::connectToEditor(ScintillaNext *editor)
 
     // Connect to the new editor
     editorUiUpdated = connect(editor, &ScintillaNext::updateUi, this, &EditorInfoStatusBar::editorUpdated);
-    documentLexerChanged = connect(editor, &ScintillaNext::lexerChanged, this, [=]() { updateLanguage(editor); });
+    documentLexerChanged = connect(editor, &ScintillaNext::lexerChanged, this, [=, this]() { updateLanguage(editor); });
 
     refresh(editor);
 }


### PR DESCRIPTION
## Summary

Replaces implicit `this` capture (`[=]`) with explicit capture (`[=, this]`) in lambdas defined inside member functions, across 18 files. This fixes the C++20 deprecation warning:

    attention: la capture implicite de « this » via « [=] » est dépréciée en C++20 [-Wdeprecated]

## Scope

- Mechanical fix, one line per occurrence, no behavior change.
- `thirdparty/scintilla/src/Editor.cxx` has one remaining occurrence of this warning, left untouched intentionally since it's vendored third-party code, not maintained here.

## Testing

Built in Debug and Release, confirmed no more `-Wdeprecated` warnings outside of the vendored Scintilla file mentioned above.