### PR TITLE
Detect external file modifications immediately, matching Notepad++ behavior

### DIFF
--- a/src/EditorManager.cpp
+++ b/src/EditorManager.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <QApplication>
+#include <QTimer>
 
 #include "ApplicationSettings.h"
 
@@ -46,10 +47,41 @@ const int MARK_HIDELINESUNDERLINE = 21;
 EditorManager::EditorManager(ApplicationSettings *settings, QObject *parent)
     : QObject(parent), settings(settings)
 {
+    fileWatcher = new QFileSystemWatcher(this);
+
+    connect(fileWatcher, &QFileSystemWatcher::fileChanged, this, [=](const QString &path) {
+        // Debounce: a single external write commonly fires this signal 2+
+        // times in a row. Only arm one timer per path; further signals
+        // received before it fires are simply dropped.
+        if (pendingFileChanges.contains(path)) {
+            return;
+        }
+
+        pendingFileChanges.insert(path);
+
+        QTimer::singleShot(250, this, [=]() {
+            pendingFileChanges.remove(path);
+            processExternalFileChange(path);
+        });
+    });
+
     connect(this, &EditorManager::editorCreated, this, [=](ScintillaNext *editor) {
         connect(editor, &ScintillaNext::closed, this, [=]() {
             emit editorClosed(editor);
         });
+
+        connect(editor, &ScintillaNext::closed, this, [=]() {
+            unwatchEditorFile(editor);
+        });
+
+        // Covers "Save As" and renaming a "New" buffer into an actual file,
+        // in addition to a plain rename - fileInfo is already up to date
+        // by the time this signal fires.
+        connect(editor, &ScintillaNext::renamed, this, [=]() {
+            watchEditorFile(editor);
+        });
+
+        watchEditorFile(editor);
     });
 
     connect(settings, &ApplicationSettings::showWrapSymbolChanged, this, [=](bool b) {
@@ -362,6 +394,51 @@ QList<QPointer<ScintillaNext> > EditorManager::getEditors()
 {
     purgeOldEditorPointers();
     return editors;
+}
+
+void EditorManager::processExternalFileChange(const QString &path)
+{
+    for (ScintillaNext *editor : qAsConst(editors)) {
+        if (editor && editor->isFile() && editor->getFilePath() == path) {
+            // Some editors/tools save by replacing the file (rename-over-write),
+            // which makes the OS-level watch silently drop the path. Re-arm it
+            // whenever we can, so subsequent external edits keep being detected.
+            if (QFileInfo::exists(path) && !fileWatcher->files().contains(path)) {
+                fileWatcher->addPath(path);
+            }
+
+            emit editorFileChangedOnDisk(editor);
+        }
+    }
+}
+
+void EditorManager::watchEditorFile(ScintillaNext *editor)
+{
+    const QString oldPath = watchedPaths.value(editor);
+    const QString newPath = editor->isFile() ? editor->getFilePath() : QString();
+
+    if (oldPath == newPath) {
+        return;
+    }
+
+    if (!oldPath.isEmpty()) {
+        fileWatcher->removePath(oldPath);
+        watchedPaths.remove(editor);
+    }
+
+    if (!newPath.isEmpty()) {
+        fileWatcher->addPath(newPath);
+        watchedPaths.insert(editor, newPath);
+    }
+}
+
+void EditorManager::unwatchEditorFile(ScintillaNext *editor)
+{
+    const QString path = watchedPaths.take(editor);
+
+    if (!path.isEmpty()) {
+        fileWatcher->removePath(path);
+    }
 }
 
 int EditorManager::detectEOLMode(ScintillaNext *editor) const

--- a/src/EditorManager.h
+++ b/src/EditorManager.h
@@ -22,6 +22,9 @@
 
 #include <QObject>
 #include <QPointer>
+#include <QFileSystemWatcher>
+#include <QHash>
+#include <QSet>
 
 
 class ApplicationSettings;
@@ -45,14 +48,38 @@ signals:
     void editorCreated(ScintillaNext *editor);
     void editorClosed(ScintillaNext *editor);
 
+    // Emitted asynchronously whenever the OS reports that an open file was
+    // touched outside the application (write, permissions, delete, etc).
+    // Does NOT get emitted for the application's own saves, since the
+    // in-memory timestamp is refreshed synchronously before this signal
+    // could ever be observed.
+    void editorFileChangedOnDisk(ScintillaNext *editor);
+
 private:
     void setupEditor(ScintillaNext *editor);
     void purgeOldEditorPointers();
     QList<QPointer<ScintillaNext>> getEditors();
     int detectEOLMode(ScintillaNext *editor) const;
 
+    void watchEditorFile(ScintillaNext *editor);
+    void unwatchEditorFile(ScintillaNext *editor);
+    void processExternalFileChange(const QString &path);
+
     QList<QPointer<ScintillaNext>> editors;
     ApplicationSettings *settings;
+
+    QFileSystemWatcher *fileWatcher;
+
+    // Tracks the path currently registered with fileWatcher for each editor,
+    // so a rename/"Save As" can drop the old path instead of leaking an
+    // orphaned watch on it.
+    QHash<ScintillaNext *, QString> watchedPaths;
+
+    // A single external write commonly triggers 2+ fileChanged signals in a
+    // row (this is a well-known QFileSystemWatcher/inotify quirk, not a bug
+    // in this class). Paths in this set already have a debounce timer
+    // pending, so further signals for them are ignored until it fires.
+    QSet<QString> pendingFileChanges;
 };
 
 #endif // EDITORMANAGER_H

--- a/src/dialogs/MainWindow.cpp
+++ b/src/dialogs/MainWindow.cpp
@@ -122,6 +122,27 @@ MainWindow::MainWindow(NotepadNextApplication *app) :
     connect(dockedEditor, &DockedEditor::contextMenuRequestedForEditor, this, &MainWindow::tabBarRightClicked);
     connect(dockedEditor, &DockedEditor::titleBarDoubleClicked, this, &MainWindow::newFile);
 
+    // React immediately (instead of only on tab-switch/window-focus) when an
+    // open file is changed by another program - but only if NotepadNext is
+    // actually the foreground window and the affected editor is the one
+    // currently visible, matching Notepad++'s behavior. Otherwise, do
+    // nothing here: the existing activateEditor() (tab switch) and
+    // focusIn() (window regains focus) code paths already re-check the
+    // file's timestamp and will surface the dialog at the right time.
+    connect(app->getEditorManager(), &EditorManager::editorFileChangedOnDisk, this, [=, this](ScintillaNext *editor) {
+        if (!isActiveWindow()) {
+            return;
+        }
+
+        if (editor != currentEditor()) {
+            return;
+        }
+
+        if (checkFileForModification(editor)) {
+            updateGui(currentEditor());
+        }
+    });
+
     // Set up the menus
     connect(ui->actionNew, &QAction::triggered, this, &MainWindow::newFile);
     connect(ui->actionOpen, &QAction::triggered, this, &MainWindow::openFileDialog);
@@ -1952,8 +1973,15 @@ bool MainWindow::checkFileForModification(ScintillaNext *editor)
     else if (state == ScintillaNext::Modified) {
         qInfo("ScintillaNext::Modified");
         const QString filePath = editor->getFilePath();
-        auto reply = QMessageBox::question(this, tr("Reload File"), tr("<b>%1</b> has been modified by another program. Do you want to reload it?").arg(filePath));
+        QString message = tr("<b>%1</b> has been modified by another program. Do you want to reload it?").arg(filePath);
 
+        if (!editor->isSavedToDisk()) {
+            message += tr("<br><br><b>Warning:</b> you have unsaved changes in this tab. "
+                           "Reloading will discard them permanently.");
+        }
+
+        auto reply = QMessageBox::question(this, tr("Reload File"), message);
+		
         if (reply == QMessageBox::Yes) {
             editor->reload();
         }
@@ -2099,6 +2127,18 @@ void MainWindow::focusIn()
     if (editor) {
         if (checkFileForModification(currentEditor())) {
             updateGui(currentEditor());
+        }
+    }
+}
+
+void MainWindow::changeEvent(QEvent *event)
+{
+    QMainWindow::changeEvent(event);
+
+    if (event->type() == QEvent::ActivationChange) {
+        qInfo() << "ActivationChange reçu, isActiveWindow() =" << isActiveWindow();
+        if (isActiveWindow()) {
+            focusIn();
         }
     }
 }

--- a/src/dialogs/MainWindow.h
+++ b/src/dialogs/MainWindow.h
@@ -140,6 +140,7 @@ protected:
     void closeEvent(QCloseEvent *event) override;
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
+    void changeEvent(QEvent *event) override;
 
 private slots:
     void tabBarRightClicked(ScintillaNext *editor);


### PR DESCRIPTION
### Description:

Closes #558.

Currently, NotepadNext only detects that a file was modified by another program when the tab is activated or the window regains focus (checkFileForModification() called only from activateEditor() and focusIn()). This means changes made externally can go unnoticed for a long time if the user stays on the same tab with the window in the background.

This PR adds a centralized QFileSystemWatcher in EditorManager to detect external modifications immediately, without waiting for a tab switch or focus change — matching Notepad++'s behavior.

### Changes

- EditorManager: single shared QFileSystemWatcher (rather than one per editor, to conserve file descriptors as discussed in #558). Watches/unwatches paths on editorCreated, closed, and renamed (the latter also covers Save As and New→File transitions). A 250ms debounce via QTimer::singleShot absorbs the double-signal behavior common to inotify-based watchers. New signal editorFileChangedOnDisk(ScintillaNext*).
- MainWindow: connects to the new signal, guarded by isActiveWindow() and editor == currentEditor() so the dialog only appears for the currently visible tab in the foreground window — same UX as before, just triggered sooner.
- MainWindow::changeEvent(): new override reacting to QEvent::ActivationChange to reliably catch the "switch back to NotepadNext without changing tabs" case. The existing applicationStateChanged-based path doesn't reliably fire in this scenario under X11/Cinnamon; changeEvent is Qt's own cross-platform activation notification and closes that gap. Left the existing mechanism in place since checkFileForModification() is a no-op when nothing changed.
- Reload confirmation dialog now warns explicitly when the current tab has unsaved changes, since immediate detection makes the unsaved-changes + external-modification conflict much easier to hit than before (previously it required a coincidental tab switch). Reloading still discards local changes; this PR only makes that risk visible rather than adding merge/backup logic, which is out of scope here.

### Known limitation
QFileSystemWatcher stops watching a file if it's replaced via atomic rename (as some editors/tools do on save). A best-effort re-arm (addPath if the path dropped out of fileWatcher->files()) is included, but this hasn't been exhaustively tested against every external tool's save strategy.

### Tested

- External modification while tab active / window focused
- External modification while tab active / window unfocused, then refocus without switching tabs
- External modification while tab active / window unfocused, then refocus via tab switch
- Rename, Save As
- Delete/recreate
- Unsaved local changes + external modification (dialog now warns before discarding)